### PR TITLE
feat: per-campsite availability collection (+ CI/lint repairs to unblock checks)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,8 @@ jobs:
       
       - name: Install uv
         uses: astral-sh/setup-uv@v5
-- name: Install dependencies
+
+      - name: Install dependencies
         run: |
           npm install -g wrangler
           cd backend && npm install

--- a/CAMPSITE-PLAN.md
+++ b/CAMPSITE-PLAN.md
@@ -1,6 +1,6 @@
 # CAMPSITE-PLAN.md — Per-Campsite Availability Collection
 
-**Status:** Proposed
+**Status:** Phase 1 (collect) implemented — see §8. Phases 2–3 pending.
 **Goal:** Collect availability at the level of the *individual campsite* (e.g. loop A, site 12), not just the campground-wide aggregate, so we can eventually predict when a specific site/date sells out.
 **Non-goal:** Changing the daily cadence. Daily sampling stays — this is purely about granularity, not frequency.
 
@@ -85,7 +85,7 @@ Per-site detail lives in R2 (`sites/`). The Mac-side ingest decides how much of 
 
 ## 8. Rollout
 
-1. **Phase 1 — collect (this PR's follow-up):** implement §5, deploy. Per-site files start landing in `sites/`. No consumer yet — purely begin banking the data so history accrues from day one.
+1. **Phase 1 — collect (✅ done, this PR):** §5 implemented. Per-site files land in `sites/<date>/<id>.json` on the same daily run. No consumer yet — purely begin banking the data so history accrues from day one.
 2. **Phase 2 — ingest:** extend the Mac ingest to read `sites/` into InfluxDB for a curated watchlist of `(campground, date)` pairs (the dates we actually want to forecast), keeping cardinality bounded.
 3. **Phase 3 — model:** once a season of per-site history exists, build the per-site sell-out projection on top of it.
 

--- a/CAMPSITE-PLAN.md
+++ b/CAMPSITE-PLAN.md
@@ -1,0 +1,100 @@
+# CAMPSITE-PLAN.md — Per-Campsite Availability Collection
+
+**Status:** Proposed
+**Goal:** Collect availability at the level of the *individual campsite* (e.g. loop A, site 12), not just the campground-wide aggregate, so we can eventually predict when a specific site/date sells out.
+**Non-goal:** Changing the daily cadence. Daily sampling stays — this is purely about granularity, not frequency.
+
+---
+
+## 1. Why
+
+Today the collector predicts (at best) *campground* sell-out. The `summary/<date>/<id>.json` snapshot stores `by_date[YYYY-MM-DD] = {available, reserved, total}` — counts rolled up across every site in a campground (`backend/src/workflows.ts:58`, `backend/src/availability.ts:43-47`). That tells us "3 of 15 sites are free on June 15," but not *which* sites, what type they are, or which specific site burned down first.
+
+For per-site sell-out prediction we need a time series keyed on `(campground, campsite, target_date)`, not `(campground, target_date)`.
+
+## 2. The key realization: we already fetch this data
+
+We are not adding any new network calls or scraping. The per-site detail is **already in the responses we fetch and then discard**:
+
+- **rec.gov** — `fetchRecAvailability` iterates `data.campsites` (keyed by `campsite_id`), and for each site walks `site.availabilities` (a `date → status` map) — `backend/src/availability.ts:40-48`. It immediately collapses every site into per-day counts. The per-site identity (`campsite_id`, the `site` label like `A012`, `loop`, `campsite_type`, `type_of_use`) is dropped on the floor.
+- **WA goingtocamp** — `fetchWaAvailability` iterates `data.resourceAvailabilities` (keyed by resource id) — `backend/src/availability.ts:76-83` — and likewise collapses to counts. The `/api/maps` call already pulls the resource/site metadata we'd need for labels.
+
+So this is a **summarization change, not a collection change.** We stop throwing the per-site rows away.
+
+## 3. Proposed data model
+
+A normalized, source-agnostic per-site shape (unifies rec.gov + WA into one schema downstream consumers can read without knowing the source):
+
+```jsonc
+// sites/<date>/<campground-id>.json   — one file per campground per day
+{
+  "id": "246855",                 // campground id (matches campsites-index.json)
+  "name": "Colonial Creek North",
+  "agency": "nps",
+  "kind": "rec",
+  "collected_date": "2026-06-01",
+  "sites": {
+    "<campsite_id>": {
+      "label": "A012",            // human site number / loop label
+      "loop": "Loop A",
+      "type": "STANDARD NONELECTRIC",
+      "use": "Overnight",
+      "by_date": {                // status per target night, source-normalized
+        "2026-06-15": "available",
+        "2026-06-16": "reserved"
+      }
+    }
+    // … one entry per individual campsite
+  }
+}
+```
+
+Normalized status vocabulary: `available | reserved | other` (mirrors the existing rec/WA mapping in `availability.ts:45-46` and `WA_AVAIL` at `:54-56`). Anything not clearly available/reserved → `other`, so closed/NYR/management-hold sites don't masquerade as bookable.
+
+## 4. R2 storage layout
+
+| Prefix | Status | Contents |
+|---|---|---|
+| `raw/<date>/<agency>/<id>.json` | **unchanged** | full upstream API payloads (already per-site, but in two different un-normalized schemas) |
+| `summary/<date>/<id>.json` | **unchanged** | campground aggregate `{available, reserved, total}` — the Mac/InfluxDB ingest still reads this, so we keep it for backward compatibility |
+| `sites/<date>/<id>.json` | **NEW** | normalized per-campsite breakdown (§3) |
+
+Keeping `summary/` untouched means **zero downstream breakage** — the existing ingest keeps working while the new per-site layer is added alongside it. `sites/` is a clean normalization of data that's otherwise only available in the bulky, dual-schema `raw/` blobs.
+
+## 5. Code changes
+
+Small and contained — three files in `backend/`:
+
+1. **`src/availability.ts`** — have `fetchRecAvailability` / `fetchWaAvailability` return a `bySite` map alongside the existing `by` (campground rollup). Build `bySite` from the same loop that currently builds `by`, so the aggregate stays a derived sum and the two can't drift. `fetchAvailability` passes it through.
+2. **`src/workflows.ts`** — in the `collect <id>` step (`workflows.ts:49-86`), write the new `sites/<date>/<id>.json` from `bySite` after the existing `raw/` and `summary/` puts. Aggregate `summary/` write stays as-is.
+3. **`src/availability.ts` types** — add `PerSite` / `BySite` types next to `Counts`/`ByDate` (`availability.ts:10-11`).
+
+No changes to the cron, the pacing/jitter logic, the Hono routes, or `wrangler.toml` bindings (R2 prefix reuse needs no new binding).
+
+## 6. Analytics Engine / observability
+
+Per-site-per-date is high cardinality: ~61 campgrounds × (tens–hundreds of sites) × ~180 nights ≈ millions of cells per day. **Do not** fan this into Analytics Engine as one row per site-night — keep the existing campground-level AE datasets (`campsite_availability`, etc.) unchanged for Grafana coverage dashboards.
+
+Per-site detail lives in R2 (`sites/`). The Mac-side ingest decides how much of it to land in InfluxDB and at what cardinality (proposed: tag by `campground_id` + `campsite_id`, field `state` 0/1, scoped to a watchlist of target dates rather than all 180 nights — see Open Questions).
+
+## 7. Volume & cost
+
+- **Reads:** unchanged — same fetches, same daily cadence.
+- **R2 writes:** +1 object per campground per day (61 extra PUTs/day). Negligible.
+- **R2 storage:** `sites/` objects are larger than `summary/` (per-site rows) but far smaller than `raw/`. Order of low single-digit MB/day across all campgrounds. Append-forever is fine for now; a retention policy is a separate follow-up (already a gap noted for `summary/`/`raw/`).
+
+## 8. Rollout
+
+1. **Phase 1 — collect (this PR's follow-up):** implement §5, deploy. Per-site files start landing in `sites/`. No consumer yet — purely begin banking the data so history accrues from day one.
+2. **Phase 2 — ingest:** extend the Mac ingest to read `sites/` into InfluxDB for a curated watchlist of `(campground, date)` pairs (the dates we actually want to forecast), keeping cardinality bounded.
+3. **Phase 3 — model:** once a season of per-site history exists, build the per-site sell-out projection on top of it.
+
+## 9. Open questions
+
+- **WA site labels:** confirm the `/api/maps` response carries usable per-resource site numbers/loop names; if not, `sites/` carries the resource id and we enrich labels later.
+- **Watchlist vs. firehose into InfluxDB:** land all site-nights, or only a curated set of target dates? (Leaning curated, to keep InfluxDB cardinality sane — full fidelity always remains in R2.)
+- **`raw/` retention:** once `sites/` is the normalized source of truth, can `raw/` move to a shorter retention window to cap storage growth?
+
+---
+
+*This is a planning document. Implementation lands in a follow-up PR per the [ISSUES.md](./ISSUES.md) lifecycle (feature branch → local verify → PR → review).*

--- a/backend/src/availability.test.ts
+++ b/backend/src/availability.test.ts
@@ -1,0 +1,66 @@
+import { expect, test, describe, vi, afterEach } from 'vitest';
+import { fetchRecAvailability } from './availability';
+
+// A single-month rec.gov availability payload, two sites, mixed statuses.
+const REC_PAYLOAD = {
+  campsites: {
+    '111': {
+      campsite_id: '111',
+      site: 'A001',
+      loop: 'Loop A',
+      campsite_type: 'STANDARD NONELECTRIC',
+      type_of_use: 'Overnight',
+      availabilities: {
+        '2026-06-15T00:00:00Z': 'Available',
+        '2026-06-16T00:00:00Z': 'Reserved',
+      },
+    },
+    '222': {
+      campsite_id: '222',
+      site: 'A002',
+      loop: 'Loop A',
+      campsite_type: 'TENT ONLY',
+      type_of_use: 'Overnight',
+      availabilities: {
+        '2026-06-15T00:00:00Z': 'Reserved',
+        '2026-06-16T00:00:00Z': 'Not Reservable',
+      },
+    },
+  },
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('fetchRecAvailability per-site collection', () => {
+  test('preserves per-campsite identity and status', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => REC_PAYLOAD }));
+
+    const { bySite } = await fetchRecAvailability('123', 1, new Date('2026-06-01T00:00:00Z'));
+
+    expect(Object.keys(bySite).sort()).toEqual(['111', '222']);
+    expect(bySite['111']).toMatchObject({ label: 'A001', loop: 'Loop A', type: 'STANDARD NONELECTRIC', use: 'Overnight' });
+    expect(bySite['111'].by_date).toEqual({ '2026-06-15': 'available', '2026-06-16': 'reserved' });
+    // Unknown statuses normalize to "other", not silently dropped.
+    expect(bySite['222'].by_date).toEqual({ '2026-06-15': 'reserved', '2026-06-16': 'other' });
+  });
+
+  test('aggregate counts equal the derived per-site sum (no drift)', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => REC_PAYLOAD }));
+
+    const { by, bySite } = await fetchRecAvailability('123', 1, new Date('2026-06-01T00:00:00Z'));
+
+    // Recompute the aggregate straight from bySite and assert it matches `by`.
+    const derived: Record<string, { available: number; reserved: number; total: number }> = {};
+    for (const site of Object.values(bySite)) {
+      for (const [day, status] of Object.entries(site.by_date)) {
+        const c = (derived[day] ??= { available: 0, reserved: 0, total: 0 });
+        if (status === 'available') c.available++;
+        else if (status === 'reserved') c.reserved++;
+        c.total++;
+      }
+    }
+    expect(by).toEqual(derived);
+    expect(by['2026-06-15']).toEqual({ available: 1, reserved: 1, total: 2 });
+    expect(by['2026-06-16']).toEqual({ available: 0, reserved: 1, total: 2 });
+  });
+});

--- a/backend/src/availability.ts
+++ b/backend/src/availability.ts
@@ -10,6 +10,25 @@ const pad = (n: number) => String(n).padStart(2, "0");
 export type Counts = { available: number; reserved: number; total: number };
 export type ByDate = Record<string, Counts>;
 
+// Per-individual-campsite detail — preserved instead of collapsed into Counts.
+// `by_date` mirrors the aggregate's keys (daily for rec.gov, monthly for WA).
+export type SiteStatus = "available" | "reserved" | "other";
+export type PerSite = {
+  label: string | null; // site number / loop label (e.g. "A012"); null until enriched (WA)
+  loop: string | null;
+  type: string | null; // campsite type (e.g. "STANDARD NONELECTRIC")
+  use: string | null; // type of use (e.g. "Overnight")
+  by_date: Record<string, SiteStatus>;
+};
+export type BySite = Record<string, PerSite>;
+
+function recStatus(status: string): SiteStatus {
+  const s = String(status).toLowerCase();
+  if (s === "available") return "available";
+  if (s === "reserved") return "reserved";
+  return "other";
+}
+
 function monthStarts(start: Date, n: number): { y: number; m: number }[] {
   const out: { y: number; m: number }[] = [];
   for (let i = 0; i < n; i++) {
@@ -30,6 +49,7 @@ async function getJson(url: string, referer: string): Promise<any> {
 export async function fetchRecAvailability(id: string, months = 6, start = new Date()) {
   const raw: Record<string, any> = {};
   const by: ByDate = {};
+  const bySite: BySite = {};
   for (const { y, m } of monthStarts(start, months)) {
     const sd = `${y}-${pad(m)}-01T00:00:00.000Z`;
     const data = await getJson(
@@ -38,17 +58,26 @@ export async function fetchRecAvailability(id: string, months = 6, start = new D
     );
     raw[`${y}-${pad(m)}`] = data;
     for (const site of Object.values<any>(data.campsites ?? {})) {
+      const sid = String(site.campsite_id ?? site.site ?? "");
+      const ps = (bySite[sid] ??= {
+        label: site.site ?? null,
+        loop: site.loop ?? null,
+        type: site.campsite_type ?? null,
+        use: site.type_of_use ?? null,
+        by_date: {},
+      });
       for (const [ds, status] of Object.entries<string>(site.availabilities ?? {})) {
         const day = ds.slice(0, 10);
         const c = (by[day] ??= { available: 0, reserved: 0, total: 0 });
-        const s = String(status).toLowerCase();
-        if (s === "available") c.available++;
-        else if (s === "reserved") c.reserved++;
+        const label = recStatus(status);
+        if (label === "available") c.available++;
+        else if (label === "reserved") c.reserved++;
         c.total++;
+        ps.by_date[day] = label;
       }
     }
   }
-  return { raw, by };
+  return { raw, by, bySite };
 }
 
 const WA_AVAIL: Record<number, "available" | "reserved" | "other"> = {
@@ -61,6 +90,7 @@ export async function fetchWaAvailability(ref: number | string, months = 6, star
   const mapIds = (Array.isArray(maps) ? maps : []).map((m: any) => m.mapId).filter(Boolean);
   const raw: Record<string, any> = {};
   const by: ByDate = {};
+  const bySite: BySite = {};
   for (const { y, m } of monthStarts(start, months)) {
     const startISO = `${y}-${pad(m)}-01`;
     const end = m === 12 ? `${y + 1}-01-01` : `${y}-${pad(m + 1)}-01`;
@@ -80,6 +110,10 @@ export async function fetchWaAvailability(ref: number | string, months = 6, star
           if (label === "available") c.available++;
           else if (label === "reserved") c.reserved++;
           c.total++;
+          // WA labels aren't resolved yet (see CAMPSITE-PLAN.md open questions);
+          // the stable resource id keys a per-site series we can enrich later.
+          const ps = (bySite[rid] ??= { label: null, loop: null, type: null, use: null, by_date: {} });
+          ps.by_date[startISO] = label;
         }
       } catch {
         /* some sub-maps 403 — skip */
@@ -87,7 +121,7 @@ export async function fetchWaAvailability(ref: number | string, months = 6, star
     }
     by[startISO] = c;
   }
-  return { raw, by };
+  return { raw, by, bySite };
 }
 
 export async function fetchAvailability(kind: "rec" | "wa", ref: string | number, months = 6) {

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -23,6 +23,20 @@ describe('Hono API Tests', () => {
     expect(body).toEqual({ error: 'Campsite not found' });
   });
 
+  test('GET /campsite/:id matches agency-prefixed (slash-containing) ids', async () => {
+    const mockCampsite = { id: 'blm/fishtrap-recreation-area', name: 'Fishtrap Recreation Area', agency_short: 'blm' };
+    const MOCK_CAMPSITES = { get: vi.fn().mockResolvedValue(mockCampsite) };
+
+    const res = await app.request('/campsite/blm/fishtrap-recreation-area', {}, {
+      CAMPSITES: MOCK_CAMPSITES,
+    } as any);
+
+    expect(res.status).toBe(200);
+    // The full agency/slug path, not just the last segment, is used as the KV key.
+    expect(MOCK_CAMPSITES.get).toHaveBeenCalledWith('blm/fishtrap-recreation-area', { type: 'json' });
+    expect(await res.json()).toEqual(mockCampsite);
+  });
+
   test('GET /campsite/:id should return campsite if found', async () => {
     const mockCampsite = {
       id: 'test-camp',

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,8 +21,10 @@ app.get('/', (c) => {
   return c.text('Robot Geographical Society Backend API');
 });
 
-// GET /campsite/:id - Fetch individual campsite details
-app.get('/campsite/:id', async (c) => {
+// GET /campsite/:id - Fetch individual campsite details.
+// Ids are agency-prefixed and contain a slash (e.g. "blm/fishtrap-recreation-area"),
+// so capture the full remainder of the path with {.+} rather than a single segment.
+app.get('/campsite/:id{.+}', async (c) => {
   const id = c.req.param('id');
   const campsite = await c.env.CAMPSITES.get(id, { type: 'json' });
   if (!campsite) {

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -57,6 +57,19 @@ export class CampsiteCollectorWorkflow extends WorkflowEntrypoint<WfEnv, { date:
               `summary/${date}/${site.id}.json`,
               JSON.stringify({ id: site.id, name: site.name, agency: site.agency, kind: site.kind, by_date: a.by }),
             );
+            // Per-individual-campsite breakdown (CAMPSITE-PLAN.md). Same fetch,
+            // same cadence — preserves the per-site rows the summary collapses.
+            await this.env.RAW.put(
+              `sites/${date}/${site.id}.json`,
+              JSON.stringify({
+                id: site.id,
+                name: site.name,
+                agency: site.agency,
+                kind: site.kind,
+                collected_date: date,
+                sites: a.bySite,
+              }),
+            );
             // Per-site coverage metric (AE is sampled / at-least-once — fine for metrics).
             this.env.COLLECTOR_AE?.writeDataPoint({
               indexes: [site.id],

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -8,7 +8,9 @@ binding = "CAMPSITES"
 id = "aad9f04d90e945ffb8d278d7b8e70976"
 preview_id = "aad9f04d90e945ffb8d278d7b8e70976"
 
-# Raw + summarized availability snapshots; the Mac pulls summary/<date>/* → InfluxDB.
+# Availability snapshots. Layout: raw/<date>/<agency>/<id>.json (upstream payloads),
+# summary/<date>/<id>.json (campground aggregate — the Mac pulls these → InfluxDB),
+# sites/<date>/<id>.json (per-individual-campsite breakdown — see CAMPSITE-PLAN.md).
 [[r2_buckets]]
 binding = "RAW"
 bucket_name = "campsite-raw"

--- a/web/e2e/campsite.test.js
+++ b/web/e2e/campsite.test.js
@@ -9,7 +9,7 @@ test.describe('Robot Geographical Society - Integration', () => {
     let response;
     for (let i = 0; i < 5; i++) {
         try {
-            response = await request.get(`${BACKEND_URL}/campsite/fishtrap-recreation-area`);
+            response = await request.get(`${BACKEND_URL}/campsite/blm/fishtrap-recreation-area`);
             if (response.ok()) break;
         } catch (e) {
             console.log(`Backend attempt ${i+1} failed: ${e.message}`);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -373,14 +373,14 @@ export default function App() {
           )}
 
           {loadingDetails ? (
-            <div className=”loading-indicator”>Loading additional details...</div>
+            <div className="loading-indicator">Loading additional details...</div>
           ) : campsiteDetails?.reservation_dates?.length > 0 ? (
-            <div className=”panel-reservations”>
+            <div className="panel-reservations">
               <h3>Opening Reservation Dates</h3>
-              <ul className=”res-list”>
+              <ul className="res-list">
                 {campsiteDetails.reservation_dates.map((date) => (
-                  <li key={date} className=”res-item”>
-                    ðŸ—“ï¸  {new Date(date).toLocaleDateString(undefined, {
+                  <li key={date} className="res-item">
+                    🗓️  {new Date(date).toLocaleDateString(undefined, {
                       month: 'long',
                       day: 'numeric',
                       year: 'numeric',
@@ -402,11 +402,11 @@ export default function App() {
               .slice(0, 10);
             if (availDates.length === 0) return null;
             return (
-              <div className=”panel-reservations”>
+              <div className="panel-reservations">
                 <h3>Sites Available (next {availDates.length} dates)</h3>
-                <ul className=”res-list”>
+                <ul className="res-list">
                   {availDates.map(([date, count]) => (
-                    <li key={date} className=”res-item”>
+                    <li key={date} className="res-item">
                       <span style={{ color: 'var(--cyan)', marginRight: 6 }}>{count}</span>
                       {new Date(date + 'T12:00:00').toLocaleDateString(undefined, {
                         month: 'short',

--- a/web/src/App.test.jsx
+++ b/web/src/App.test.jsx
@@ -92,11 +92,14 @@ describe('Standalone mode (VITE_STANDALONE=true)', () => {
     });
   }
 
-  it('does not call fetch when a campsite is selected', async () => {
+  it('does not call the backend API when a campsite is selected', async () => {
     render(<App />);
     selectCampsite(fakeCampsite);
     await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument());
-    expect(fetchSpy).not.toHaveBeenCalled();
+    // Standalone mode may load the static /availability.json bundled with the SPA,
+    // but must never hit the backend /campsite API (the guard at App.jsx).
+    const calledUrls = fetchSpy.mock.calls.map(([url]) => String(url));
+    expect(calledUrls.some((u) => u.includes('/campsite/'))).toBe(false);
   });
 
   it('detail panel renders campsite info from GeoJSON properties', async () => {


### PR DESCRIPTION
## Summary

Collects availability at the **individual-campsite** level (loop A, site 12) instead of only the campground-wide aggregate — the data needed to eventually predict when a *specific* site/date sells out. **Daily cadence is unchanged**; this is purely granularity.

The key insight: we already fetch the per-site rows and throw them away. `availability.ts` iterated `data.campsites` / `resourceAvailabilities` and collapsed them straight into `{available, reserved, total}`. This preserves them — **no new fetches, no cadence change.**

### What changed (the feature)
- `availability.ts` now returns `bySite` (`campsite_id → {label, loop, type, use, by_date}`) alongside the existing aggregate, built in the same loop so the two can't drift.
- Collector writes a new normalized **`sites/<date>/<id>.json`** R2 object per campground/day. `summary/` is untouched → existing Mac→InfluxDB ingest keeps working.
- New `availability.test.ts`: per-site extraction, status normalization, and the aggregate-equals-derived-sum invariant.
- `CAMPSITE-PLAN.md` design doc (Phase 1 marked done).

### Incidental CI/lint repairs (required to get checks running)
CI had been failing instantly on **invalid workflow YAML**, so several breakages on `main` were latent. Fixing the YAML surfaced them; each is committed separately:
- `ci.yaml` indentation (the workflow was invalid YAML).
- `App.jsx`: corrupted curly quotes + mojibake emoji (ESLint parse error).
- Standalone-mode test: asserted *no fetch at all*; updated to assert *no backend API call* (static `/availability.json` is allowed). 
- `/campsite/:id` route: campsite ids are now agency-prefixed and contain a slash (`blm/fishtrap-recreation-area`); the single-segment route 404'd for every real id (broke e2e **and** the production frontend fetch). Now `:id{.+}`, with a unit test.

## Verification
- Backend: `tsc --noEmit` clean, 6 vitest tests pass.
- Web: ESLint clean, 8 unit tests pass.
- **CI green** (lint + unit + build + Playwright e2e).

## Scope note
The CI/lint/route fixes are unrelated to per-campsite collection but were necessary for this PR's checks to pass at all. Happy to split them into a separate PR if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)