### PR TITLE
Collector: even 24h sample distribution (windowSec 86400)

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -75,9 +75,11 @@ app.post('/watch', async (c) => {
 
 export default {
   fetch: app.fetch,
-  // Daily cron → durable collection Workflow (one step.do per site, retry/resume).
+  // Daily cron → durable collection Workflow. windowSec 86400 spreads the 61
+  // sites evenly across 24h (~24 min apart, ±50% jitter) so samples cover the
+  // whole day and consecutive days tile seamlessly — not a once-daily burst.
   async scheduled(event: ScheduledEvent, env: Bindings, ctx: ExecutionContext) {
     const date = new Date(event.scheduledTime).toISOString().slice(0, 10);
-    ctx.waitUntil(env.COLLECTOR_WF.create({ params: { date } }));
+    ctx.waitUntil(env.COLLECTOR_WF.create({ params: { date, windowSec: 86400 } }));
   },
 };

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -32,9 +32,9 @@ export class CampsiteCollectorWorkflow extends WorkflowEntrypoint<WfEnv, { date:
     const { date, limit, windowSec = 3600 } = event.payload;
     const sites = limit ? (index as Site[]).slice(0, limit) : (index as Site[]);
 
-    // Pace the full refresh across ~windowSec with per-gap jitter (±50%), planned
-    // once inside a step (Math.random → replay-safe). Spreads the daily run over
-    // ~1 hour so it isn't a synchronized burst against the sources.
+    // Pace the run across ~windowSec with per-gap jitter (±50%), planned once
+    // inside a step (Math.random → replay-safe). The cron passes 86400 to spread
+    // samples evenly over 24h; not a synchronized burst against the sources.
     const gaps = await step.do('plan-schedule', async () => {
       const base = sites.length > 1 ? windowSec / sites.length : 0;
       return sites.map(() => Math.max(0, Math.round(base * (0.5 + Math.random()))));

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -42,7 +42,7 @@ binding = "WATCH_AE"
 dataset = "campsite_watch"
 
 [triggers]
-crons = ["0 13 * * *"] # 06:00 America/Los_Angeles (PDT)
+crons = ["0 7 * * *"] # 00:00 PT during PDT (cron is UTC-only → 23:00 PT in winter/PST). Starts the daily 24h sweep at midnight PT.
 
 # Workflows prototype (durable execution) — coexists with the queue collector.
 [[workflows]]


### PR DESCRIPTION
Switches the scheduled run from a 1-hour burst to **even sampling across 24h with jitter**. The cron passes `windowSec: 86400`, so the 61 sites pace ~24 min apart (±50% per-gap jitter) over the whole day; consecutive daily runs tile seamlessly. Better temporal coverage for burn-down projections and gentler on rec.gov / WA. Deployed live. `/collect/run` default stays 1h for ad-hoc runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)