### PR TITLE
Fix Data CI: add missing 'run' subcommand to uv run refresh

### DIFF
--- a/.github/workflows/data-ci.yaml
+++ b/.github/workflows/data-ci.yaml
@@ -32,7 +32,7 @@ jobs:
         run: uv run playwright install --with-deps chromium
 
       - name: Generate GeoJSON (validate + STAC-shaped FeatureCollection)
-        run: USER=ci uv run refresh --skip-availability
+        run: USER=ci uv run refresh run --skip-availability
 
       - name: Run Tests
         run: uv run pytest

--- a/scripts/sync-geojson.js
+++ b/scripts/sync-geojson.js
@@ -9,8 +9,9 @@ const DATA_DIR = path.join(__dirname, '..', 'data');
 
 try {
   console.log('Running python data generator via uv...');
-  // Ensure we are in the data directory where pyproject.toml is
-  execSync('uv run refresh --skip-availability', { stdio: 'inherit', cwd: DATA_DIR });
+  // Metaflow requires a username; fall back to "ci" when none is set.
+  const env = { ...process.env, USER: process.env.USER || process.env.USERNAME || 'ci' };
+  execSync('uv run refresh run --skip-availability', { stdio: 'inherit', cwd: DATA_DIR, env });
 } catch (err) {
   console.error('Data generation failed:', err.message);
   process.exit(1);


### PR DESCRIPTION
The Data CI workflow on PR #30 failed because Metaflow's CLI requires
an explicit subcommand — `uv run refresh --skip-availability` produced
"Error: no such option: --skip-availability". The flag is an option on
the `run` subcommand, not the top-level CLI.

Same fix in scripts/sync-geojson.js (web build's data-sync wrapper),
plus a USER fallback so Metaflow can identify the user when the wrapper
is invoked from environments without USER/USERNAME set.

https://claude.ai/code/session_01MSBRsxsJyBqKyx38UyGBM1