### PR TITLE
chore: update /dev command to pull, kill existing server, and reinstall

### DIFF
--- a/.claude/commands/dev.md
+++ b/.claude/commands/dev.md
@@ -1,6 +1,26 @@
 Start the local dev server and print access URLs.
 
-Run this command from the repo root:
+## Steps
+
+### 1. Pull latest changes
+
+```
+git -C ~/dev/robot-geographical-society pull origin main
+```
+
+### 2. Kill any existing dev server on port 5173
+
+```
+lsof -ti :5173 | xargs kill -9 2>/dev/null; true
+```
+
+### 3. Install dependencies (in case package.json changed)
+
+```
+cd ~/dev/robot-geographical-society/web && npm install
+```
+
+### 4. Start the dev server
 
 ```
 cd ~/dev/robot-geographical-society/web && npm run dev -- --host


### PR DESCRIPTION
## Summary

- `/dev` now pulls `origin/main` before starting so it always runs the latest code
- Kills any process already bound to port 5173 before starting
- Runs `npm install` to pick up any dependency changes

## Test plan

- [ ] CI passes
- [ ] Running `/dev` a second time kills the old server and starts fresh with latest changes