### PR TITLE
feat(data): Add recreation.gov campground crawler

### DIFF
--- a/data/campsites.toml
+++ b/data/campsites.toml
@@ -15,6 +15,10 @@ name = "Beckler River"
 path = "campsites/usfs/WA/Mt_Baker_Snoqualmie_NF/Beckler_River.md"
 
 [[campsites]]
+name = "Bedal Campground"
+path = "campsites/usfs/WA/Mt_Baker_Snoqualmie_NF/Bedal_Campground.md"
+
+[[campsites]]
 name = "Blue Lake Creek"
 path = "campsites/usfs/WA/Gifford_Pinchot_NF/Blue_Lake_Creek.md"
 
@@ -301,4 +305,3 @@ path = "campsites/usfs/WA/Olympic_NF/Wynoochee_Lake.md"
 [[campsites]]
 name = "Yakima River Canyon"
 path = "campsites/blm/WA/Yakima_River_Canyon.md"
-

--- a/data/campsites/usfs/WA/Mt_Baker_Snoqualmie_NF/Bedal_Campground.md
+++ b/data/campsites/usfs/WA/Mt_Baker_Snoqualmie_NF/Bedal_Campground.md
@@ -1,0 +1,24 @@
+---
+name: Bedal Campground
+agency: US Forest Service
+agency_short: usfs
+state: WA
+lat: 48.0968
+lng: -121.3869
+sites: 23
+types:
+- tent
+- rv
+reservable: true
+rec_gov_id: '233864'
+reservation_url: https://www.recreation.gov/camping/campgrounds/233864
+official_url: https://www.recreation.gov/camping/campgrounds/233864
+availability_windows:
+- start: 05-01
+  end: 09-30
+  booking_advance_days: 180
+  site_total_count: 23
+  reserved_count: 0
+---
+
+Recreation.gov campground in Mt. Baker-Snoqualmie National Forest.

--- a/data/pyproject.toml
+++ b/data/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 [project.scripts]
 update = "scripts.update_campsites:main"
 generate = "scripts.generate_geojson:main"
+crawl = "scripts.crawl_rec_gov:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["campsite_sync", "scripts"]
@@ -25,4 +26,9 @@ dev = [
     "playwright>=1.40",
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
+]
+
+[tool.pytest.ini_options]
+markers = [
+    "slow: marks tests that make real network requests (deselect with -m 'not slow')",
 ]

--- a/data/scripts/crawl_rec_gov.py
+++ b/data/scripts/crawl_rec_gov.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+Crawl Recreation.gov for WA campgrounds not yet in this dataset,
+then prompt to add them in batch.
+
+Fetches campground listings from the recreation.gov search API, cross-references
+against all rec_gov_id values already in campsites.toml, and presents new
+candidates in an interactive numbered list. Selected entries get an index.md
+created and are appended to campsites.toml (kept alphabetical).
+
+Usage (from data/):
+    uv run crawl                   # search all WA campgrounds (up to 500)
+    uv run crawl --max 200         # limit search results
+    uv run crawl --url https://www.recreation.gov/camping/campgrounds/233864
+"""
+
+import argparse
+import re
+import sys
+import tomllib
+from pathlib import Path
+from urllib.parse import urlencode
+
+import yaml
+from playwright.sync_api import APIRequestContext, sync_playwright
+
+_BASE = "https://www.recreation.gov"
+_SEARCH_PATH = "/api/search"
+_CAMPGROUND_PATH = "/api/camps/campgrounds/{id}"
+_CAMPSITES_PATH = "/api/camps/campgrounds/{id}/campsites"
+
+WA_LAT = (45.0, 49.5)
+WA_LNG = (-125.0, -116.0)
+
+
+# ---------------------------------------------------------------------------
+# Playwright helpers
+# ---------------------------------------------------------------------------
+
+def _new_context(playwright) -> APIRequestContext:
+    return playwright.request.new_context(
+        base_url=_BASE,
+        extra_http_headers={"Accept": "application/json, text/plain, */*"},
+    )
+
+
+def _search_wa_campgrounds(ctx: APIRequestContext, max_results: int) -> list[dict]:
+    """
+    Page through recreation.gov search results for WA campgrounds.
+    Returns a flat list of result dicts (may be truncated to max_results).
+    """
+    results: list[dict] = []
+    page_size = min(100, max_results)
+    start = 0
+
+    while len(results) < max_results:
+        # Build URL manually so multiple `fq` params are encoded correctly
+        qs = urlencode(
+            [
+                ("q", ""),
+                ("fq", "state_code:WA"),
+                ("fq", "entity_type:campground"),
+                ("size", page_size),
+                ("start", start),
+            ]
+        )
+        resp = ctx.get(f"{_SEARCH_PATH}?{qs}")
+        if not resp.ok:
+            print(f"  Warning: search returned HTTP {resp.status}", file=sys.stderr)
+            break
+        data = resp.json()
+        batch = data.get("results", [])
+        if not batch:
+            break
+        results.extend(batch)
+        start += len(batch)
+        total = data.get("total", 0)
+        if start >= total:
+            break
+
+    return results[:max_results]
+
+
+def _search_by_id(ctx: APIRequestContext, cid: str) -> dict | None:
+    """
+    Look up a single campground by ID via the search API.
+    Returns the search result dict (with parent_name, lat, lng) or None.
+    """
+    qs = urlencode([("q", cid), ("fq", "entity_type:campground"), ("size", 5)])
+    resp = ctx.get(f"{_SEARCH_PATH}?{qs}")
+    if not resp.ok:
+        return None
+    for r in resp.json().get("results", []):
+        if str(r.get("entity_id")) == cid:
+            return r
+    return None
+
+
+def _fetch_campground_detail(ctx: APIRequestContext, cid: str) -> dict:
+    """Fetch full campground record from the campground detail API (fallback)."""
+    resp = ctx.get(
+        _CAMPGROUND_PATH.format(id=cid),
+        headers={"Referer": f"{_BASE}/camping/campgrounds/{cid}"},
+    )
+    if not resp.ok:
+        return {}
+    return resp.json().get("campground", {})
+
+
+def _fetch_site_count(ctx: APIRequestContext, cid: str) -> int:
+    """Return the total number of bookable campsites for a campground."""
+    try:
+        resp = ctx.get(
+            _CAMPSITES_PATH.format(id=cid),
+            headers={"Referer": f"{_BASE}/camping/campgrounds/{cid}"},
+        )
+        if resp.ok:
+            campsites = resp.json().get("campsites", [])
+            return len(campsites) if isinstance(campsites, list) else 0
+    except Exception:
+        pass
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Dataset helpers
+# ---------------------------------------------------------------------------
+
+def _load_existing_ids(toml_path: Path) -> set[str]:
+    """Return the set of rec_gov_id strings already tracked in campsites.toml."""
+    with open(toml_path, "rb") as f:
+        config = tomllib.load(f)
+
+    ids: set[str] = set()
+    for entry in config.get("campsites", []):
+        path = Path(entry.get("path", ""))
+        if not path.exists():
+            continue
+        text = path.read_text()
+        m = re.match(r"^---\n(.*?)\n---", text, re.DOTALL)
+        if not m:
+            continue
+        try:
+            fm = yaml.safe_load(m.group(1)) or {}
+        except yaml.YAMLError:
+            continue
+        rid = fm.get("rec_gov_id")
+        if rid:
+            ids.add(str(rid))
+    return ids
+
+
+def _load_toml_entries(toml_path: Path) -> list[dict]:
+    """Load campsites.toml and return the list of {name, path} dicts."""
+    with open(toml_path, "rb") as f:
+        config = tomllib.load(f)
+    return list(config.get("campsites", []))
+
+
+def _write_toml(toml_path: Path, entries: list[dict]) -> None:
+    """Write campsites.toml from a list of {name, path} dicts, sorted by name."""
+    lines: list[str] = []
+    for e in sorted(entries, key=lambda x: x["name"]):
+        lines.append("[[campsites]]")
+        lines.append(f'name = "{e["name"]}"')
+        lines.append(f'path = "{e["path"]}"')
+        lines.append("")
+    toml_path.write_text("\n".join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Agency / path inference
+# ---------------------------------------------------------------------------
+
+def _detect_agency(parent_name: str) -> tuple[str, str]:
+    """Return (agency_short, agency_full) from a parent organisation name."""
+    lower = parent_name.lower()
+    if "national forest" in lower:
+        return "usfs", "US Forest Service"
+    if "national recreation area" in lower or "national park" in lower:
+        return "nps", "National Park Service"
+    if "bureau of land management" in lower or " blm" in lower:
+        return "blm", "Bureau of Land Management"
+    if "state park" in lower:
+        return "wa-state-parks", "Washington State Parks"
+    # Fallback — user will need to review
+    return "usfs", "US Forest Service"
+
+
+def _detect_subdir(agency_short: str, parent_name: str) -> str | None:
+    """Return the forest/park subdirectory name, or None if unrecognised."""
+    lower = parent_name.lower()
+    if agency_short == "usfs":
+        if "okanogan" in lower or "wenatchee" in lower:
+            return "Okanogan_Wenatchee_NF"
+        if "baker" in lower or "snoqualmie" in lower:
+            return "Mt_Baker_Snoqualmie_NF"
+        if "olympic" in lower:
+            return "Olympic_NF"
+        if "gifford" in lower or "pinchot" in lower:
+            return "Gifford_Pinchot_NF"
+        if "colville" in lower:
+            return "Colville_NF"
+        if "umatilla" in lower:
+            return "Umatilla_NF"
+        return None
+    if agency_short == "nps":
+        if "rainier" in lower:
+            return "Mt_Rainier_NP"
+        if "olympic" in lower:
+            return "Olympic_NP"
+        if "north cascades" in lower:
+            return "North_Cascades_NP"
+        if "lake roosevelt" in lower or "roosevelt" in lower:
+            return "Lake_Roosevelt_NRA"
+        return None
+    return None
+
+
+def _slugify(name: str) -> str:
+    """Convert a campsite name to a filesystem-safe slug."""
+    slug = re.sub(r"[^\w\s'\-]", "", name)
+    slug = re.sub(r"[\s\-]+", "_", slug.strip())
+    return slug
+
+
+# ---------------------------------------------------------------------------
+# index.md generation
+# ---------------------------------------------------------------------------
+
+def _build_index_md(candidate: dict, site_count: int, agency_short: str, agency_full: str) -> str:
+    """Return the full text of a new index.md for a candidate campsite."""
+    rec_id = candidate["id"]
+    lat = round(float(candidate.get("lat") or 0.0), 4)
+    lng = round(float(candidate.get("lng") or 0.0), 4)
+    url = f"https://www.recreation.gov/camping/campgrounds/{rec_id}"
+
+    fm = {
+        "name": candidate["name"],
+        "agency": agency_full,
+        "agency_short": agency_short,
+        "state": "WA",
+        "lat": lat,
+        "lng": lng,
+        "sites": site_count,
+        "types": ["tent", "rv"],  # default — review after adding
+        "reservable": True,
+        "rec_gov_id": rec_id,
+        "reservation_url": url,
+        "official_url": url,
+        "availability_windows": [
+            {
+                "start": "05-01",
+                "end": "09-30",
+                "booking_advance_days": 180,
+                "site_total_count": site_count,
+                "reserved_count": 0,
+            }
+        ],
+    }
+
+    parent = candidate.get("parent_name") or "Washington State"
+    body = f"Recreation.gov campground in {parent}."
+    fm_text = yaml.dump(fm, sort_keys=False, allow_unicode=True, width=1000).strip()
+    return f"---\n{fm_text}\n---\n\n{body}\n"
+
+
+# ---------------------------------------------------------------------------
+# Candidate normalisation
+# ---------------------------------------------------------------------------
+
+def _from_search_result(r: dict) -> dict:
+    """Build a normalised candidate dict from a search API result."""
+    return {
+        "id": str(r.get("entity_id", "")),
+        "name": r.get("name") or "",
+        "parent_name": r.get("parent_name") or "",
+        "lat": r.get("latitude"),
+        "lng": r.get("longitude"),
+        "reservable": r.get("reservable", True),
+        "site_count": 0,
+    }
+
+
+def _from_detail(cid: str, cg: dict) -> dict:
+    """Build a normalised candidate dict from a campground detail record (fallback)."""
+    # API uses snake_case; derive a rough parent from org_code + alternate_names
+    org_code = cg.get("org_code", "")
+    alt_names = cg.get("alternate_names", "") or ""
+    # alternate_names pattern: "ABBR,ABBR,FOREST NAME NF - FS" — take last segment
+    parts = [p.strip() for p in alt_names.split(",") if len(p.strip()) > 6]
+    parent = parts[-1] if parts else org_code
+    return {
+        "id": cid,
+        "name": cg.get("facility_name") or cid,
+        "parent_name": parent,
+        "lat": cg.get("facility_latitude"),
+        "lng": cg.get("facility_longitude"),
+        "reservable": True,
+        "site_count": 0,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Find Recreation.gov WA campgrounds not yet in the dataset."
+    )
+    parser.add_argument(
+        "--max", type=int, default=500, metavar="N",
+        help="Max search results to fetch (default: 500)",
+    )
+    parser.add_argument(
+        "--url", metavar="URL",
+        help="Check a specific Recreation.gov campground URL",
+    )
+    args = parser.parse_args()
+
+    toml_path = Path("campsites.toml")
+    if not toml_path.exists():
+        print("Error: campsites.toml not found — run from data/", file=sys.stderr)
+        sys.exit(1)
+
+    print("Loading existing campsite IDs...")
+    existing_ids = _load_existing_ids(toml_path)
+    print(f"  {len(existing_ids)} recreation.gov IDs already in dataset\n")
+
+    candidates: list[dict] = []
+
+    print("Connecting to recreation.gov...")
+    with sync_playwright() as p:
+        ctx = _new_context(p)
+        try:
+            if args.url:
+                # --- Single URL mode ---
+                m = re.search(r"/campgrounds/(\d+)", args.url)
+                if not m:
+                    print(f"Could not parse campground ID from: {args.url}", file=sys.stderr)
+                    sys.exit(1)
+                cid = m.group(1)
+                print(f"Checking campground {cid}...")
+                if cid in existing_ids:
+                    print(f"  Already in dataset (rec_gov_id: {cid})")
+                    sys.exit(0)
+                # Try search API first (has parent_name, lat, lng already formatted)
+                search_result = _search_by_id(ctx, cid)
+                if search_result:
+                    c = _from_search_result(search_result)
+                else:
+                    # Fallback to detail API
+                    cg = _fetch_campground_detail(ctx, cid)
+                    if not cg:
+                        print(f"  No data returned for ID {cid}", file=sys.stderr)
+                        sys.exit(1)
+                    c = _from_detail(cid, cg)
+                c["site_count"] = _fetch_site_count(ctx, cid)
+                candidates = [c]
+
+            else:
+                # --- Full search mode ---
+                print(f"Searching for WA campgrounds (max {args.max})...")
+                results = _search_wa_campgrounds(ctx, max_results=args.max)
+                already = sum(1 for r in results if str(r.get("entity_id", "")) in existing_ids)
+                new_results = [r for r in results if str(r.get("entity_id", "")) not in existing_ids]
+                print(f"  {len(results)} total  |  {already} already in dataset  |  {len(new_results)} new\n")
+                candidates = [_from_search_result(r) for r in new_results]
+
+                if candidates:
+                    print(f"Fetching site counts for {len(candidates)} candidate(s)...")
+                    for i, c in enumerate(candidates, 1):
+                        try:
+                            c["site_count"] = _fetch_site_count(ctx, c["id"])
+                        except Exception:
+                            c["site_count"] = 0
+                        if i % 10 == 0:
+                            print(f"  {i}/{len(candidates)}...", end="\r", flush=True)
+                    print()
+
+        finally:
+            ctx.dispose()
+
+    if not candidates:
+        print("No new campgrounds found.")
+        return
+
+    # Filter to WA bounds and warn on anything outside
+    in_bounds = []
+    for c in candidates:
+        lat, lng = c.get("lat"), c.get("lng")
+        if lat is None or lng is None:
+            in_bounds.append(c)  # keep — coordinates unknown
+            continue
+        try:
+            lat, lng = float(lat), float(lng)
+            c["lat"], c["lng"] = lat, lng
+        except (TypeError, ValueError):
+            in_bounds.append(c)
+            continue
+        if WA_LAT[0] <= lat <= WA_LAT[1] and WA_LNG[0] <= lng <= WA_LNG[1]:
+            in_bounds.append(c)
+        # silently skip out-of-state campgrounds (e.g. Oregon border facilities)
+    candidates = in_bounds
+
+    if not candidates:
+        print("No new WA campgrounds found after bounds filtering.")
+        return
+
+    # --- Display table ---
+    print(f"\n{'#':>4}  {'ID':>8}  {'Sites':>5}  {'Name':<38}  Parent")
+    print("-" * 95)
+    for i, c in enumerate(candidates, 1):
+        name = (c["name"] or "")[:37]
+        parent = (c["parent_name"] or "(unknown)")[:30]
+        print(f"{i:>4}  {c['id']:>8}  {c.get('site_count', 0):>5}  {name:<38}  {parent}")
+
+    print(f"\n{len(candidates)} new campground(s) found.\n")
+
+    # --- Selection prompt ---
+    while True:
+        raw = input("Add which? (e.g. '1,3,5' | 'a'=all | 'q'=quit): ").strip()
+        if raw.lower() == "q":
+            print("Cancelled — nothing added.")
+            return
+        if raw.lower() == "a":
+            selected = list(candidates)
+            break
+        try:
+            indices = [int(x.strip()) - 1 for x in raw.split(",") if x.strip()]
+            if any(i < 0 or i >= len(candidates) for i in indices):
+                print(f"  Out of range — enter 1–{len(candidates)}")
+                continue
+            selected = [candidates[i] for i in indices]
+            break
+        except ValueError:
+            print("  Enter numbers (e.g. '1,3'), 'a' for all, or 'q' to quit.")
+
+    if not selected:
+        print("Nothing selected.")
+        return
+
+    # --- Write files and update TOML ---
+    toml_entries = _load_toml_entries(toml_path)
+    existing_paths = {e["path"] for e in toml_entries}
+    added: list[str] = []
+
+    with sync_playwright() as p:
+        ctx = _new_context(p)
+        try:
+            for c in selected:
+                agency_short, agency_full = _detect_agency(c.get("parent_name", ""))
+                subdir = _detect_subdir(agency_short, c.get("parent_name", ""))
+                slug = _slugify(c["name"])
+
+                if subdir:
+                    rel_path = f"campsites/{agency_short}/WA/{subdir}/{slug}.md"
+                else:
+                    rel_path = f"campsites/{agency_short}/WA/{slug}.md"
+
+                if rel_path in existing_paths:
+                    print(f"  Skipping {c['name']} — path already in TOML: {rel_path}")
+                    continue
+
+                # Fetch site count if not already available
+                if not c.get("site_count"):
+                    try:
+                        c["site_count"] = _fetch_site_count(ctx, c["id"])
+                    except Exception:
+                        c["site_count"] = 0
+
+                file_path = Path(rel_path)
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                file_path.write_text(_build_index_md(c, c.get("site_count", 0), agency_short, agency_full))
+
+                toml_entries.append({"name": c["name"], "path": rel_path})
+                existing_paths.add(rel_path)
+                added.append(f"  + {c['name']:40s}  {rel_path}")
+        finally:
+            ctx.dispose()
+
+    if added:
+        _write_toml(toml_path, toml_entries)
+        print("\nAdded:")
+        for line in added:
+            print(line)
+        print(f"\n{len(added)} campsite(s) added.")
+        print("Next steps:")
+        print("  1. Review and edit the new index.md file(s) — check types, availability_windows, lat/lng")
+        print("  2. Run 'uv run generate' to rebuild campsites.json")
+    else:
+        print("Nothing was added.")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/tests/test_crawl_rec_gov.py
+++ b/data/tests/test_crawl_rec_gov.py
@@ -1,0 +1,368 @@
+"""
+Tests for scripts/crawl_rec_gov.py.
+
+Unit tests cover all pure functions (no network).
+Integration tests (marked slow) make real recreation.gov requests.
+
+Run unit tests only:
+    uv run pytest tests/test_crawl_rec_gov.py -v -m "not slow"
+
+Run all including network:
+    uv run pytest tests/test_crawl_rec_gov.py -v
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.crawl_rec_gov import (
+    _build_index_md,
+    _detect_agency,
+    _detect_subdir,
+    _from_detail,
+    _from_search_result,
+    _load_existing_ids,
+    _slugify,
+    _write_toml,
+)
+
+
+# ---------------------------------------------------------------------------
+# _detect_agency
+# ---------------------------------------------------------------------------
+
+class TestDetectAgency:
+    def test_national_forest(self):
+        short, full = _detect_agency("Mt. Baker-Snoqualmie National Forest")
+        assert short == "usfs"
+        assert full == "US Forest Service"
+
+    def test_national_park(self):
+        short, full = _detect_agency("Olympic National Park")
+        assert short == "nps"
+        assert full == "National Park Service"
+
+    def test_national_recreation_area(self):
+        short, full = _detect_agency("Lake Roosevelt National Recreation Area")
+        assert short == "nps"
+        assert full == "National Park Service"
+
+    def test_blm(self):
+        short, full = _detect_agency("Bureau of Land Management - Spokane District")
+        assert short == "blm"
+        assert full == "Bureau of Land Management"
+
+    def test_state_park(self):
+        short, full = _detect_agency("Washington State Parks")
+        assert short == "wa-state-parks"
+        assert full == "Washington State Parks"
+
+    def test_unknown_defaults_to_usfs(self):
+        short, full = _detect_agency("Some Unknown Org")
+        assert short == "usfs"
+
+
+# ---------------------------------------------------------------------------
+# _detect_subdir
+# ---------------------------------------------------------------------------
+
+class TestDetectSubdir:
+    @pytest.mark.parametrize("parent,expected", [
+        ("Mt. Baker-Snoqualmie National Forest", "Mt_Baker_Snoqualmie_NF"),
+        ("Okanogan-Wenatchee National Forest",   "Okanogan_Wenatchee_NF"),
+        ("Olympic National Forest",              "Olympic_NF"),
+        ("Gifford Pinchot National Forest",      "Gifford_Pinchot_NF"),
+        ("Colville National Forest",             "Colville_NF"),
+        ("Umatilla National Forest",             "Umatilla_NF"),
+    ])
+    def test_usfs_forests(self, parent, expected):
+        assert _detect_subdir("usfs", parent) == expected
+
+    @pytest.mark.parametrize("parent,expected", [
+        ("Mount Rainier National Park",          "Mt_Rainier_NP"),
+        ("Olympic National Park",                "Olympic_NP"),
+        ("North Cascades National Park",         "North_Cascades_NP"),
+        ("Lake Roosevelt National Recreation Area", "Lake_Roosevelt_NRA"),
+    ])
+    def test_nps_parks(self, parent, expected):
+        assert _detect_subdir("nps", parent) == expected
+
+    def test_unknown_usfs_returns_none(self):
+        assert _detect_subdir("usfs", "Some Unrecognised Forest") is None
+
+    def test_blm_returns_none(self):
+        assert _detect_subdir("blm", "BLM Anything") is None
+
+
+# ---------------------------------------------------------------------------
+# _slugify
+# ---------------------------------------------------------------------------
+
+class TestSlugify:
+    def test_basic(self):
+        assert _slugify("Bedal Campground") == "Bedal_Campground"
+
+    def test_apostrophe_preserved(self):
+        slug = _slugify("Heart O' the Hills")
+        assert "'" in slug or "Heart_O" in slug  # apostrophe or dropped cleanly
+
+    def test_special_chars_removed(self):
+        slug = _slugify("Buck & Doe (Test)")
+        assert "&" not in slug
+        assert "(" not in slug
+
+    def test_multiple_spaces_collapsed(self):
+        assert _slugify("A  B   C") == "A_B_C"
+
+    def test_hyphens_become_underscores(self):
+        assert _slugify("Rimrock-Lake") == "Rimrock_Lake"
+
+
+# ---------------------------------------------------------------------------
+# _from_search_result
+# ---------------------------------------------------------------------------
+
+class TestFromSearchResult:
+    def _make_result(self, **overrides):
+        base = {
+            "entity_id": "233864",
+            "name": "Bedal Campground",
+            "parent_name": "Mt. Baker-Snoqualmie National Forest",
+            "latitude": "48.0968",
+            "longitude": "-121.3869",
+            "reservable": True,
+        }
+        base.update(overrides)
+        return base
+
+    def test_basic_fields(self):
+        c = _from_search_result(self._make_result())
+        assert c["id"] == "233864"
+        assert c["name"] == "Bedal Campground"
+        assert c["parent_name"] == "Mt. Baker-Snoqualmie National Forest"
+        assert c["lat"] == "48.0968"
+        assert c["lng"] == "-121.3869"
+
+    def test_id_coerced_to_string(self):
+        c = _from_search_result(self._make_result(entity_id=233864))
+        assert c["id"] == "233864"
+
+    def test_site_count_initialised_to_zero(self):
+        c = _from_search_result(self._make_result())
+        assert c["site_count"] == 0
+
+    def test_missing_parent_name(self):
+        c = _from_search_result(self._make_result(parent_name=None))
+        assert c["parent_name"] == ""
+
+
+# ---------------------------------------------------------------------------
+# _from_detail (snake_case API response)
+# ---------------------------------------------------------------------------
+
+class TestFromDetail:
+    def _make_cg(self, **overrides):
+        base = {
+            "facility_name": "Bedal Campground",
+            "facility_latitude": 48.0968,
+            "facility_longitude": -121.3869,
+            "org_code": "FS",
+            "alternate_names": "BEDA,BEDAL,MT. BAKER-SNOQU NF - FS",
+        }
+        base.update(overrides)
+        return base
+
+    def test_basic_fields(self):
+        c = _from_detail("233864", self._make_cg())
+        assert c["id"] == "233864"
+        assert c["name"] == "Bedal Campground"
+        assert c["lat"] == 48.0968
+        assert c["lng"] == -121.3869
+
+    def test_name_falls_back_to_id(self):
+        c = _from_detail("233864", self._make_cg(facility_name=None))
+        assert c["name"] == "233864"
+
+    def test_parent_parsed_from_alternate_names(self):
+        c = _from_detail("233864", self._make_cg())
+        # Last segment of alternate_names (len > 6) becomes parent
+        assert "MT. BAKER-SNOQU NF - FS" in c["parent_name"] or c["parent_name"] != ""
+
+    def test_site_count_initialised_to_zero(self):
+        c = _from_detail("233864", self._make_cg())
+        assert c["site_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _build_index_md
+# ---------------------------------------------------------------------------
+
+class TestBuildIndexMd:
+    def _candidate(self, **overrides):
+        base = {
+            "id": "233864",
+            "name": "Bedal Campground",
+            "parent_name": "Mt. Baker-Snoqualmie National Forest",
+            "lat": 48.0968,
+            "lng": -121.3869,
+            "site_count": 23,
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_yaml_frontmatter(self):
+        md = _build_index_md(self._candidate(), 23, "usfs", "US Forest Service")
+        parts = md.split("---\n")
+        assert len(parts) >= 3
+        fm = yaml.safe_load(parts[1])
+        assert fm["name"] == "Bedal Campground"
+
+    def test_required_fields_present(self):
+        md = _build_index_md(self._candidate(), 23, "usfs", "US Forest Service")
+        fm = yaml.safe_load(md.split("---\n")[1])
+        for field in ("name", "agency", "agency_short", "state", "lat", "lng",
+                      "sites", "types", "reservable", "rec_gov_id",
+                      "reservation_url", "official_url", "availability_windows"):
+            assert field in fm, f"Missing field: {field}"
+
+    def test_rec_gov_id_is_string(self):
+        md = _build_index_md(self._candidate(), 23, "usfs", "US Forest Service")
+        fm = yaml.safe_load(md.split("---\n")[1])
+        assert fm["rec_gov_id"] == "233864"
+        assert isinstance(fm["rec_gov_id"], str)
+
+    def test_reservation_url_contains_id(self):
+        md = _build_index_md(self._candidate(), 23, "usfs", "US Forest Service")
+        fm = yaml.safe_load(md.split("---\n")[1])
+        assert "233864" in fm["reservation_url"]
+        assert fm["reservation_url"].startswith("https://www.recreation.gov")
+
+    def test_lat_lng_rounded(self):
+        md = _build_index_md(self._candidate(lat=48.09684300000, lng=-121.38694300000), 23, "usfs", "US Forest Service")
+        fm = yaml.safe_load(md.split("---\n")[1])
+        # Should be rounded to 4 decimal places
+        assert len(str(fm["lat"]).split(".")[-1]) <= 4
+        assert len(str(abs(fm["lng"])).split(".")[-1]) <= 4
+
+    def test_sites_from_site_count(self):
+        md = _build_index_md(self._candidate(), 17, "usfs", "US Forest Service")
+        fm = yaml.safe_load(md.split("---\n")[1])
+        assert fm["sites"] == 17
+
+    def test_availability_windows_has_site_total_count(self):
+        md = _build_index_md(self._candidate(), 23, "usfs", "US Forest Service")
+        fm = yaml.safe_load(md.split("---\n")[1])
+        windows = fm["availability_windows"]
+        assert len(windows) == 1
+        assert windows[0]["site_total_count"] == 23
+
+    def test_body_contains_parent_name(self):
+        md = _build_index_md(self._candidate(), 23, "usfs", "US Forest Service")
+        body = md.split("---\n", 2)[-1]
+        assert "Mt. Baker-Snoqualmie National Forest" in body
+
+
+# ---------------------------------------------------------------------------
+# _write_toml / _load_existing_ids (filesystem round-trip)
+# ---------------------------------------------------------------------------
+
+class TestTomlRoundTrip:
+    def test_write_sorted(self, tmp_path):
+        entries = [
+            {"name": "Zebra Lake", "path": "campsites/usfs/WA/Zebra_Lake.md"},
+            {"name": "Apple Creek", "path": "campsites/usfs/WA/Apple_Creek.md"},
+            {"name": "Middle Camp", "path": "campsites/usfs/WA/Middle_Camp.md"},
+        ]
+        toml_file = tmp_path / "campsites.toml"
+        _write_toml(toml_file, entries)
+        text = toml_file.read_text()
+        positions = {name: text.index(name) for name in ["Apple Creek", "Middle Camp", "Zebra Lake"]}
+        assert positions["Apple Creek"] < positions["Middle Camp"] < positions["Zebra Lake"]
+
+    def test_write_valid_toml(self, tmp_path):
+        import tomllib
+        entries = [{"name": "Test Camp", "path": "campsites/usfs/WA/Test_Camp.md"}]
+        toml_file = tmp_path / "campsites.toml"
+        _write_toml(toml_file, entries)
+        with open(toml_file, "rb") as f:
+            config = tomllib.load(f)
+        assert config["campsites"][0]["name"] == "Test Camp"
+        assert config["campsites"][0]["path"] == "campsites/usfs/WA/Test_Camp.md"
+
+    def test_load_existing_ids(self, tmp_path):
+        # Create a minimal index.md with a rec_gov_id
+        camp_dir = tmp_path / "campsites" / "usfs" / "WA"
+        camp_dir.mkdir(parents=True)
+        md_file = camp_dir / "Test_Camp.md"
+        md_file.write_text(textwrap.dedent("""\
+            ---
+            name: Test Camp
+            rec_gov_id: '999001'
+            ---
+
+            A test campsite.
+        """))
+        # Write a matching TOML
+        toml_file = tmp_path / "campsites.toml"
+        _write_toml(toml_file, [{"name": "Test Camp", "path": str(md_file)}])
+
+        ids = _load_existing_ids(toml_file)
+        assert "999001" in ids
+
+    def test_load_existing_ids_skips_missing_files(self, tmp_path):
+        toml_file = tmp_path / "campsites.toml"
+        _write_toml(toml_file, [{"name": "Ghost Camp", "path": "does/not/exist.md"}])
+        ids = _load_existing_ids(toml_file)
+        assert len(ids) == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — real network (marked slow)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.slow
+class TestCrawlIntegration:
+    """Live recreation.gov requests — requires network access."""
+
+    BEDAL_ID = "233864"
+
+    @pytest.fixture(scope="class")
+    def ctx(self):
+        from playwright.sync_api import sync_playwright
+        from scripts.crawl_rec_gov import _new_context
+        with sync_playwright() as p:
+            context = _new_context(p)
+            yield context
+            context.dispose()
+
+    def test_search_by_id_finds_bedal(self, ctx):
+        from scripts.crawl_rec_gov import _search_by_id
+        result = _search_by_id(ctx, self.BEDAL_ID)
+        assert result is not None
+        assert str(result.get("entity_id")) == self.BEDAL_ID
+        assert "Bedal" in result.get("name", "")
+
+    def test_search_by_id_has_parent_name(self, ctx):
+        from scripts.crawl_rec_gov import _search_by_id
+        result = _search_by_id(ctx, self.BEDAL_ID)
+        assert result is not None
+        assert "Baker" in result.get("parent_name", "") or "Snoqualmie" in result.get("parent_name", "")
+
+    def test_search_by_id_has_coordinates(self, ctx):
+        from scripts.crawl_rec_gov import _search_by_id
+        result = _search_by_id(ctx, self.BEDAL_ID)
+        assert result is not None
+        assert result.get("latitude") is not None
+        assert result.get("longitude") is not None
+
+    def test_fetch_site_count_bedal(self, ctx):
+        from scripts.crawl_rec_gov import _fetch_site_count
+        count = _fetch_site_count(ctx, self.BEDAL_ID)
+        assert count > 0, "Expected at least one campsite"
+
+    def test_search_unknown_id_returns_none(self, ctx):
+        from scripts.crawl_rec_gov import _search_by_id
+        result = _search_by_id(ctx, "0000000")
+        assert result is None


### PR DESCRIPTION
## Summary

- Adds `uv run crawl` — searches recreation.gov for WA campgrounds not yet in the dataset and prompts to add them interactively in batch
- Supports two modes: full WA search (`uv run crawl`) and single-URL check (`uv run crawl --url https://www.recreation.gov/camping/campgrounds/233864`)
- New campgrounds get an `index.md` created and are inserted into `campsites.toml` (alphabetically sorted)
- Includes 43 unit tests (pure functions, no network) + 5 `@pytest.mark.slow` integration tests against live recreation.gov API
- Registers `slow` pytest mark in `pyproject.toml` so CI can skip network tests with `-m "not slow"`
- First campsite added via crawler: **Bedal Campground** (Mt. Baker-Snoqualmie NF, rec_gov_id 233864)

## Test plan

- [x] `uv run pytest tests/test_crawl_rec_gov.py -m "not slow"` — 43 unit tests pass
- [ ] `uv run crawl --url https://www.recreation.gov/camping/campgrounds/233864` → shows Bedal Campground as already in dataset
- [ ] `uv run crawl --max 50` → lists new WA campgrounds not in dataset, interactive prompt works
- [ ] After adding a campsite, `uv run generate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)