### PR TITLE
fix(ui): debug panel viewport fix + upcoming UI polish

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -269,7 +269,7 @@ body {
 
 /* Debug panel */
 .debug-panel {
-  position: absolute;
+  position: fixed;
   bottom: 40px;
   left: 12px;
   z-index: 100;


### PR DESCRIPTION
## Summary

- Fix debug panel appearing below the visible viewport on Safari — `position: absolute` + `bottom` offset inside a `100vh` container breaks because Safari's `100vh` exceeds the visible area (browser chrome not accounted for). Switched to `position: fixed` to anchor the panel to the actual viewport.

## Test plan

- [ ] Visit `/?debug` and confirm zoom/lng/lat panel is visible in the bottom-left
- [ ] Verify on both desktop and mobile Safari (Tailscale preview)
- [ ] Confirm panel updates as you pan/zoom the map

🤖 Generated with [Claude Code](https://claude.com/claude-code)