### PR TITLE
data: replace Node.js sync script with Python Jupyter notebook

### DIFF
--- a/data/CLAUDE.md
+++ b/data/CLAUDE.md
@@ -7,9 +7,11 @@ This file instructs Claude Code on how to work with campsite data in this projec
 Individual campsite files (`data/{agency}/WA/{name}/index.md` or `data/{agency}/WA/{park}/{name}/index.md`) are the **source of truth**. The GeoJSON (`data/campsites.json`) is a **derived artifact** — regenerate it from the markdown files, never edit it directly.
 
 To sync after any edits:
+```bash
+uv run --project data jupyter nbconvert --to notebook --inplace --execute data/sync_campsites.ipynb
 ```
-node scripts/sync-geojson.js
-```
+
+The notebook validates first and halts before writing if any errors are found. Outputs are written back into the notebook so you can inspect results inline.
 
 ---
 
@@ -92,7 +94,7 @@ Link directly to the campground page on the agency website, not the homepage. Ex
 ## Updating existing data
 
 1. Edit the relevant `index.md` field(s)
-2. Run `node scripts/sync-geojson.js`
+2. Run the sync notebook (see above)
 3. Commit both the `index.md` change and the updated `data/campsites.json`
 
 ## Validation checklist

--- a/data/pyproject.toml
+++ b/data/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "campsite-sync"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "jupyter",
+    "nbconvert",
+]
+
+[tool.uv]
+dev-dependencies = []

--- a/data/sync_campsites.ipynb
+++ b/data/sync_campsites.ipynb
@@ -1,0 +1,366 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "705de802",
+   "metadata": {},
+   "source": [
+    "# Campsite Data Sync\n",
+    "\n",
+    "Validates all `data/{agency}/WA/**/index.md` files, then rebuilds `data/campsites.json` as a full replacement.\n",
+    "\n",
+    "**Run from project root:**\n",
+    "```bash\n",
+    "uv run --project data jupyter nbconvert --to notebook --inplace --execute data/sync_campsites.ipynb\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a5b12245",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.409264Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.408941Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.415072Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.413998Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "import re\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "46b77f5f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.418283Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.417988Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.425459Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.424498Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Base directory: /Users/tommydoerr/dev/robot-geographical-society/data\n",
+      "Output: /Users/tommydoerr/dev/robot-geographical-society/data/campsites.json\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Works whether invoked from project root or from data/\n",
+    "BASE = Path(\"data\") if (Path(\"data\") / \"campsites.json\").exists() else Path(\".\")\n",
+    "OUTPUT = BASE / \"campsites.json\"\n",
+    "\n",
+    "AGENCIES = [\"blm\", \"nps\", \"usfs\", \"wa-state-parks\"]\n",
+    "\n",
+    "VALID_TYPES = {\"tent\", \"rv\", \"walk-in\", \"cabin\", \"bike-in\", \"parking\"}\n",
+    "\n",
+    "MONTH_MAP = {\n",
+    "    \"january\": 1, \"february\": 2, \"march\": 3, \"april\": 4,\n",
+    "    \"may\": 5, \"june\": 6, \"july\": 7, \"august\": 8,\n",
+    "    \"september\": 9, \"october\": 10, \"november\": 11, \"december\": 12,\n",
+    "}\n",
+    "\n",
+    "WA_LAT = (45.5, 49.1)\n",
+    "WA_LNG = (-124.9, -116.9)\n",
+    "\n",
+    "print(f\"Base directory: {BASE.resolve()}\")\n",
+    "print(f\"Output: {OUTPUT.resolve()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "978d3f80",
+   "metadata": {},
+   "source": [
+    "## Step 1 \u2014 Parse & Validate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "c24760e7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.428121Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.427900Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.434715Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.433978Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def parse_frontmatter(text: str) -> dict:\n",
+    "    \"\"\"Parse YAML frontmatter + plain-text body from an index.md.\"\"\"\n",
+    "    match = re.match(r\"^---\\n(.*?)\\n---\\n?(.*)\", text, re.DOTALL)\n",
+    "    if not match:\n",
+    "        raise ValueError(\"No frontmatter block found\")\n",
+    "    block, body = match.group(1), match.group(2).strip()\n",
+    "\n",
+    "    result: dict = {}\n",
+    "    for line in block.splitlines():\n",
+    "        if \":\" not in line:\n",
+    "            continue\n",
+    "        key, _, val = line.partition(\":\")\n",
+    "        key = key.strip()\n",
+    "        val = val.strip().split(\"#\")[0].strip()  # strip inline comments\n",
+    "\n",
+    "        if val.startswith(\"[\") and val.endswith(\"]\"):\n",
+    "            result[key] = [v.strip() for v in val[1:-1].split(\",\") if v.strip()]\n",
+    "        elif (val.startswith('\"') and val.endswith('\"')) or \\\n",
+    "             (val.startswith(\"'\") and val.endswith(\"'\")):\n",
+    "            result[key] = val[1:-1]\n",
+    "        elif val == \"true\":\n",
+    "            result[key] = True\n",
+    "        elif val == \"false\":\n",
+    "            result[key] = False\n",
+    "        elif val == \"null\":\n",
+    "            result[key] = None\n",
+    "        else:\n",
+    "            try:\n",
+    "                result[key] = float(val) if \".\" in val else int(val)\n",
+    "            except ValueError:\n",
+    "                result[key] = val\n",
+    "\n",
+    "    result[\"_notes\"] = body or None\n",
+    "    return result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "35c8d781",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.436646Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.436479Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.442329Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.441699Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "def validate(fm: dict, path: Path) -> list[str]:\n",
+    "    \"\"\"Return a list of validation error strings (empty = valid).\"\"\"\n",
+    "    errors = []\n",
+    "\n",
+    "    for field in [\"name\", \"agency\", \"agency_short\", \"lat\", \"lng\",\n",
+    "                  \"sites\", \"types\", \"reservable\", \"year_round\"]:\n",
+    "        if fm.get(field) is None:\n",
+    "            errors.append(f\"missing required field: {field}\")\n",
+    "\n",
+    "    lat, lng = fm.get(\"lat\"), fm.get(\"lng\")\n",
+    "    if lat is not None and not (WA_LAT[0] <= lat <= WA_LAT[1]):\n",
+    "        errors.append(f\"lat {lat} outside WA range {WA_LAT}\")\n",
+    "    if lng is not None and not (WA_LNG[0] <= lng <= WA_LNG[1]):\n",
+    "        errors.append(f\"lng {lng} outside WA range {WA_LNG}\")\n",
+    "\n",
+    "    open_date = fm.get(\"open_date\")\n",
+    "    if fm.get(\"year_round\") and open_date is not None:\n",
+    "        errors.append(\"year_round: true but open_date is set\")\n",
+    "    if not fm.get(\"year_round\") and open_date is not None:\n",
+    "        month_name = str(open_date).split()[0].lower()\n",
+    "        if month_name not in MONTH_MAP:\n",
+    "            errors.append(f\"open_date month '{month_name}' not recognised\")\n",
+    "\n",
+    "    for t in fm.get(\"types\") or []:\n",
+    "        if t not in VALID_TYPES:\n",
+    "            errors.append(f\"unknown type '{t}' \u2014 valid: {sorted(VALID_TYPES)}\")\n",
+    "\n",
+    "    return errors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "302901dd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.444406Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.444242Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.461402Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.460801Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Found 75 campsite files\n",
+      "\n",
+      "\u2713 All 75 files passed validation\n"
+     ]
+    }
+   ],
+   "source": [
+    "all_files = []\n",
+    "for agency in AGENCIES:\n",
+    "    agency_dir = BASE / agency / \"WA\"\n",
+    "    if agency_dir.is_dir():\n",
+    "        all_files.extend(sorted(agency_dir.rglob(\"index.md\")))\n",
+    "\n",
+    "print(f\"Found {len(all_files)} campsite files\\n\")\n",
+    "\n",
+    "validation_errors: dict[str, list[str]] = {}\n",
+    "parsed: dict[Path, dict] = {}\n",
+    "\n",
+    "for path in all_files:\n",
+    "    try:\n",
+    "        fm = parse_frontmatter(path.read_text())\n",
+    "        errs = validate(fm, path)\n",
+    "        if errs:\n",
+    "            validation_errors[str(path)] = errs\n",
+    "        else:\n",
+    "            parsed[path] = fm\n",
+    "    except Exception as exc:\n",
+    "        validation_errors[str(path)] = [f\"parse error: {exc}\"]\n",
+    "\n",
+    "if validation_errors:\n",
+    "    print(f\"\u2717 {len(validation_errors)} file(s) with errors:\\n\")\n",
+    "    for p, errs in validation_errors.items():\n",
+    "        rel = Path(p).relative_to(Path.cwd()) if Path(p).is_absolute() else Path(p)\n",
+    "        print(f\"  {rel}\")\n",
+    "        for e in errs:\n",
+    "            print(f\"    \u00b7 {e}\")\n",
+    "else:\n",
+    "    print(f\"\u2713 All {len(all_files)} files passed validation\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "4529020b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.462861Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.462732Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.465107Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.464575Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Halt notebook execution if any file failed validation.\n",
+    "# Fix the errors above, then re-run.\n",
+    "if validation_errors:\n",
+    "    raise RuntimeError(\n",
+    "        f\"{len(validation_errors)} validation error(s) \u2014 fix before syncing. \"\n",
+    "        \"See output above for details.\"\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4846259c",
+   "metadata": {},
+   "source": [
+    "## Step 2 \u2014 Build & Write GeoJSON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "08ace7b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-02-20T03:50:07.466406Z",
+     "iopub.status.busy": "2026-02-20T03:50:07.466294Z",
+     "iopub.status.idle": "2026-02-20T03:50:07.471717Z",
+     "shell.execute_reply": "2026-02-20T03:50:07.471163Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u2713 75 campsites written to campsites.json\n",
+      "\n",
+      "  blm                  5\n",
+      "  nps                  24\n",
+      "  usfs                 21\n",
+      "  wa-state-parks       25\n"
+     ]
+    }
+   ],
+   "source": [
+    "def open_date_to_month(val) -> int | None:\n",
+    "    if not val:\n",
+    "        return None\n",
+    "    return MONTH_MAP.get(str(val).strip().split()[0].lower())\n",
+    "\n",
+    "\n",
+    "def build_feature(fm: dict) -> dict:\n",
+    "    return {\n",
+    "        \"type\": \"Feature\",\n",
+    "        \"geometry\": {\n",
+    "            \"type\": \"Point\",\n",
+    "            \"coordinates\": [fm[\"lng\"], fm[\"lat\"]],\n",
+    "        },\n",
+    "        \"properties\": {\n",
+    "            \"name\":            fm[\"name\"],\n",
+    "            \"agency\":          fm[\"agency\"],\n",
+    "            \"agency_short\":    fm[\"agency_short\"],\n",
+    "            \"sites\":           fm[\"sites\"],\n",
+    "            \"types\":           fm[\"types\"],\n",
+    "            \"reservable\":      fm[\"reservable\"],\n",
+    "            \"year_round\":      fm[\"year_round\"],\n",
+    "            \"open_month\":      open_date_to_month(fm.get(\"open_date\")),\n",
+    "            \"reservation_url\": fm.get(\"reservation_url\"),\n",
+    "            \"notes\":           fm.get(\"_notes\"),\n",
+    "        },\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "features = sorted(\n",
+    "    [build_feature(fm) for fm in parsed.values()],\n",
+    "    key=lambda f: (f[\"properties\"][\"agency_short\"], f[\"properties\"][\"name\"]),\n",
+    ")\n",
+    "\n",
+    "geojson = {\"type\": \"FeatureCollection\", \"features\": features}\n",
+    "OUTPUT.write_text(json.dumps(geojson, indent=2) + \"\\n\")\n",
+    "\n",
+    "by_agency = {}\n",
+    "for f in features:\n",
+    "    a = f[\"properties\"][\"agency_short\"]\n",
+    "    by_agency[a] = by_agency.get(a, 0) + 1\n",
+    "\n",
+    "print(f\"\u2713 {len(features)} campsites written to {OUTPUT}\\n\")\n",
+    "for agency, count in sorted(by_agency.items()):\n",
+    "    print(f\"  {agency:20s} {count}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- data/sync_campsites.ipynb — validates all index.md files (bounds, required fields, types, open_date/year_round consistency), halts before writing on any error, then rebuilds campsites.json in full
- data/pyproject.toml — uv project spec (jupyter, nbconvert)
- Updated data/CLAUDE.md to document the new sync command

Run from project root:
  uv run --project data jupyter nbconvert --to notebook --inplace --execute data/sync_campsites.ipynb