### PR TITLE
Add Claude context files

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,14 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr list:*)",
+      "Bash(git pull:*)",
+      "Bash(git branch:*)",
+      "Bash(git remote prune:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-**robot-geographical-society** is a robotic trip planner for human adventure, written in Python.
+**robot-geographical-society** is a robotic trip planner for human adventure — a modern, computer-driven equivalent of the Royal Geographical Society, focused on helping users discover and reserve campsites across Washington State Parks, USFS, and the National Park Service.
+
+### Core Features (Functional Prototype)
+- **Map interface** built on Mapbox GL JS showing campsites currently open for reservation
+- **Static JSON dataset** of all campsites with metadata (site count, parameters, links)
+- **Static RSS feed** of reservation opening dates for tracked campsites (year-round sites excluded)
+- **Rich popups** per campsite: site count, site types (RV/tent/bike-in/parking), ICS calendar links, and links to official pages
 
 ## Setup
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+**robot-geographical-society** is a robotic trip planner for human adventure, written in Python.
+
+## Setup
+
+This project is in early development. No dependency manager or build tooling has been committed yet. Based on the `.gitignore`, the project is expected to use one of: `uv`, `poetry`, `pipenv`, or `pdm` for dependency management, and `pytest` for testing.
+
+Once tooling is established, update this file with the actual commands.
+
+## Expected Tooling (from .gitignore signals)
+
+- **Testing:** `pytest`
+- **Linting/Formatting:** `ruff`
+- **Type checking:** `mypy`
+- **Dependency management:** `uv` (preferred) or `poetry`
+
+## Development Protocol
+
+1. **Branch isolation**: Develop on a descriptive feature branch. Never commit directly to `main`.
+2. **Never merge your own PRs**: Open a PR targeting `main` and wait for a human maintainer to merge.
+
+## Issue Lifecycle
+
+### Phase 1: Exploration
+- Use Grep/Glob to locate relevant components, logic, and tests before proposing changes.
+- Identify test and lint commands.
+
+### Phase 2: Implementation & Verification
+1. Implement on a feature branch.
+2. Run unit tests, linting, and type checks locally.
+3. Fix any failures before opening a PR.
+
+### Phase 3: Pull Request
+1. Open a PR to `main`, using `Fixes #N` or `Closes #N` in the PR body so GitHub auto-closes the issue on merge.
+2. Respond to review feedback with new commits on the same branch. Do NOT merge.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # robot-geographical-society
-A robotic trip planner for human adventure 
+🤖 A robotic trip planner for human adventure 🤖
+
+The Royal Geographical Society was founded in 1830 to advance geographical science, famously sponsoring monumental expeditions to the Nile, the Amazon, and the Antarctic. Throughout the Victorian era, it served as the primary institution for mapping the "unknown" world and remains a global authority on exploration today via its Wikipedia page.
+
+The Robot Geographical Society performs the same job using computers, foregoing the patriarchal, paper-based excesses of the past.
+
+## Functional Prototype
+* A map interface (built on Mapbox GL JS) allowing a user to view campsites currently open to reserve, hosted by either Washington State Parks, USFS or the National Park Service
+* A statically hosted JSON dataset with all campsites and metadata
+* A statically hosted RSS feed with opening dates for reservations for all tracked campsites. All year campsites are not included
+* Rich popups with the following data for each campsite:
+    * Number of sites
+    * Site parameters (RV, tent, bike-in, parking)
+    * ICS links to opening days and first reservstion days
+    * Links to official sites


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` with project overview, expected Python tooling (pytest, ruff, mypy, uv), and a development/issue lifecycle protocol adapted from [vitamind](https://github.com/tommyroar/vitamind)
- Adds `.claude/settings.local.json` with pre-approved git/gh CLI permissions

## Notes

The README.md appeared unchanged at time of commit — its content still shows the original one-liner. If you've updated it locally, please add those changes to this branch before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)