### PR TITLE
data: add individual campsite files, sync script, and data CLAUDE.md

### DIFF
--- a/data/CLAUDE.md
+++ b/data/CLAUDE.md
@@ -1,0 +1,106 @@
+# Campsite Data — Claude Context
+
+This file instructs Claude Code on how to work with campsite data in this project.
+
+## Source of truth
+
+Individual campsite files (`data/{agency}/WA/{name}/index.md` or `data/{agency}/WA/{park}/{name}/index.md`) are the **source of truth**. The GeoJSON (`data/campsites.json`) is a **derived artifact** — regenerate it from the markdown files, never edit it directly.
+
+To sync after any edits:
+```
+node scripts/sync-geojson.js
+```
+
+---
+
+## Directory structure
+
+```
+data/
+  blm/WA/{Campsite Name}/index.md
+  nps/WA/{Park Name}/{Campsite Name}/index.md
+  usfs/WA/{Forest Name}/{Campsite Name}/index.md
+  wa-state-parks/WA/{Park Name}/index.md
+```
+
+Directory names are human-readable and match the `name` field. Use title case with spaces — no slugs.
+
+---
+
+## Schema
+
+Each `index.md` has YAML frontmatter followed by a plain-text notes body.
+
+```yaml
+---
+name: Heart O' the Hills          # string, required — must match directory name
+agency: National Park Service      # string, required — full agency name
+agency_short: nps                  # string, required — one of: blm | nps | usfs | wa-state-parks
+state: WA                          # string, required — always WA for now
+lat: 47.9813                       # float, required — WGS84 decimal degrees
+lng: -123.4318                     # float, required — WGS84 decimal degrees
+sites: 105                         # integer, required — total number of campsites
+types: [tent, rv]                  # array, required — see valid values below
+reservable: true                   # boolean, required
+year_round: false                  # boolean, required
+open_date: "May 1"                 # string or null — "Month Day" format; null if year_round: true
+first_reservation_date: null       # string or null — "Month Day" format, e.g. "February 1"
+reservation_url: https://...       # string, required — booking/info system URL
+official_url: https://...          # string, required — authoritative agency page for this campsite
+---
+
+Plain-text description of the campsite. One or two sentences.
+```
+
+### Valid `types` values
+
+| Value | Meaning |
+|---|---|
+| `tent` | Standard tent sites |
+| `rv` | RV/trailer hookup or pull-through sites |
+| `walk-in` | Walk-in or hike-in tent sites |
+| `cabin` | Cabins or yurts |
+| `bike-in` | Bike-in sites |
+| `parking` | Parking lot / car-camping style |
+
+### `open_date` format
+
+- Year-round sites: `open_date: null`
+- Seasonal sites: `open_date: "Month 1"` — use full month name + day 1, e.g. `"May 1"`, `"July 1"`
+- Update to a specific date if known, e.g. `"May 23"` for a confirmed opening
+
+### `first_reservation_date`
+
+The date reservations open (often months before `open_date`). Leave `null` until confirmed from the booking system. Format same as `open_date`: `"February 1"`.
+
+### `official_url`
+
+Link directly to the campground page on the agency website, not the homepage. Examples:
+- recreation.gov: `https://www.recreation.gov/camping/campgrounds/234429`
+- WA State Parks: `https://washington.goingtocamp.com/campingworld/searchavailability?mapId=-2147483508`
+- BLM: specific district page URL
+
+---
+
+## Adding a new campsite
+
+1. Create the directory: `data/{agency_short}/WA/{optional-park}/{Campsite Name}/`
+2. Copy the schema above into `index.md` and fill in all required fields
+3. Run `node scripts/sync-geojson.js` to regenerate the GeoJSON
+4. Verify the new pin appears on the map at `http://localhost:5173`
+
+## Updating existing data
+
+1. Edit the relevant `index.md` field(s)
+2. Run `node scripts/sync-geojson.js`
+3. Commit both the `index.md` change and the updated `data/campsites.json`
+
+## Validation checklist
+
+Before committing, verify:
+- [ ] `lat`/`lng` are plausible for Washington State (lat: 45.5–49.0, lng: -124.9 to -116.9)
+- [ ] `types` contains only valid values from the table above
+- [ ] `open_date` is `null` when `year_round: true`
+- [ ] `reservation_url` and `official_url` are valid URLs (not placeholder `https://www.blm.gov/`)
+- [ ] `name` matches the directory name exactly
+- [ ] Notes body is a single concise sentence or two (no markdown formatting)

--- a/data/blm/WA/Fishtrap Recreation Area/index.md
+++ b/data/blm/WA/Fishtrap Recreation Area/index.md
@@ -1,0 +1,18 @@
+---
+name: Fishtrap Recreation Area
+agency: Bureau of Land Management
+agency_short: blm
+state: WA
+lat: 47.4438
+lng: -117.6929
+sites: 20
+types: [tent,rv]
+reservable: false
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.blm.gov/
+official_url: https://www.blm.gov/
+---
+
+On Fishtrap Lake near Sprague; wildlife-rich shrub-steppe environment

--- a/data/blm/WA/Juniper Dunes Wilderness/index.md
+++ b/data/blm/WA/Juniper Dunes Wilderness/index.md
@@ -1,0 +1,18 @@
+---
+name: Juniper Dunes Wilderness
+agency: Bureau of Land Management
+agency_short: blm
+state: WA
+lat: 46.5471
+lng: -118.9054
+sites: 10
+types: [tent]
+reservable: false
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.blm.gov/
+official_url: https://www.blm.gov/
+---
+
+Primitive camping near the largest natural juniper forest in WA; no facilities

--- a/data/blm/WA/Liberty Recreation Site/index.md
+++ b/data/blm/WA/Liberty Recreation Site/index.md
@@ -1,0 +1,18 @@
+---
+name: Liberty Recreation Site
+agency: Bureau of Land Management
+agency_short: blm
+state: WA
+lat: 47.2638
+lng: -120.9518
+sites: 18
+types: [tent,rv]
+reservable: false
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.blm.gov/
+official_url: https://www.blm.gov/
+---
+
+Near the historic gold mining town of Liberty; dispersed camping area

--- a/data/blm/WA/Taunton Dispersed Area/index.md
+++ b/data/blm/WA/Taunton Dispersed Area/index.md
@@ -1,0 +1,18 @@
+---
+name: Taunton Dispersed Area
+agency: Bureau of Land Management
+agency_short: blm
+state: WA
+lat: 47.1704
+lng: -119.2238
+sites: 15
+types: [tent,rv]
+reservable: false
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.blm.gov/
+official_url: https://www.blm.gov/
+---
+
+Dispersed camping in Columbia Plateau; excellent stargazing

--- a/data/blm/WA/Yakima River Canyon/index.md
+++ b/data/blm/WA/Yakima River Canyon/index.md
@@ -1,0 +1,18 @@
+---
+name: Yakima River Canyon
+agency: Bureau of Land Management
+agency_short: blm
+state: WA
+lat: 46.8268
+lng: -120.4927
+sites: 25
+types: [tent,rv]
+reservable: false
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.blm.gov/
+official_url: https://www.blm.gov/
+---
+
+Along the Yakima River between Ellensburg and Yakima; popular for fly fishing

--- a/data/campsites.json
+++ b/data/campsites.json
@@ -3,1149 +3,22 @@
   "features": [
     {
       "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.6430, 48.4073] },
-      "properties": {
-        "name": "Deception Pass State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 310,
-        "types": ["tent", "rv", "walk-in"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 3,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Largest state park campground; Cranberry Lake and North Beach loops"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.4875, 48.6618] },
-      "properties": {
-        "name": "Larrabee State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 87,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "First state park in WA; saltwater access on Samish Bay"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.8327, 48.6571] },
-      "properties": {
-        "name": "Moran State Park (Orcas Island)",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 151,
-        "types": ["tent", "rv", "walk-in"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Four campgrounds near Summit Lake and Cascade Lake on Orcas Island"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.7602, 48.1329] },
-      "properties": {
-        "name": "Fort Worden State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 80,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Historic fort on Port Townsend Bay; year-round camping available"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.7005, 48.0929] },
-      "properties": {
-        "name": "Fort Flagler State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 116,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Former military fort on Marrowstone Island; panoramic views of Puget Sound"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.9017, 47.6868] },
-      "properties": {
-        "name": "Dosewallips State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 140,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "At the confluence of the Dosewallips River and Hood Canal"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.1581, 47.5571] },
-      "properties": {
-        "name": "Potlatch State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 35,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "On Hood Canal; excellent oyster and shellfish harvesting"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.6391, 47.8374] },
-      "properties": {
-        "name": "Kitsap Memorial State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 43,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Wooded park on Hood Canal near Poulsbo"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.0419, 48.0457] },
-      "properties": {
-        "name": "Sequim Bay State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 86,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Protected bay in the Olympic rain shadow; calm waters for boating"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.2786, 47.8982] },
-      "properties": {
-        "name": "Bogachiel State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 42,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Along the Bogachiel River near Forks; gateway to Olympic backcountry"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.0557, 46.2874] },
-      "properties": {
-        "name": "Cape Disappointment State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 250,
-        "types": ["tent", "rv", "cabin"],
-        "reservable": true,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Where the Columbia River meets the Pacific; two historic lighthouses"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.8234, 46.6157] },
-      "properties": {
-        "name": "Bruceport County Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 30,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "On Willapa Bay near South Bend"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.0871, 46.7716] },
-      "properties": {
-        "name": "Grayland Beach State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 100,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Ocean beach camping near cranberry bogs"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.2001, 47.2107] },
-      "properties": {
-        "name": "Pacific Beach State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 138,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Right on the Pacific Ocean; popular for razor clam season"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.1655, 47.0388] },
-      "properties": {
-        "name": "Ocean City State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 178,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "On the coast near Ocean Shores; vast sandy beach access"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.9997, 45.6254] },
-      "properties": {
-        "name": "Beacon Rock State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 35,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Below the famous basalt monolith in the Columbia River Gorge"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.8268, 46.2916] },
-      "properties": {
-        "name": "Seaquest State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 92,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Adjacent to Mount St. Helens National Volcanic Monument; views of the volcano"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.7108, 45.8613] },
-      "properties": {
-        "name": "Paradise Point State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 70,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Along the East Fork Lewis River near Ridgefield"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-122.4875, 45.7957] },
-      "properties": {
-        "name": "Battle Ground Lake State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 50,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Volcanic lake in Clark County; swimming and fishing"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-119.4644, 47.5968] },
-      "properties": {
-        "name": "Sun Lakes-Dry Falls State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 193,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Near the world's largest prehistoric waterfall; coulees and lakes"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-119.0871, 47.8596] },
-      "properties": {
-        "name": "Steamboat Rock State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 213,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "On Banks Lake in the Grand Coulee area; massive basalt butte"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-117.4793, 47.7046] },
-      "properties": {
-        "name": "Riverside State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 16,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Along the Spokane River near Spokane; Bowl and Pitcher area"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-119.4436, 48.9493] },
-      "properties": {
-        "name": "Osoyoos Lake State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 86,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Warmest lake in WA on the Canadian border; excellent swimming"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.6668, 48.7096] },
-      "properties": {
-        "name": "Curlew Lake State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 82,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Scenic lake in Ferry County near Republic"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.2274, 46.6638] },
-      "properties": {
-        "name": "Palouse Falls State Park",
-        "agency": "Washington State Parks",
-        "agency_short": "wa-state-parks",
-        "sites": 10,
-        "types": ["tent"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 4,
-        "reservation_url": "https://washington.goingtocamp.com/",
-        "notes": "Washington State waterfall; 198-ft drop into the Palouse River canyon"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.2583, 47.9511] },
-      "properties": {
-        "name": "Olympic NP — Deer Park",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 14,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 7,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "High alpine meadow campground; no RVs; stunning views of the Strait of Juan de Fuca"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.9021, 48.0590] },
-      "properties": {
-        "name": "Olympic NP — Fairholme",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 88,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On the west end of Lake Crescent; boat launch access"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.7058, 47.5682] },
-      "properties": {
-        "name": "Olympic NP — Graves Creek",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 30,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "In the Quinault Rain Forest; trailhead for Enchanted Valley hike"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.4318, 47.9813] },
-      "properties": {
-        "name": "Olympic NP — Heart O' the Hills",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 105,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Main campground for Hurricane Ridge area access"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.9348, 47.8601] },
-      "properties": {
-        "name": "Olympic NP — Hoh Rain Forest",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 88,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "In the heart of the temperate rain forest; Hall of Mosses trailhead"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.3757, 47.6107] },
-      "properties": {
-        "name": "Olympic NP — Kalaloch",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 170,
-        "types": ["tent", "rv", "cabin"],
-        "reservable": true,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On coastal bluffs above the Pacific; beach access and tide pools"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.5972, 47.9218] },
-      "properties": {
-        "name": "Olympic NP — Mora",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 94,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Near Rialto Beach; old-growth forest along Quillayute River"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.5913, 47.5271] },
-      "properties": {
-        "name": "Olympic NP — North Fork",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 9,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Small primitive campground in Quinault Valley"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.0992, 47.5228] },
-      "properties": {
-        "name": "Olympic NP — Queets",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 20,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Remote campground in the Queets River valley; old-growth rainforest"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.1565, 47.9704] },
-      "properties": {
-        "name": "Olympic NP — Sol Duc",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 82,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Along the Sol Duc River; hot springs resort nearby"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.3656, 47.5715] },
-      "properties": {
-        "name": "Olympic NP — South Beach",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 55,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Primitive coastal campground just south of Kalaloch"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.3283, 47.5163] },
-      "properties": {
-        "name": "Olympic NP — Staircase",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 47,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "At the foot of the North Fork Skokomish River; gateway to the Olympics"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.8059, 46.7613] },
-      "properties": {
-        "name": "Rainier — Cougar Rock",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 173,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Near the Paradise area; excellent views of the Tatoosh Range"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.6403, 46.9010] },
-      "properties": {
-        "name": "Rainier — White River",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 112,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 7,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Trailhead for Sunrise area and Emmons Glacier route"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.5682, 46.7296] },
-      "properties": {
-        "name": "Rainier — Ohanapecosh",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 188,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "In old-growth forest on the SE side of Rainier; Grove of the Patriarchs nearby"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.8636, 46.9329] },
-      "properties": {
-        "name": "Rainier — Mowich Lake",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 30,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 7,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Walk-in only; on the remote NW side of Rainier; no RVs or trailers"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.2441, 48.6718] },
-      "properties": {
-        "name": "North Cascades — Newhalem Creek",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 111,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Main campground at the Ross Lake NRA gateway town of Newhalem"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.1948, 48.6780] },
-      "properties": {
-        "name": "North Cascades — Gorge Lake",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 6,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Small primitive campground on Gorge Lake; walk-in sites"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.2563, 48.6793] },
-      "properties": {
-        "name": "North Cascades — Goodell Creek",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 21,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Year-round campground; popular for whitewater kayaking put-in"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.0718, 48.6996] },
-      "properties": {
-        "name": "North Cascades — Colonial Creek North",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 60,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On the north shore of Diablo Lake; stunning turquoise waters"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.0760, 48.6957] },
-      "properties": {
-        "name": "North Cascades — Colonial Creek South",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 32,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Walk-in sites on south shore of Diablo Lake"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.0634, 48.6099] },
-      "properties": {
-        "name": "Lake Roosevelt NRA — Kettle Falls",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 76,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On the upper Columbia/Lake Roosevelt; near historic Kettle Falls"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.9808, 47.9318] },
-      "properties": {
-        "name": "Lake Roosevelt NRA — Spring Canyon",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 87,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Near the town of Grand Coulee; swimming beach on Lake Roosevelt"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.3119, 48.5174] },
-      "properties": {
-        "name": "Lake Roosevelt NRA — Snag Cove",
-        "agency": "National Park Service",
-        "agency_short": "nps",
-        "sites": 9,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Small boat-in or hike-in campground on Lake Roosevelt"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.6018, 46.2668] },
-      "properties": {
-        "name": "Gifford Pinchot — Takhlakh Lake",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 54,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 7,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Stunning views of Mt. Adams from the lake; high-elevation campground"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.4729, 46.4154] },
-      "properties": {
-        "name": "Gifford Pinchot — Walupt Lake",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 44,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 7,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Remote lake near the Goat Rocks Wilderness; excellent fishing"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.9866, 46.5296] },
-      "properties": {
-        "name": "Gifford Pinchot — Iron Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 98,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Near Mt. St. Helens; along Cispus River corridor"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.5436, 45.9954] },
-      "properties": {
-        "name": "Gifford Pinchot — Trout Lake Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 21,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Near Trout Lake; gateway to Mt. Adams Wilderness trails"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.6557, 45.9882] },
-      "properties": {
-        "name": "Gifford Pinchot — Blue Lake Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 11,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Small creek-side campground near Trout Lake"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.2990, 46.9213] },
-      "properties": {
-        "name": "Okanogan-Wenatchee — Bumping Lake",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 45,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 6,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On Bumping Lake reservoir; excellent hiking into the Norse Peak Wilderness"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.3574, 46.9441] },
-      "properties": {
-        "name": "Okanogan-Wenatchee — Soda Springs",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 26,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 6,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Along Bumping River; natural carbonated spring nearby"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-120.5218, 47.8543] },
-      "properties": {
-        "name": "Okanogan-Wenatchee — Cottonwood",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 25,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On the Entiat River near Lake Chelan NRA; remote and uncrowded"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-120.6629, 47.9696] },
-      "properties": {
-        "name": "Okanogan-Wenatchee — Chiwawa Horse Camp",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 21,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 6,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Horse camp in the Chiwawa River corridor; Glacier Peak Wilderness access"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.2246, 46.6571] },
-      "properties": {
-        "name": "Okanogan-Wenatchee — Indian Creek (Rimrock)",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 39,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On Rimrock Lake reservoir; fishing and swimming"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.4338, 47.4221] },
-      "properties": {
-        "name": "Mt. Baker-Snoqualmie — Denny Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 33,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Near Snoqualmie Pass; access to Franklin Falls and Alpine Lakes Wilderness"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.3944, 47.7671] },
-      "properties": {
-        "name": "Mt. Baker-Snoqualmie — Beckler River",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 27,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Along the Beckler River near Skykomish; popular for families"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.7654, 48.5518] },
-      "properties": {
-        "name": "Mt. Baker-Snoqualmie — Douglas Fir",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 30,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On the North Fork Nooksack River; gateway to Mt. Baker"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.3118, 48.1629] },
-      "properties": {
-        "name": "Mt. Baker-Snoqualmie — Buck Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 29,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 6,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On the Suiattle River; access to Glacier Peak Wilderness"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-121.8154, 48.2354] },
-      "properties": {
-        "name": "Mt. Baker-Snoqualmie — Clear Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 12,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Small campground on the Sauk River near Darrington"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-124.0718, 47.5482] },
-      "properties": {
-        "name": "Olympic NF — Falls Creek",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 31,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "In the Quinault Valley; access to Lake Quinault and rainforest trails"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.6254, 47.4579] },
-      "properties": {
-        "name": "Olympic NF — Coho",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 56,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On Lake Cushman in Hood Canal area"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-123.5846, 47.3871] },
-      "properties": {
-        "name": "Olympic NF — Wynoochee Lake",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 40,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "On Wynoochee Lake reservoir; swimming, fishing, and boating"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-119.0615, 48.7982] },
-      "properties": {
-        "name": "Colville NF — Bonaparte Lake",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 28,
-        "types": ["tent", "rv"],
-        "reservable": true,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Scenic lake in northeast WA near Tonasket; good fishing"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.8527, 48.5146] },
-      "properties": {
-        "name": "Colville NF — Beaver Lake",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 24,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 5,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Remote lake in the Colville NF; wildlife viewing and fishing"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.6907, 48.6418] },
-      "properties": {
-        "name": "Colville NF — Lake Leo",
-        "agency": "US Forest Service",
-        "agency_short": "usfs",
-        "sites": 8,
-        "types": ["tent"],
-        "reservable": false,
-        "year_round": false,
-        "open_month": 6,
-        "reservation_url": "https://www.recreation.gov/",
-        "notes": "Small alpine lake campground; hike-in only"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-120.9518, 47.2638] },
-      "properties": {
-        "name": "Liberty Recreation Site",
-        "agency": "Bureau of Land Management",
-        "agency_short": "blm",
-        "sites": 18,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://www.blm.gov/",
-        "notes": "Near the historic gold mining town of Liberty; dispersed camping area"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-117.6929, 47.4438] },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -117.6929,
+          47.4438
+        ]
+      },
       "properties": {
         "name": "Fishtrap Recreation Area",
         "agency": "Bureau of Land Management",
         "agency_short": "blm",
         "sites": 20,
-        "types": ["tent", "rv"],
+        "types": [
+          "tent",
+          "rv"
+        ],
         "reservable": false,
         "year_round": true,
         "open_month": null,
@@ -1155,29 +28,21 @@
     },
     {
       "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-119.2238, 47.1704] },
-      "properties": {
-        "name": "Taunton Dispersed Area",
-        "agency": "Bureau of Land Management",
-        "agency_short": "blm",
-        "sites": 15,
-        "types": ["tent", "rv"],
-        "reservable": false,
-        "year_round": true,
-        "open_month": null,
-        "reservation_url": "https://www.blm.gov/",
-        "notes": "Dispersed camping in Columbia Plateau; excellent stargazing"
-      }
-    },
-    {
-      "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-118.9054, 46.5471] },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.9054,
+          46.5471
+        ]
+      },
       "properties": {
         "name": "Juniper Dunes Wilderness",
         "agency": "Bureau of Land Management",
         "agency_short": "blm",
         "sites": 10,
-        "types": ["tent"],
+        "types": [
+          "tent"
+        ],
         "reservable": false,
         "year_round": true,
         "open_month": null,
@@ -1187,18 +52,1822 @@
     },
     {
       "type": "Feature",
-      "geometry": { "type": "Point", "coordinates": [-120.4927, 46.8268] },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -120.9518,
+          47.2638
+        ]
+      },
+      "properties": {
+        "name": "Liberty Recreation Site",
+        "agency": "Bureau of Land Management",
+        "agency_short": "blm",
+        "sites": 18,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://www.blm.gov/",
+        "notes": "Near the historic gold mining town of Liberty; dispersed camping area"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -119.2238,
+          47.1704
+        ]
+      },
+      "properties": {
+        "name": "Taunton Dispersed Area",
+        "agency": "Bureau of Land Management",
+        "agency_short": "blm",
+        "sites": 15,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://www.blm.gov/",
+        "notes": "Dispersed camping in Columbia Plateau; excellent stargazing"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -120.4927,
+          46.8268
+        ]
+      },
       "properties": {
         "name": "Yakima River Canyon",
         "agency": "Bureau of Land Management",
         "agency_short": "blm",
         "sites": 25,
-        "types": ["tent", "rv"],
+        "types": [
+          "tent",
+          "rv"
+        ],
         "reservable": false,
         "year_round": true,
         "open_month": null,
         "reservation_url": "https://www.blm.gov/",
         "notes": "Along the Yakima River between Ellensburg and Yakima; popular for fly fishing"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.0718,
+          48.6996
+        ]
+      },
+      "properties": {
+        "name": "Colonial Creek North",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 60,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On the north shore of Diablo Lake; stunning turquoise waters"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.076,
+          48.6957
+        ]
+      },
+      "properties": {
+        "name": "Colonial Creek South",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 32,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Walk-in sites on south shore of Diablo Lake"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.8059,
+          46.7613
+        ]
+      },
+      "properties": {
+        "name": "Cougar Rock",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 173,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Near the Paradise area; excellent views of the Tatoosh Range"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.2583,
+          47.9511
+        ]
+      },
+      "properties": {
+        "name": "Deer Park",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 14,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 7,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "High alpine meadow campground; no RVs; stunning views of the Strait of Juan de Fuca"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.9021,
+          48.059
+        ]
+      },
+      "properties": {
+        "name": "Fairholme",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 88,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On the west end of Lake Crescent; boat launch access"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.2563,
+          48.6793
+        ]
+      },
+      "properties": {
+        "name": "Goodell Creek",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 21,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Year-round campground; popular for whitewater kayaking put-in"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.1948,
+          48.678
+        ]
+      },
+      "properties": {
+        "name": "Gorge Lake",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 6,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Small primitive campground on Gorge Lake; walk-in sites"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.7058,
+          47.5682
+        ]
+      },
+      "properties": {
+        "name": "Graves Creek",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 30,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "In the Quinault Rain Forest; trailhead for Enchanted Valley hike"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.4318,
+          47.9813
+        ]
+      },
+      "properties": {
+        "name": "Heart O' the Hills",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 105,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Main campground for Hurricane Ridge area access"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.9348,
+          47.8601
+        ]
+      },
+      "properties": {
+        "name": "Hoh Rain Forest",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 88,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "In the heart of the temperate rain forest; Hall of Mosses trailhead"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.3757,
+          47.6107
+        ]
+      },
+      "properties": {
+        "name": "Kalaloch",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 170,
+        "types": [
+          "tent",
+          "rv",
+          "cabin"
+        ],
+        "reservable": true,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On coastal bluffs above the Pacific; beach access and tide pools"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.0634,
+          48.6099
+        ]
+      },
+      "properties": {
+        "name": "Kettle Falls",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 76,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On the upper Columbia/Lake Roosevelt; near historic Kettle Falls"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.5972,
+          47.9218
+        ]
+      },
+      "properties": {
+        "name": "Mora",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 94,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Near Rialto Beach; old-growth forest along Quillayute River"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.8636,
+          46.9329
+        ]
+      },
+      "properties": {
+        "name": "Mowich Lake",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 30,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 7,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Walk-in only; on the remote NW side of Rainier; no RVs or trailers"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.2441,
+          48.6718
+        ]
+      },
+      "properties": {
+        "name": "Newhalem Creek",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 111,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Main campground at the Ross Lake NRA gateway town of Newhalem"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.5913,
+          47.5271
+        ]
+      },
+      "properties": {
+        "name": "North Fork",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 9,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Small primitive campground in Quinault Valley"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.5682,
+          46.7296
+        ]
+      },
+      "properties": {
+        "name": "Ohanapecosh",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 188,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "In old-growth forest on the SE side of Rainier; Grove of the Patriarchs nearby"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.0992,
+          47.5228
+        ]
+      },
+      "properties": {
+        "name": "Queets",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 20,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Remote campground in the Queets River valley; old-growth rainforest"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.3119,
+          48.5174
+        ]
+      },
+      "properties": {
+        "name": "Snag Cove",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 9,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Small boat-in or hike-in campground on Lake Roosevelt"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.1565,
+          47.9704
+        ]
+      },
+      "properties": {
+        "name": "Sol Duc",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 82,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Along the Sol Duc River; hot springs resort nearby"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.3656,
+          47.5715
+        ]
+      },
+      "properties": {
+        "name": "South Beach",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 55,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Primitive coastal campground just south of Kalaloch"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.9808,
+          47.9318
+        ]
+      },
+      "properties": {
+        "name": "Spring Canyon",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 87,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Near the town of Grand Coulee; swimming beach on Lake Roosevelt"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.3283,
+          47.5163
+        ]
+      },
+      "properties": {
+        "name": "Staircase",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 47,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "At the foot of the North Fork Skokomish River; gateway to the Olympics"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.6403,
+          46.901
+        ]
+      },
+      "properties": {
+        "name": "White River",
+        "agency": "National Park Service",
+        "agency_short": "nps",
+        "sites": 112,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 7,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Trailhead for Sunrise area and Emmons Glacier route"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.8527,
+          48.5146
+        ]
+      },
+      "properties": {
+        "name": "Beaver Lake",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 24,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Remote lake in the Colville NF; wildlife viewing and fishing"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.3944,
+          47.7671
+        ]
+      },
+      "properties": {
+        "name": "Beckler River",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 27,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Along the Beckler River near Skykomish; popular for families"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.6557,
+          45.9882
+        ]
+      },
+      "properties": {
+        "name": "Blue Lake Creek",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 11,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Small creek-side campground near Trout Lake"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -119.0615,
+          48.7982
+        ]
+      },
+      "properties": {
+        "name": "Bonaparte Lake",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 28,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Scenic lake in northeast WA near Tonasket; good fishing"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.3118,
+          48.1629
+        ]
+      },
+      "properties": {
+        "name": "Buck Creek",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 29,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 6,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On the Suiattle River; access to Glacier Peak Wilderness"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.299,
+          46.9213
+        ]
+      },
+      "properties": {
+        "name": "Bumping Lake",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 45,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 6,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On Bumping Lake reservoir; excellent hiking into the Norse Peak Wilderness"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -120.6629,
+          47.9696
+        ]
+      },
+      "properties": {
+        "name": "Chiwawa Horse Camp",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 21,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 6,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Horse camp in the Chiwawa River corridor; Glacier Peak Wilderness access"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.8154,
+          48.2354
+        ]
+      },
+      "properties": {
+        "name": "Clear Creek",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 12,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Small campground on the Sauk River near Darrington"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.6254,
+          47.4579
+        ]
+      },
+      "properties": {
+        "name": "Coho",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 56,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On Lake Cushman in Hood Canal area"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -120.5218,
+          47.8543
+        ]
+      },
+      "properties": {
+        "name": "Cottonwood",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 25,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On the Entiat River near Lake Chelan NRA; remote and uncrowded"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.4338,
+          47.4221
+        ]
+      },
+      "properties": {
+        "name": "Denny Creek",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 33,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Near Snoqualmie Pass; access to Franklin Falls and Alpine Lakes Wilderness"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.7654,
+          48.5518
+        ]
+      },
+      "properties": {
+        "name": "Douglas Fir",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 30,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On the North Fork Nooksack River; gateway to Mt. Baker"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.0718,
+          47.5482
+        ]
+      },
+      "properties": {
+        "name": "Falls Creek",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 31,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "In the Quinault Valley; access to Lake Quinault and rainforest trails"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.6907,
+          48.6418
+        ]
+      },
+      "properties": {
+        "name": "Lake Leo",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 8,
+        "types": [
+          "tent"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 6,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Small alpine lake campground; hike-in only"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.2246,
+          46.6571
+        ]
+      },
+      "properties": {
+        "name": "Rimrock Lake (Indian Creek)",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 39,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On Rimrock Lake reservoir; fishing and swimming"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.3574,
+          46.9441
+        ]
+      },
+      "properties": {
+        "name": "Soda Springs",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 26,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 6,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Along Bumping River; natural carbonated spring nearby"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.9866,
+          46.5296
+        ]
+      },
+      "properties": {
+        "name": "Steamboat Creek (Iron Creek)",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 98,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Near Mt. St. Helens; along Cispus River corridor"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.6018,
+          46.2668
+        ]
+      },
+      "properties": {
+        "name": "Takhlakh Lake",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 54,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 7,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Stunning views of Mt. Adams from the lake; high-elevation campground"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.5436,
+          45.9954
+        ]
+      },
+      "properties": {
+        "name": "Trout Lake Creek",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 21,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": false,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Near Trout Lake; gateway to Mt. Adams Wilderness trails"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.4729,
+          46.4154
+        ]
+      },
+      "properties": {
+        "name": "Walupt Lake",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 44,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 7,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "Remote lake near the Goat Rocks Wilderness; excellent fishing"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.5846,
+          47.3871
+        ]
+      },
+      "properties": {
+        "name": "Wynoochee Lake",
+        "agency": "US Forest Service",
+        "agency_short": "usfs",
+        "sites": 40,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://www.recreation.gov/",
+        "notes": "On Wynoochee Lake reservoir; swimming, fishing, and boating"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.4875,
+          45.7957
+        ]
+      },
+      "properties": {
+        "name": "Battle Ground Lake State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 50,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Volcanic lake in Clark County; swimming and fishing"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -121.9997,
+          45.6254
+        ]
+      },
+      "properties": {
+        "name": "Beacon Rock State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 35,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Below the famous basalt monolith in the Columbia River Gorge"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.2786,
+          47.8982
+        ]
+      },
+      "properties": {
+        "name": "Bogachiel State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 42,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Along the Bogachiel River near Forks; gateway to Olympic backcountry"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.8234,
+          46.6157
+        ]
+      },
+      "properties": {
+        "name": "Bruceport County Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 30,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 5,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "On Willapa Bay near South Bend"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.0557,
+          46.2874
+        ]
+      },
+      "properties": {
+        "name": "Cape Disappointment State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 250,
+        "types": [
+          "tent",
+          "rv",
+          "cabin"
+        ],
+        "reservable": true,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Where the Columbia River meets the Pacific; two historic lighthouses"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.6668,
+          48.7096
+        ]
+      },
+      "properties": {
+        "name": "Curlew Lake State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 82,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Scenic lake in Ferry County near Republic"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.643,
+          48.4073
+        ]
+      },
+      "properties": {
+        "name": "Deception Pass State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 310,
+        "types": [
+          "tent",
+          "rv",
+          "walk-in"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 3,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Largest state park campground; Cranberry Lake and North Beach loops"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.9017,
+          47.6868
+        ]
+      },
+      "properties": {
+        "name": "Dosewallips State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 140,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "At the confluence of the Dosewallips River and Hood Canal"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.7005,
+          48.0929
+        ]
+      },
+      "properties": {
+        "name": "Fort Flagler State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 116,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Former military fort on Marrowstone Island; panoramic views of Puget Sound"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.7602,
+          48.1329
+        ]
+      },
+      "properties": {
+        "name": "Fort Worden State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 80,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Historic fort on Port Townsend Bay; year-round camping available"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.0871,
+          46.7716
+        ]
+      },
+      "properties": {
+        "name": "Grayland Beach State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 100,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Ocean beach camping near cranberry bogs"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.6391,
+          47.8374
+        ]
+      },
+      "properties": {
+        "name": "Kitsap Memorial State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 43,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Wooded park on Hood Canal near Poulsbo"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.4875,
+          48.6618
+        ]
+      },
+      "properties": {
+        "name": "Larrabee State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 87,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "First state park in WA; saltwater access on Samish Bay"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.8327,
+          48.6571
+        ]
+      },
+      "properties": {
+        "name": "Moran State Park (Orcas Island)",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 151,
+        "types": [
+          "tent",
+          "rv",
+          "walk-in"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Four campgrounds near Summit Lake and Cascade Lake on Orcas Island"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.1655,
+          47.0388
+        ]
+      },
+      "properties": {
+        "name": "Ocean City State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 178,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "On the Long Beach Peninsula; vast sandy beach access"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -119.4436,
+          48.9493
+        ]
+      },
+      "properties": {
+        "name": "Osoyoos Lake State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 86,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Warmest lake in WA on the Canadian border; excellent swimming"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -124.2001,
+          47.2107
+        ]
+      },
+      "properties": {
+        "name": "Pacific Beach State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 138,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Right on the Pacific Ocean; popular for razor clam season"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -118.2274,
+          46.6638
+        ]
+      },
+      "properties": {
+        "name": "Palouse Falls State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 10,
+        "types": [
+          "tent"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Washington State waterfall; 198-ft drop into the Palouse River canyon"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.7108,
+          45.8613
+        ]
+      },
+      "properties": {
+        "name": "Paradise Point State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 70,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Along the East Fork Lewis River near Ridgefield"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.1581,
+          47.5571
+        ]
+      },
+      "properties": {
+        "name": "Potlatch State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 35,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "On Hood Canal; excellent oyster and shellfish harvesting"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -117.4793,
+          47.7046
+        ]
+      },
+      "properties": {
+        "name": "Riverside State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 16,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": true,
+        "open_month": null,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Along the Spokane River near Spokane; Bowl and Pitcher area"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -122.8268,
+          46.2916
+        ]
+      },
+      "properties": {
+        "name": "Seaquest State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 92,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Adjacent to Mount St. Helens National Volcanic Monument; views of the volcano"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -123.0419,
+          48.0457
+        ]
+      },
+      "properties": {
+        "name": "Sequim Bay State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 86,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Protected bay in the Olympic rain shadow; calm waters for boating"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -119.0871,
+          47.8596
+        ]
+      },
+      "properties": {
+        "name": "Steamboat Rock State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 213,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "On Banks Lake in the Grand Coulee area; massive basalt butte"
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -119.4644,
+          47.5968
+        ]
+      },
+      "properties": {
+        "name": "Sun Lakes-Dry Falls State Park",
+        "agency": "Washington State Parks",
+        "agency_short": "wa-state-parks",
+        "sites": 193,
+        "types": [
+          "tent",
+          "rv"
+        ],
+        "reservable": true,
+        "year_round": false,
+        "open_month": 4,
+        "reservation_url": "https://washington.goingtocamp.com/",
+        "notes": "Near the world's largest prehistoric waterfall; coulees and lakes"
       }
     }
   ]

--- a/data/nps/WA/Lake Roosevelt NRA/Kettle Falls/index.md
+++ b/data/nps/WA/Lake Roosevelt NRA/Kettle Falls/index.md
@@ -1,0 +1,18 @@
+---
+name: Kettle Falls
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.6099
+lng: -118.0634
+sites: 76
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On the upper Columbia/Lake Roosevelt; near historic Kettle Falls

--- a/data/nps/WA/Lake Roosevelt NRA/Snag Cove/index.md
+++ b/data/nps/WA/Lake Roosevelt NRA/Snag Cove/index.md
@@ -1,0 +1,18 @@
+---
+name: Snag Cove
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.5174
+lng: -118.3119
+sites: 9
+types: [tent]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Small boat-in or hike-in campground on Lake Roosevelt

--- a/data/nps/WA/Lake Roosevelt NRA/Spring Canyon/index.md
+++ b/data/nps/WA/Lake Roosevelt NRA/Spring Canyon/index.md
@@ -1,0 +1,18 @@
+---
+name: Spring Canyon
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.9318
+lng: -118.9808
+sites: 87
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Near the town of Grand Coulee; swimming beach on Lake Roosevelt

--- a/data/nps/WA/Mt. Rainier NP/Cougar Rock/index.md
+++ b/data/nps/WA/Mt. Rainier NP/Cougar Rock/index.md
@@ -1,0 +1,18 @@
+---
+name: Cougar Rock
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 46.7613
+lng: -121.8059
+sites: 173
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Near the Paradise area; excellent views of the Tatoosh Range

--- a/data/nps/WA/Mt. Rainier NP/Mowich Lake/index.md
+++ b/data/nps/WA/Mt. Rainier NP/Mowich Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Mowich Lake
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 46.9329
+lng: -121.8636
+sites: 30
+types: [tent]
+reservable: false
+year_round: false
+open_date: "July 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Walk-in only; on the remote NW side of Rainier; no RVs or trailers

--- a/data/nps/WA/Mt. Rainier NP/Ohanapecosh/index.md
+++ b/data/nps/WA/Mt. Rainier NP/Ohanapecosh/index.md
@@ -1,0 +1,18 @@
+---
+name: Ohanapecosh
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 46.7296
+lng: -121.5682
+sites: 188
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+In old-growth forest on the SE side of Rainier; Grove of the Patriarchs nearby

--- a/data/nps/WA/Mt. Rainier NP/White River/index.md
+++ b/data/nps/WA/Mt. Rainier NP/White River/index.md
@@ -1,0 +1,18 @@
+---
+name: White River
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 46.901
+lng: -121.6403
+sites: 112
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "July 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Trailhead for Sunrise area and Emmons Glacier route

--- a/data/nps/WA/North Cascades NP/Colonial Creek North/index.md
+++ b/data/nps/WA/North Cascades NP/Colonial Creek North/index.md
@@ -1,0 +1,18 @@
+---
+name: Colonial Creek North
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.6996
+lng: -121.0718
+sites: 60
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On the north shore of Diablo Lake; stunning turquoise waters

--- a/data/nps/WA/North Cascades NP/Colonial Creek South/index.md
+++ b/data/nps/WA/North Cascades NP/Colonial Creek South/index.md
@@ -1,0 +1,18 @@
+---
+name: Colonial Creek South
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.6957
+lng: -121.076
+sites: 32
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Walk-in sites on south shore of Diablo Lake

--- a/data/nps/WA/North Cascades NP/Goodell Creek/index.md
+++ b/data/nps/WA/North Cascades NP/Goodell Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Goodell Creek
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.6793
+lng: -121.2563
+sites: 21
+types: [tent,rv]
+reservable: false
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Year-round campground; popular for whitewater kayaking put-in

--- a/data/nps/WA/North Cascades NP/Gorge Lake/index.md
+++ b/data/nps/WA/North Cascades NP/Gorge Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Gorge Lake
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.678
+lng: -121.1948
+sites: 6
+types: [tent]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Small primitive campground on Gorge Lake; walk-in sites

--- a/data/nps/WA/North Cascades NP/Newhalem Creek/index.md
+++ b/data/nps/WA/North Cascades NP/Newhalem Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Newhalem Creek
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.6718
+lng: -121.2441
+sites: 111
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Main campground at the Ross Lake NRA gateway town of Newhalem

--- a/data/nps/WA/Olympic NP/Deer Park/index.md
+++ b/data/nps/WA/Olympic NP/Deer Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Deer Park
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.9511
+lng: -123.2583
+sites: 14
+types: [tent]
+reservable: false
+year_round: false
+open_date: "July 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+High alpine meadow campground; no RVs; stunning views of the Strait of Juan de Fuca

--- a/data/nps/WA/Olympic NP/Fairholme/index.md
+++ b/data/nps/WA/Olympic NP/Fairholme/index.md
@@ -1,0 +1,18 @@
+---
+name: Fairholme
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 48.059
+lng: -123.9021
+sites: 88
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On the west end of Lake Crescent; boat launch access

--- a/data/nps/WA/Olympic NP/Graves Creek/index.md
+++ b/data/nps/WA/Olympic NP/Graves Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Graves Creek
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.5682
+lng: -123.7058
+sites: 30
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+In the Quinault Rain Forest; trailhead for Enchanted Valley hike

--- a/data/nps/WA/Olympic NP/Heart O' the Hills/index.md
+++ b/data/nps/WA/Olympic NP/Heart O' the Hills/index.md
@@ -1,0 +1,18 @@
+---
+name: Heart O' the Hills
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.9813
+lng: -123.4318
+sites: 105
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Main campground for Hurricane Ridge area access

--- a/data/nps/WA/Olympic NP/Hoh Rain Forest/index.md
+++ b/data/nps/WA/Olympic NP/Hoh Rain Forest/index.md
@@ -1,0 +1,18 @@
+---
+name: Hoh Rain Forest
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.8601
+lng: -123.9348
+sites: 88
+types: [tent,rv]
+reservable: true
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+In the heart of the temperate rain forest; Hall of Mosses trailhead

--- a/data/nps/WA/Olympic NP/Kalaloch/index.md
+++ b/data/nps/WA/Olympic NP/Kalaloch/index.md
@@ -1,0 +1,18 @@
+---
+name: Kalaloch
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.6107
+lng: -124.3757
+sites: 170
+types: [tent,rv,cabin]
+reservable: true
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On coastal bluffs above the Pacific; beach access and tide pools

--- a/data/nps/WA/Olympic NP/Mora/index.md
+++ b/data/nps/WA/Olympic NP/Mora/index.md
@@ -1,0 +1,18 @@
+---
+name: Mora
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.9218
+lng: -124.5972
+sites: 94
+types: [tent,rv]
+reservable: true
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Near Rialto Beach; old-growth forest along Quillayute River

--- a/data/nps/WA/Olympic NP/North Fork/index.md
+++ b/data/nps/WA/Olympic NP/North Fork/index.md
@@ -1,0 +1,18 @@
+---
+name: North Fork
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.5271
+lng: -123.5913
+sites: 9
+types: [tent]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Small primitive campground in Quinault Valley

--- a/data/nps/WA/Olympic NP/Queets/index.md
+++ b/data/nps/WA/Olympic NP/Queets/index.md
@@ -1,0 +1,18 @@
+---
+name: Queets
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.5228
+lng: -124.0992
+sites: 20
+types: [tent]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Remote campground in the Queets River valley; old-growth rainforest

--- a/data/nps/WA/Olympic NP/Sol Duc/index.md
+++ b/data/nps/WA/Olympic NP/Sol Duc/index.md
@@ -1,0 +1,18 @@
+---
+name: Sol Duc
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.9704
+lng: -124.1565
+sites: 82
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Along the Sol Duc River; hot springs resort nearby

--- a/data/nps/WA/Olympic NP/South Beach/index.md
+++ b/data/nps/WA/Olympic NP/South Beach/index.md
@@ -1,0 +1,18 @@
+---
+name: South Beach
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.5715
+lng: -124.3656
+sites: 55
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Primitive coastal campground just south of Kalaloch

--- a/data/nps/WA/Olympic NP/Staircase/index.md
+++ b/data/nps/WA/Olympic NP/Staircase/index.md
@@ -1,0 +1,18 @@
+---
+name: Staircase
+agency: National Park Service
+agency_short: nps
+state: WA
+lat: 47.5163
+lng: -123.3283
+sites: 47
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+At the foot of the North Fork Skokomish River; gateway to the Olympics

--- a/data/usfs/WA/Colville NF/Beaver Lake/index.md
+++ b/data/usfs/WA/Colville NF/Beaver Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Beaver Lake
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.5146
+lng: -118.8527
+sites: 24
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Remote lake in the Colville NF; wildlife viewing and fishing

--- a/data/usfs/WA/Colville NF/Bonaparte Lake/index.md
+++ b/data/usfs/WA/Colville NF/Bonaparte Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Bonaparte Lake
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.7982
+lng: -119.0615
+sites: 28
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Scenic lake in northeast WA near Tonasket; good fishing

--- a/data/usfs/WA/Colville NF/Lake Leo/index.md
+++ b/data/usfs/WA/Colville NF/Lake Leo/index.md
@@ -1,0 +1,18 @@
+---
+name: Lake Leo
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.6418
+lng: -118.6907
+sites: 8
+types: [tent]
+reservable: false
+year_round: false
+open_date: "June 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Small alpine lake campground; hike-in only

--- a/data/usfs/WA/Gifford Pinchot NF/Blue Lake Creek/index.md
+++ b/data/usfs/WA/Gifford Pinchot NF/Blue Lake Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Blue Lake Creek
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 45.9882
+lng: -121.6557
+sites: 11
+types: [tent]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Small creek-side campground near Trout Lake

--- a/data/usfs/WA/Gifford Pinchot NF/Steamboat Creek (Iron Creek)/index.md
+++ b/data/usfs/WA/Gifford Pinchot NF/Steamboat Creek (Iron Creek)/index.md
@@ -1,0 +1,18 @@
+---
+name: Steamboat Creek (Iron Creek)
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 46.5296
+lng: -121.9866
+sites: 98
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Near Mt. St. Helens; along Cispus River corridor

--- a/data/usfs/WA/Gifford Pinchot NF/Takhlakh Lake/index.md
+++ b/data/usfs/WA/Gifford Pinchot NF/Takhlakh Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Takhlakh Lake
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 46.2668
+lng: -121.6018
+sites: 54
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "July 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Stunning views of Mt. Adams from the lake; high-elevation campground

--- a/data/usfs/WA/Gifford Pinchot NF/Trout Lake Creek/index.md
+++ b/data/usfs/WA/Gifford Pinchot NF/Trout Lake Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Trout Lake Creek
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 45.9954
+lng: -121.5436
+sites: 21
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Near Trout Lake; gateway to Mt. Adams Wilderness trails

--- a/data/usfs/WA/Gifford Pinchot NF/Walupt Lake/index.md
+++ b/data/usfs/WA/Gifford Pinchot NF/Walupt Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Walupt Lake
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 46.4154
+lng: -121.4729
+sites: 44
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "July 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Remote lake near the Goat Rocks Wilderness; excellent fishing

--- a/data/usfs/WA/Mt. Baker-Snoqualmie NF/Beckler River/index.md
+++ b/data/usfs/WA/Mt. Baker-Snoqualmie NF/Beckler River/index.md
@@ -1,0 +1,18 @@
+---
+name: Beckler River
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.7671
+lng: -121.3944
+sites: 27
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Along the Beckler River near Skykomish; popular for families

--- a/data/usfs/WA/Mt. Baker-Snoqualmie NF/Buck Creek/index.md
+++ b/data/usfs/WA/Mt. Baker-Snoqualmie NF/Buck Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Buck Creek
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.1629
+lng: -121.3118
+sites: 29
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "June 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On the Suiattle River; access to Glacier Peak Wilderness

--- a/data/usfs/WA/Mt. Baker-Snoqualmie NF/Clear Creek/index.md
+++ b/data/usfs/WA/Mt. Baker-Snoqualmie NF/Clear Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Clear Creek
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.2354
+lng: -121.8154
+sites: 12
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Small campground on the Sauk River near Darrington

--- a/data/usfs/WA/Mt. Baker-Snoqualmie NF/Denny Creek/index.md
+++ b/data/usfs/WA/Mt. Baker-Snoqualmie NF/Denny Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Denny Creek
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.4221
+lng: -121.4338
+sites: 33
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Near Snoqualmie Pass; access to Franklin Falls and Alpine Lakes Wilderness

--- a/data/usfs/WA/Mt. Baker-Snoqualmie NF/Douglas Fir/index.md
+++ b/data/usfs/WA/Mt. Baker-Snoqualmie NF/Douglas Fir/index.md
@@ -1,0 +1,18 @@
+---
+name: Douglas Fir
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.5518
+lng: -121.7654
+sites: 30
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On the North Fork Nooksack River; gateway to Mt. Baker

--- a/data/usfs/WA/Okanogan-Wenatchee NF/Bumping Lake/index.md
+++ b/data/usfs/WA/Okanogan-Wenatchee NF/Bumping Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Bumping Lake
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 46.9213
+lng: -121.299
+sites: 45
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "June 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On Bumping Lake reservoir; excellent hiking into the Norse Peak Wilderness

--- a/data/usfs/WA/Okanogan-Wenatchee NF/Chiwawa Horse Camp/index.md
+++ b/data/usfs/WA/Okanogan-Wenatchee NF/Chiwawa Horse Camp/index.md
@@ -1,0 +1,18 @@
+---
+name: Chiwawa Horse Camp
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.9696
+lng: -120.6629
+sites: 21
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "June 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Horse camp in the Chiwawa River corridor; Glacier Peak Wilderness access

--- a/data/usfs/WA/Okanogan-Wenatchee NF/Cottonwood/index.md
+++ b/data/usfs/WA/Okanogan-Wenatchee NF/Cottonwood/index.md
@@ -1,0 +1,18 @@
+---
+name: Cottonwood
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.8543
+lng: -120.5218
+sites: 25
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On the Entiat River near Lake Chelan NRA; remote and uncrowded

--- a/data/usfs/WA/Okanogan-Wenatchee NF/Rimrock Lake (Indian Creek)/index.md
+++ b/data/usfs/WA/Okanogan-Wenatchee NF/Rimrock Lake (Indian Creek)/index.md
@@ -1,0 +1,18 @@
+---
+name: Rimrock Lake (Indian Creek)
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 46.6571
+lng: -121.2246
+sites: 39
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On Rimrock Lake reservoir; fishing and swimming

--- a/data/usfs/WA/Okanogan-Wenatchee NF/Soda Springs/index.md
+++ b/data/usfs/WA/Okanogan-Wenatchee NF/Soda Springs/index.md
@@ -1,0 +1,18 @@
+---
+name: Soda Springs
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 46.9441
+lng: -121.3574
+sites: 26
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "June 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+Along Bumping River; natural carbonated spring nearby

--- a/data/usfs/WA/Olympic NF/Coho/index.md
+++ b/data/usfs/WA/Olympic NF/Coho/index.md
@@ -1,0 +1,18 @@
+---
+name: Coho
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.4579
+lng: -123.6254
+sites: 56
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On Lake Cushman in Hood Canal area

--- a/data/usfs/WA/Olympic NF/Falls Creek/index.md
+++ b/data/usfs/WA/Olympic NF/Falls Creek/index.md
@@ -1,0 +1,18 @@
+---
+name: Falls Creek
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.5482
+lng: -124.0718
+sites: 31
+types: [tent,rv]
+reservable: false
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+In the Quinault Valley; access to Lake Quinault and rainforest trails

--- a/data/usfs/WA/Olympic NF/Wynoochee Lake/index.md
+++ b/data/usfs/WA/Olympic NF/Wynoochee Lake/index.md
@@ -1,0 +1,18 @@
+---
+name: Wynoochee Lake
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 47.3871
+lng: -123.5846
+sites: 40
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://www.recreation.gov/
+official_url: https://www.recreation.gov/
+---
+
+On Wynoochee Lake reservoir; swimming, fishing, and boating

--- a/data/wa-state-parks/WA/Battle Ground Lake State Park/index.md
+++ b/data/wa-state-parks/WA/Battle Ground Lake State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Battle Ground Lake State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 45.7957
+lng: -122.4875
+sites: 50
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Volcanic lake in Clark County; swimming and fishing

--- a/data/wa-state-parks/WA/Beacon Rock State Park/index.md
+++ b/data/wa-state-parks/WA/Beacon Rock State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Beacon Rock State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 45.6254
+lng: -121.9997
+sites: 35
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Below the famous basalt monolith in the Columbia River Gorge

--- a/data/wa-state-parks/WA/Bogachiel State Park/index.md
+++ b/data/wa-state-parks/WA/Bogachiel State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Bogachiel State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.8982
+lng: -124.2786
+sites: 42
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Along the Bogachiel River near Forks; gateway to Olympic backcountry

--- a/data/wa-state-parks/WA/Bruceport County Park/index.md
+++ b/data/wa-state-parks/WA/Bruceport County Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Bruceport County Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 46.6157
+lng: -123.8234
+sites: 30
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "May 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+On Willapa Bay near South Bend

--- a/data/wa-state-parks/WA/Cape Disappointment State Park/index.md
+++ b/data/wa-state-parks/WA/Cape Disappointment State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Cape Disappointment State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 46.2874
+lng: -124.0557
+sites: 250
+types: [tent,rv,cabin]
+reservable: true
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Where the Columbia River meets the Pacific; two historic lighthouses

--- a/data/wa-state-parks/WA/Curlew Lake State Park/index.md
+++ b/data/wa-state-parks/WA/Curlew Lake State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Curlew Lake State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.7096
+lng: -118.6668
+sites: 82
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Scenic lake in Ferry County near Republic

--- a/data/wa-state-parks/WA/Deception Pass State Park/index.md
+++ b/data/wa-state-parks/WA/Deception Pass State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Deception Pass State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.4073
+lng: -122.643
+sites: 310
+types: [tent,rv,walk-in]
+reservable: true
+year_round: false
+open_date: "March 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Largest state park campground; Cranberry Lake and North Beach loops

--- a/data/wa-state-parks/WA/Dosewallips State Park/index.md
+++ b/data/wa-state-parks/WA/Dosewallips State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Dosewallips State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.6868
+lng: -122.9017
+sites: 140
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+At the confluence of the Dosewallips River and Hood Canal

--- a/data/wa-state-parks/WA/Fort Flagler State Park/index.md
+++ b/data/wa-state-parks/WA/Fort Flagler State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Fort Flagler State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.0929
+lng: -122.7005
+sites: 116
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Former military fort on Marrowstone Island; panoramic views of Puget Sound

--- a/data/wa-state-parks/WA/Fort Worden State Park/index.md
+++ b/data/wa-state-parks/WA/Fort Worden State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Fort Worden State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.1329
+lng: -122.7602
+sites: 80
+types: [tent,rv]
+reservable: true
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Historic fort on Port Townsend Bay; year-round camping available

--- a/data/wa-state-parks/WA/Grayland Beach State Park/index.md
+++ b/data/wa-state-parks/WA/Grayland Beach State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Grayland Beach State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 46.7716
+lng: -124.0871
+sites: 100
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Ocean beach camping near cranberry bogs

--- a/data/wa-state-parks/WA/Kitsap Memorial State Park/index.md
+++ b/data/wa-state-parks/WA/Kitsap Memorial State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Kitsap Memorial State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.8374
+lng: -122.6391
+sites: 43
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Wooded park on Hood Canal near Poulsbo

--- a/data/wa-state-parks/WA/Larrabee State Park/index.md
+++ b/data/wa-state-parks/WA/Larrabee State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Larrabee State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.6618
+lng: -122.4875
+sites: 87
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+First state park in WA; saltwater access on Samish Bay

--- a/data/wa-state-parks/WA/Moran State Park (Orcas Island)/index.md
+++ b/data/wa-state-parks/WA/Moran State Park (Orcas Island)/index.md
@@ -1,0 +1,18 @@
+---
+name: Moran State Park (Orcas Island)
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.6571
+lng: -122.8327
+sites: 151
+types: [tent,rv,walk-in]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Four campgrounds near Summit Lake and Cascade Lake on Orcas Island

--- a/data/wa-state-parks/WA/Ocean City State Park/index.md
+++ b/data/wa-state-parks/WA/Ocean City State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Ocean City State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.0388
+lng: -124.1655
+sites: 178
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+On the Long Beach Peninsula; vast sandy beach access

--- a/data/wa-state-parks/WA/Osoyoos Lake State Park/index.md
+++ b/data/wa-state-parks/WA/Osoyoos Lake State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Osoyoos Lake State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.9493
+lng: -119.4436
+sites: 86
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Warmest lake in WA on the Canadian border; excellent swimming

--- a/data/wa-state-parks/WA/Pacific Beach State Park/index.md
+++ b/data/wa-state-parks/WA/Pacific Beach State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Pacific Beach State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.2107
+lng: -124.2001
+sites: 138
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Right on the Pacific Ocean; popular for razor clam season

--- a/data/wa-state-parks/WA/Palouse Falls State Park/index.md
+++ b/data/wa-state-parks/WA/Palouse Falls State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Palouse Falls State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 46.6638
+lng: -118.2274
+sites: 10
+types: [tent]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Washington State waterfall; 198-ft drop into the Palouse River canyon

--- a/data/wa-state-parks/WA/Paradise Point State Park/index.md
+++ b/data/wa-state-parks/WA/Paradise Point State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Paradise Point State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 45.8613
+lng: -122.7108
+sites: 70
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Along the East Fork Lewis River near Ridgefield

--- a/data/wa-state-parks/WA/Potlatch State Park/index.md
+++ b/data/wa-state-parks/WA/Potlatch State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Potlatch State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.5571
+lng: -123.1581
+sites: 35
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+On Hood Canal; excellent oyster and shellfish harvesting

--- a/data/wa-state-parks/WA/Riverside State Park/index.md
+++ b/data/wa-state-parks/WA/Riverside State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Riverside State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.7046
+lng: -117.4793
+sites: 16
+types: [tent,rv]
+reservable: true
+year_round: true
+open_date: null
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Along the Spokane River near Spokane; Bowl and Pitcher area

--- a/data/wa-state-parks/WA/Seaquest State Park/index.md
+++ b/data/wa-state-parks/WA/Seaquest State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Seaquest State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 46.2916
+lng: -122.8268
+sites: 92
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Adjacent to Mount St. Helens National Volcanic Monument; views of the volcano

--- a/data/wa-state-parks/WA/Sequim Bay State Park/index.md
+++ b/data/wa-state-parks/WA/Sequim Bay State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Sequim Bay State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 48.0457
+lng: -123.0419
+sites: 86
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Protected bay in the Olympic rain shadow; calm waters for boating

--- a/data/wa-state-parks/WA/Steamboat Rock State Park/index.md
+++ b/data/wa-state-parks/WA/Steamboat Rock State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Steamboat Rock State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.8596
+lng: -119.0871
+sites: 213
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+On Banks Lake in the Grand Coulee area; massive basalt butte

--- a/data/wa-state-parks/WA/Sun Lakes-Dry Falls State Park/index.md
+++ b/data/wa-state-parks/WA/Sun Lakes-Dry Falls State Park/index.md
@@ -1,0 +1,18 @@
+---
+name: Sun Lakes-Dry Falls State Park
+agency: Washington State Parks
+agency_short: wa-state-parks
+state: WA
+lat: 47.5968
+lng: -119.4644
+sites: 193
+types: [tent,rv]
+reservable: true
+year_round: false
+open_date: "April 1"
+first_reservation_date: null
+reservation_url: https://washington.goingtocamp.com/
+official_url: https://washington.goingtocamp.com/
+---
+
+Near the world's largest prehistoric waterfall; coulees and lakes

--- a/scripts/generate-campsite-files.js
+++ b/scripts/generate-campsite-files.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+const BASE_DIR = '/Users/tommydoerr/dev/robot-geographical-society/data';
+
+const MONTH_NAMES = [
+  null, 'January', 'February', 'March', 'April', 'May', 'June',
+  'July', 'August', 'September', 'October', 'November', 'December'
+];
+
+function formatOpenDate(yearRound, openMonth) {
+  if (yearRound || openMonth == null) return 'null';
+  return `"${MONTH_NAMES[openMonth]} 1"`;
+}
+
+function formatTypes(types) {
+  return types.join(',');
+}
+
+function buildFrontmatter(fields) {
+  const openDate = formatOpenDate(fields.year_round, fields.open_month);
+  return `---
+name: ${fields.name}
+agency: ${fields.agency}
+agency_short: ${fields.agency_short}
+state: WA
+lat: ${fields.lat}
+lng: ${fields.lng}
+sites: ${fields.sites}
+types: [${formatTypes(fields.types)}]
+reservable: ${fields.reservable}
+year_round: ${fields.year_round}
+open_date: ${openDate}
+first_reservation_date: null
+reservation_url: ${fields.reservation_url}
+official_url: ${fields.reservation_url}
+---
+
+${fields.notes}
+`;
+}
+
+function sanitizeDir(name) {
+  // Keep the name as-is for directory (parentheses, spaces, etc.)
+  return name;
+}
+
+function writeFile(filePath, content) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, 'utf8');
+}
+
+let count = 0;
+
+// ─── BLM ────────────────────────────────────────────────────────────────────
+const blm = [
+  { name: 'Liberty Recreation Site',   lat: 47.2638, lng: -120.9518, sites: 18, types: ['tent','rv'], reservable: false, year_round: true,  open_month: null, url: 'https://www.blm.gov/', notes: 'Near the historic gold mining town of Liberty; dispersed camping area' },
+  { name: 'Fishtrap Recreation Area',  lat: 47.4438, lng: -117.6929, sites: 20, types: ['tent','rv'], reservable: false, year_round: true,  open_month: null, url: 'https://www.blm.gov/', notes: 'On Fishtrap Lake near Sprague; wildlife-rich shrub-steppe environment' },
+  { name: 'Taunton Dispersed Area',    lat: 47.1704, lng: -119.2238, sites: 15, types: ['tent','rv'], reservable: false, year_round: true,  open_month: null, url: 'https://www.blm.gov/', notes: 'Dispersed camping in Columbia Plateau; excellent stargazing' },
+  { name: 'Juniper Dunes Wilderness',  lat: 46.5471, lng: -118.9054, sites: 10, types: ['tent'],      reservable: false, year_round: true,  open_month: null, url: 'https://www.blm.gov/', notes: 'Primitive camping near the largest natural juniper forest in WA; no facilities' },
+  { name: 'Yakima River Canyon',       lat: 46.8268, lng: -120.4927, sites: 25, types: ['tent','rv'], reservable: false, year_round: true,  open_month: null, url: 'https://www.blm.gov/', notes: 'Along the Yakima River between Ellensburg and Yakima; popular for fly fishing' },
+];
+
+for (const c of blm) {
+  const filePath = path.join(BASE_DIR, 'blm', 'WA', sanitizeDir(c.name), 'index.md');
+  const content = buildFrontmatter({
+    name: c.name,
+    agency: 'Bureau of Land Management',
+    agency_short: 'blm',
+    lat: c.lat,
+    lng: c.lng,
+    sites: c.sites,
+    types: c.types,
+    reservable: c.reservable,
+    year_round: c.year_round,
+    open_month: c.open_month,
+    reservation_url: c.url,
+    notes: c.notes,
+  });
+  writeFile(filePath, content);
+  console.log(`  created: ${filePath}`);
+  count++;
+}
+
+// ─── NPS ────────────────────────────────────────────────────────────────────
+const nps = [
+  // Olympic NP
+  { park: 'Olympic NP', name: 'Deer Park',          lat: 47.9511, lng: -123.2583, sites: 14,  types: ['tent'],             reservable: false, year_round: false, open_month: 7,    url: 'https://www.recreation.gov/', notes: 'High alpine meadow campground; no RVs; stunning views of the Strait of Juan de Fuca' },
+  { park: 'Olympic NP', name: 'Fairholme',           lat: 48.0590, lng: -123.9021, sites: 88,  types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'On the west end of Lake Crescent; boat launch access' },
+  { park: 'Olympic NP', name: 'Graves Creek',        lat: 47.5682, lng: -123.7058, sites: 30,  types: ['tent','rv'],        reservable: false, year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'In the Quinault Rain Forest; trailhead for Enchanted Valley hike' },
+  { park: 'Olympic NP', name: "Heart O' the Hills",  lat: 47.9813, lng: -123.4318, sites: 105, types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Main campground for Hurricane Ridge area access' },
+  { park: 'Olympic NP', name: 'Hoh Rain Forest',     lat: 47.8601, lng: -123.9348, sites: 88,  types: ['tent','rv'],        reservable: true,  year_round: true,  open_month: null, url: 'https://www.recreation.gov/', notes: 'In the heart of the temperate rain forest; Hall of Mosses trailhead' },
+  { park: 'Olympic NP', name: 'Kalaloch',             lat: 47.6107, lng: -124.3757, sites: 170, types: ['tent','rv','cabin'], reservable: true,  year_round: true,  open_month: null, url: 'https://www.recreation.gov/', notes: 'On coastal bluffs above the Pacific; beach access and tide pools' },
+  { park: 'Olympic NP', name: 'Mora',                 lat: 47.9218, lng: -124.5972, sites: 94,  types: ['tent','rv'],        reservable: true,  year_round: true,  open_month: null, url: 'https://www.recreation.gov/', notes: 'Near Rialto Beach; old-growth forest along Quillayute River' },
+  { park: 'Olympic NP', name: 'North Fork',           lat: 47.5271, lng: -123.5913, sites: 9,   types: ['tent'],             reservable: false, year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Small primitive campground in Quinault Valley' },
+  { park: 'Olympic NP', name: 'Queets',               lat: 47.5228, lng: -124.0992, sites: 20,  types: ['tent'],             reservable: false, year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Remote campground in the Queets River valley; old-growth rainforest' },
+  { park: 'Olympic NP', name: 'Sol Duc',              lat: 47.9704, lng: -124.1565, sites: 82,  types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Along the Sol Duc River; hot springs resort nearby' },
+  { park: 'Olympic NP', name: 'South Beach',          lat: 47.5715, lng: -124.3656, sites: 55,  types: ['tent','rv'],        reservable: false, year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Primitive coastal campground just south of Kalaloch' },
+  { park: 'Olympic NP', name: 'Staircase',            lat: 47.5163, lng: -123.3283, sites: 47,  types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'At the foot of the North Fork Skokomish River; gateway to the Olympics' },
+  // Mt. Rainier NP
+  { park: 'Mt. Rainier NP', name: 'Cougar Rock',     lat: 46.7613, lng: -121.8059, sites: 173, types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Near the Paradise area; excellent views of the Tatoosh Range' },
+  { park: 'Mt. Rainier NP', name: 'White River',     lat: 46.9010, lng: -121.6403, sites: 112, types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 7,    url: 'https://www.recreation.gov/', notes: 'Trailhead for Sunrise area and Emmons Glacier route' },
+  { park: 'Mt. Rainier NP', name: 'Ohanapecosh',     lat: 46.7296, lng: -121.5682, sites: 188, types: ['tent','rv'],        reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'In old-growth forest on the SE side of Rainier; Grove of the Patriarchs nearby' },
+  { park: 'Mt. Rainier NP', name: 'Mowich Lake',     lat: 46.9329, lng: -121.8636, sites: 30,  types: ['tent'],             reservable: false, year_round: false, open_month: 7,    url: 'https://www.recreation.gov/', notes: 'Walk-in only; on the remote NW side of Rainier; no RVs or trailers' },
+  // North Cascades NP
+  { park: 'North Cascades NP', name: 'Newhalem Creek',       lat: 48.6718, lng: -121.2441, sites: 111, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Main campground at the Ross Lake NRA gateway town of Newhalem' },
+  { park: 'North Cascades NP', name: 'Gorge Lake',           lat: 48.6780, lng: -121.1948, sites: 6,   types: ['tent'],      reservable: false, year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Small primitive campground on Gorge Lake; walk-in sites' },
+  { park: 'North Cascades NP', name: 'Goodell Creek',        lat: 48.6793, lng: -121.2563, sites: 21,  types: ['tent','rv'], reservable: false, year_round: true,  open_month: null, url: 'https://www.recreation.gov/', notes: 'Year-round campground; popular for whitewater kayaking put-in' },
+  { park: 'North Cascades NP', name: 'Colonial Creek North', lat: 48.6996, lng: -121.0718, sites: 60,  types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'On the north shore of Diablo Lake; stunning turquoise waters' },
+  { park: 'North Cascades NP', name: 'Colonial Creek South', lat: 48.6957, lng: -121.0760, sites: 32,  types: ['tent','rv'], reservable: false, year_round: false, open_month: 5,    url: 'https://www.recreation.gov/', notes: 'Walk-in sites on south shore of Diablo Lake' },
+  // Lake Roosevelt NRA
+  { park: 'Lake Roosevelt NRA', name: 'Kettle Falls',  lat: 48.6099, lng: -118.0634, sites: 76, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'On the upper Columbia/Lake Roosevelt; near historic Kettle Falls' },
+  { park: 'Lake Roosevelt NRA', name: 'Spring Canyon', lat: 47.9318, lng: -118.9808, sites: 87, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Near the town of Grand Coulee; swimming beach on Lake Roosevelt' },
+  { park: 'Lake Roosevelt NRA', name: 'Snag Cove',     lat: 48.5174, lng: -118.3119, sites: 9,  types: ['tent'],      reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Small boat-in or hike-in campground on Lake Roosevelt' },
+];
+
+for (const c of nps) {
+  const filePath = path.join(BASE_DIR, 'nps', 'WA', sanitizeDir(c.park), sanitizeDir(c.name), 'index.md');
+  const content = buildFrontmatter({
+    name: c.name,
+    agency: 'National Park Service',
+    agency_short: 'nps',
+    lat: c.lat,
+    lng: c.lng,
+    sites: c.sites,
+    types: c.types,
+    reservable: c.reservable,
+    year_round: c.year_round,
+    open_month: c.open_month,
+    reservation_url: c.url,
+    notes: c.notes,
+  });
+  writeFile(filePath, content);
+  console.log(`  created: ${filePath}`);
+  count++;
+}
+
+// ─── USFS ───────────────────────────────────────────────────────────────────
+const usfs = [
+  // Gifford Pinchot NF
+  { forest: 'Gifford Pinchot NF', name: 'Takhlakh Lake',              lat: 46.2668, lng: -121.6018, sites: 54, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 7, url: 'https://www.recreation.gov/', notes: 'Stunning views of Mt. Adams from the lake; high-elevation campground' },
+  { forest: 'Gifford Pinchot NF', name: 'Walupt Lake',                lat: 46.4154, lng: -121.4729, sites: 44, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 7, url: 'https://www.recreation.gov/', notes: 'Remote lake near the Goat Rocks Wilderness; excellent fishing' },
+  { forest: 'Gifford Pinchot NF', name: 'Steamboat Creek (Iron Creek)',lat: 46.5296, lng: -121.9866, sites: 98, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Near Mt. St. Helens; along Cispus River corridor' },
+  { forest: 'Gifford Pinchot NF', name: 'Trout Lake Creek',           lat: 45.9954, lng: -121.5436, sites: 21, types: ['tent','rv'], reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Near Trout Lake; gateway to Mt. Adams Wilderness trails' },
+  { forest: 'Gifford Pinchot NF', name: 'Blue Lake Creek',            lat: 45.9882, lng: -121.6557, sites: 11, types: ['tent'],      reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Small creek-side campground near Trout Lake' },
+  // Okanogan-Wenatchee NF
+  { forest: 'Okanogan-Wenatchee NF', name: 'Bumping Lake',            lat: 46.9213, lng: -121.2990, sites: 45, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 6, url: 'https://www.recreation.gov/', notes: 'On Bumping Lake reservoir; excellent hiking into the Norse Peak Wilderness' },
+  { forest: 'Okanogan-Wenatchee NF', name: 'Soda Springs',            lat: 46.9441, lng: -121.3574, sites: 26, types: ['tent','rv'], reservable: false, year_round: false, open_month: 6, url: 'https://www.recreation.gov/', notes: 'Along Bumping River; natural carbonated spring nearby' },
+  { forest: 'Okanogan-Wenatchee NF', name: 'Cottonwood',              lat: 47.8543, lng: -120.5218, sites: 25, types: ['tent','rv'], reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'On the Entiat River near Lake Chelan NRA; remote and uncrowded' },
+  { forest: 'Okanogan-Wenatchee NF', name: 'Chiwawa Horse Camp',      lat: 47.9696, lng: -120.6629, sites: 21, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 6, url: 'https://www.recreation.gov/', notes: 'Horse camp in the Chiwawa River corridor; Glacier Peak Wilderness access' },
+  { forest: 'Okanogan-Wenatchee NF', name: 'Rimrock Lake (Indian Creek)', lat: 46.6571, lng: -121.2246, sites: 39, types: ['tent','rv'], reservable: true, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'On Rimrock Lake reservoir; fishing and swimming' },
+  // Mt. Baker-Snoqualmie NF
+  { forest: 'Mt. Baker-Snoqualmie NF', name: 'Denny Creek',           lat: 47.4221, lng: -121.4338, sites: 33, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Near Snoqualmie Pass; access to Franklin Falls and Alpine Lakes Wilderness' },
+  { forest: 'Mt. Baker-Snoqualmie NF', name: 'Beckler River',         lat: 47.7671, lng: -121.3944, sites: 27, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Along the Beckler River near Skykomish; popular for families' },
+  { forest: 'Mt. Baker-Snoqualmie NF', name: 'Douglas Fir',           lat: 48.5518, lng: -121.7654, sites: 30, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'On the North Fork Nooksack River; gateway to Mt. Baker' },
+  { forest: 'Mt. Baker-Snoqualmie NF', name: 'Buck Creek',            lat: 48.1629, lng: -121.3118, sites: 29, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 6, url: 'https://www.recreation.gov/', notes: 'On the Suiattle River; access to Glacier Peak Wilderness' },
+  { forest: 'Mt. Baker-Snoqualmie NF', name: 'Clear Creek',           lat: 48.2354, lng: -121.8154, sites: 12, types: ['tent','rv'], reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Small campground on the Sauk River near Darrington' },
+  // Olympic NF
+  { forest: 'Olympic NF', name: 'Falls Creek',                        lat: 47.5482, lng: -124.0718, sites: 31, types: ['tent','rv'], reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'In the Quinault Valley; access to Lake Quinault and rainforest trails' },
+  { forest: 'Olympic NF', name: 'Coho',                               lat: 47.4579, lng: -123.6254, sites: 56, types: ['tent','rv'], reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'On Lake Cushman in Hood Canal area' },
+  { forest: 'Olympic NF', name: 'Wynoochee Lake',                     lat: 47.3871, lng: -123.5846, sites: 40, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'On Wynoochee Lake reservoir; swimming, fishing, and boating' },
+  // Colville NF
+  { forest: 'Colville NF', name: 'Bonaparte Lake',                    lat: 48.7982, lng: -119.0615, sites: 28, types: ['tent','rv'], reservable: true,  year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Scenic lake in northeast WA near Tonasket; good fishing' },
+  { forest: 'Colville NF', name: 'Beaver Lake',                       lat: 48.5146, lng: -118.8527, sites: 24, types: ['tent','rv'], reservable: false, year_round: false, open_month: 5, url: 'https://www.recreation.gov/', notes: 'Remote lake in the Colville NF; wildlife viewing and fishing' },
+  { forest: 'Colville NF', name: 'Lake Leo',                          lat: 48.6418, lng: -118.6907, sites: 8,  types: ['tent'],      reservable: false, year_round: false, open_month: 6, url: 'https://www.recreation.gov/', notes: 'Small alpine lake campground; hike-in only' },
+];
+
+for (const c of usfs) {
+  const filePath = path.join(BASE_DIR, 'usfs', 'WA', sanitizeDir(c.forest), sanitizeDir(c.name), 'index.md');
+  const content = buildFrontmatter({
+    name: c.name,
+    agency: 'US Forest Service',
+    agency_short: 'usfs',
+    lat: c.lat,
+    lng: c.lng,
+    sites: c.sites,
+    types: c.types,
+    reservable: c.reservable,
+    year_round: c.year_round,
+    open_month: c.open_month,
+    reservation_url: c.url,
+    notes: c.notes,
+  });
+  writeFile(filePath, content);
+  console.log(`  created: ${filePath}`);
+  count++;
+}
+
+// ─── WA State Parks ──────────────────────────────────────────────────────────
+const waParks = [
+  { name: 'Deception Pass State Park',        lat: 48.4073, lng: -122.6430, sites: 310, types: ['tent','rv','walk-in'], reservable: true,  year_round: false, open_month: 3,    url: 'https://washington.goingtocamp.com/', notes: 'Largest state park campground; Cranberry Lake and North Beach loops' },
+  { name: 'Larrabee State Park',              lat: 48.6618, lng: -122.4875, sites: 87,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'First state park in WA; saltwater access on Samish Bay' },
+  { name: 'Moran State Park (Orcas Island)',  lat: 48.6571, lng: -122.8327, sites: 151, types: ['tent','rv','walk-in'], reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Four campgrounds near Summit Lake and Cascade Lake on Orcas Island' },
+  { name: 'Fort Worden State Park',           lat: 48.1329, lng: -122.7602, sites: 80,  types: ['tent','rv'],           reservable: true,  year_round: true,  open_month: null, url: 'https://washington.goingtocamp.com/', notes: 'Historic fort on Port Townsend Bay; year-round camping available' },
+  { name: 'Fort Flagler State Park',          lat: 48.0929, lng: -122.7005, sites: 116, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Former military fort on Marrowstone Island; panoramic views of Puget Sound' },
+  { name: 'Dosewallips State Park',           lat: 47.6868, lng: -122.9017, sites: 140, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'At the confluence of the Dosewallips River and Hood Canal' },
+  { name: 'Potlatch State Park',              lat: 47.5571, lng: -123.1581, sites: 35,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'On Hood Canal; excellent oyster and shellfish harvesting' },
+  { name: 'Kitsap Memorial State Park',       lat: 47.8374, lng: -122.6391, sites: 43,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Wooded park on Hood Canal near Poulsbo' },
+  { name: 'Sequim Bay State Park',            lat: 48.0457, lng: -123.0419, sites: 86,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Protected bay in the Olympic rain shadow; calm waters for boating' },
+  { name: 'Bogachiel State Park',             lat: 47.8982, lng: -124.2786, sites: 42,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Along the Bogachiel River near Forks; gateway to Olympic backcountry' },
+  { name: 'Cape Disappointment State Park',   lat: 46.2874, lng: -124.0557, sites: 250, types: ['tent','rv','cabin'],   reservable: true,  year_round: true,  open_month: null, url: 'https://washington.goingtocamp.com/', notes: 'Where the Columbia River meets the Pacific; two historic lighthouses' },
+  { name: 'Bruceport County Park',            lat: 46.6157, lng: -123.8234, sites: 30,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 5,    url: 'https://washington.goingtocamp.com/', notes: 'On Willapa Bay near South Bend' },
+  { name: 'Grayland Beach State Park',        lat: 46.7716, lng: -124.0871, sites: 100, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Ocean beach camping near cranberry bogs' },
+  { name: 'Pacific Beach State Park',         lat: 47.2107, lng: -124.2001, sites: 138, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Right on the Pacific Ocean; popular for razor clam season' },
+  { name: 'Ocean City State Park',            lat: 47.0388, lng: -124.1655, sites: 178, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'On the Long Beach Peninsula; vast sandy beach access' },
+  { name: 'Beacon Rock State Park',           lat: 45.6254, lng: -121.9997, sites: 35,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Below the famous basalt monolith in the Columbia River Gorge' },
+  { name: 'Seaquest State Park',              lat: 46.2916, lng: -122.8268, sites: 92,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Adjacent to Mount St. Helens National Volcanic Monument; views of the volcano' },
+  { name: 'Paradise Point State Park',        lat: 45.8613, lng: -122.7108, sites: 70,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Along the East Fork Lewis River near Ridgefield' },
+  { name: 'Battle Ground Lake State Park',    lat: 45.7957, lng: -122.4875, sites: 50,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Volcanic lake in Clark County; swimming and fishing' },
+  { name: 'Sun Lakes-Dry Falls State Park',   lat: 47.5968, lng: -119.4644, sites: 193, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Near the world\'s largest prehistoric waterfall; coulees and lakes' },
+  { name: 'Steamboat Rock State Park',        lat: 47.8596, lng: -119.0871, sites: 213, types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'On Banks Lake in the Grand Coulee area; massive basalt butte' },
+  { name: 'Riverside State Park',             lat: 47.7046, lng: -117.4793, sites: 16,  types: ['tent','rv'],           reservable: true,  year_round: true,  open_month: null, url: 'https://washington.goingtocamp.com/', notes: 'Along the Spokane River near Spokane; Bowl and Pitcher area' },
+  { name: 'Osoyoos Lake State Park',          lat: 48.9493, lng: -119.4436, sites: 86,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Warmest lake in WA on the Canadian border; excellent swimming' },
+  { name: 'Curlew Lake State Park',           lat: 48.7096, lng: -118.6668, sites: 82,  types: ['tent','rv'],           reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Scenic lake in Ferry County near Republic' },
+  { name: 'Palouse Falls State Park',         lat: 46.6638, lng: -118.2274, sites: 10,  types: ['tent'],                reservable: true,  year_round: false, open_month: 4,    url: 'https://washington.goingtocamp.com/', notes: 'Washington State waterfall; 198-ft drop into the Palouse River canyon' },
+];
+
+for (const c of waParks) {
+  const filePath = path.join(BASE_DIR, 'wa-state-parks', 'WA', sanitizeDir(c.name), 'index.md');
+  const content = buildFrontmatter({
+    name: c.name,
+    agency: 'Washington State Parks',
+    agency_short: 'wa-state-parks',
+    lat: c.lat,
+    lng: c.lng,
+    sites: c.sites,
+    types: c.types,
+    reservable: c.reservable,
+    year_round: c.year_round,
+    open_month: c.open_month,
+    reservation_url: c.url,
+    notes: c.notes,
+  });
+  writeFile(filePath, content);
+  console.log(`  created: ${filePath}`);
+  count++;
+}
+
+console.log(`\nDone. ${count} files created.`);

--- a/scripts/sync-geojson.js
+++ b/scripts/sync-geojson.js
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * sync-geojson.js
+ *
+ * Reads all campsite index.md files under data/{agency}/WA/
+ * and regenerates data/campsites.json.
+ *
+ * Usage: node scripts/sync-geojson.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const DATA_DIR = path.join(__dirname, '..', 'data');
+const OUTPUT = path.join(DATA_DIR, 'campsites.json');
+
+const AGENCIES = ['blm', 'nps', 'usfs', 'wa-state-parks'];
+
+const MONTH_MAP = {
+  january: 1, february: 2, march: 3, april: 4, may: 5, june: 6,
+  july: 7, august: 8, september: 9, october: 10, november: 11, december: 12,
+};
+
+// Parse "May 1" or "July 15" → month integer, or null
+function parseOpenDate(val) {
+  if (!val || val === 'null') return null;
+  const month = val.trim().split(/\s+/)[0].toLowerCase();
+  return MONTH_MAP[month] ?? null;
+}
+
+// Minimal YAML frontmatter parser for the known campsite schema
+function parseFrontmatter(raw) {
+  const match = raw.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) throw new Error('No frontmatter found');
+  const block = match[1];
+  const body = raw.slice(match[0].length).trim();
+
+  const result = {};
+  for (const line of block.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    const key = line.slice(0, colon).trim();
+    let val = line.slice(colon + 1).trim();
+
+    // Strip inline comments
+    val = val.replace(/\s+#.*$/, '');
+
+    // Types array: [tent, rv] or [tent,rv]
+    if (val.startsWith('[') && val.endsWith(']')) {
+      result[key] = val.slice(1, -1).split(',').map(v => v.trim()).filter(Boolean);
+      continue;
+    }
+
+    // Quoted string
+    if ((val.startsWith('"') && val.endsWith('"')) ||
+        (val.startsWith("'") && val.endsWith("'"))) {
+      result[key] = val.slice(1, -1);
+      continue;
+    }
+
+    // Booleans / null / numbers
+    if (val === 'true') { result[key] = true; continue; }
+    if (val === 'false') { result[key] = false; continue; }
+    if (val === 'null') { result[key] = null; continue; }
+    const num = Number(val);
+    if (!isNaN(num) && val !== '') { result[key] = num; continue; }
+
+    result[key] = val;
+  }
+
+  result._body = body;
+  return result;
+}
+
+function findIndexFiles(dir, results = []) {
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      findIndexFiles(full, results);
+    } else if (entry.name === 'index.md') {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function validate(fm, open_month, filePath) {
+  const errors = [];
+  const requiredFm = ['name', 'agency', 'agency_short', 'lat', 'lng', 'sites', 'types', 'reservable', 'year_round'];
+  for (const f of requiredFm) {
+    if (fm[f] == null) errors.push(`missing required field: ${f}`);
+  }
+  if (fm.lat != null && (fm.lat < 45.5 || fm.lat > 49.1)) errors.push(`lat out of WA range: ${fm.lat}`);
+  if (fm.lng != null && (fm.lng < -124.9 || fm.lng > -116.9)) errors.push(`lng out of WA range: ${fm.lng}`);
+  if (fm.year_round && open_month != null) errors.push('year_round:true but open_month is set');
+  const validTypes = new Set(['tent', 'rv', 'walk-in', 'cabin', 'bike-in', 'parking']);
+  for (const t of (fm.types || [])) {
+    if (!validTypes.has(t)) errors.push(`unknown type: ${t}`);
+  }
+  if (errors.length) {
+    console.error(`\nValidation errors in ${filePath}:`);
+    errors.forEach(e => console.error(`  - ${e}`));
+  }
+  return errors.length === 0;
+}
+
+function buildFeature(fm, filePath) {
+  const open_month = parseOpenDate(fm.open_date);
+  const props = {
+    name: fm.name,
+    agency: fm.agency,
+    agency_short: fm.agency_short,
+    sites: fm.sites,
+    types: fm.types,
+    reservable: fm.reservable,
+    year_round: fm.year_round,
+    open_month,
+    reservation_url: fm.reservation_url,
+    notes: fm._body || null,
+  };
+  validate(fm, open_month, filePath);
+  return {
+    type: 'Feature',
+    geometry: { type: 'Point', coordinates: [fm.lng, fm.lat] },
+    properties: props,
+  };
+}
+
+// --- Main ---
+let valid = 0;
+let errors = 0;
+const features = [];
+
+for (const agency of AGENCIES) {
+  const agencyDir = path.join(DATA_DIR, agency, 'WA');
+  const files = findIndexFiles(agencyDir);
+  for (const filePath of files) {
+    try {
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const fm = parseFrontmatter(raw);
+      features.push(buildFeature(fm, filePath));
+      valid++;
+    } catch (err) {
+      console.error(`Error processing ${filePath}: ${err.message}`);
+      errors++;
+    }
+  }
+}
+
+// Sort: agency_short, then name
+features.sort((a, b) => {
+  const as = a.properties.agency_short;
+  const bs = b.properties.agency_short;
+  if (as !== bs) return as.localeCompare(bs);
+  return a.properties.name.localeCompare(b.properties.name);
+});
+
+const geojson = { type: 'FeatureCollection', features };
+fs.writeFileSync(OUTPUT, JSON.stringify(geojson, null, 2));
+
+console.log(`\n✓ ${valid} campsites written to data/campsites.json`);
+if (errors) console.error(`✗ ${errors} files had errors`);


### PR DESCRIPTION
- 75 campsite index.md files under data/{agency}/WA/{park?}/{name}/ covering BLM (5), NPS (24), USFS (21), WA State Parks (25)
- Each file has consistent YAML frontmatter: coords, sites, types, open_date ("Month 1" format), first_reservation_date, reservation_url, official_url (placeholder), and a plain-text notes body
- scripts/sync-geojson.js regenerates data/campsites.json from the markdown files with validation (bounds, types, open/year_round logic)
- data/CLAUDE.md documents the schema, valid field values, directory conventions, and the add/update/sync workflow
- Regenerated data/campsites.json from the new source files