### PR TITLE
feat: distributed, per-booking-system collection schedule

### DIFF
--- a/CAMPSITE-PLAN.md
+++ b/CAMPSITE-PLAN.md
@@ -69,13 +69,35 @@ Small and contained — three files in `backend/`:
 2. **`src/workflows.ts`** — in the `collect <id>` step (`workflows.ts:49-86`), write the new `sites/<date>/<id>.json` from `bySite` after the existing `raw/` and `summary/` puts. Aggregate `summary/` write stays as-is.
 3. **`src/availability.ts` types** — add `PerSite` / `BySite` types next to `Counts`/`ByDate` (`availability.ts:10-11`).
 
-No changes to the cron, the pacing/jitter logic, the Hono routes, or `wrangler.toml` bindings (R2 prefix reuse needs no new binding).
+No changes to the cron, the Hono routes, or `wrangler.toml` bindings (R2 prefix reuse needs no new binding). The pacing logic is replaced by `planSchedule` — see §6b.
 
 ## 6. Analytics Engine / observability
 
 Per-site-per-date is high cardinality: ~61 campgrounds × (tens–hundreds of sites) × ~180 nights ≈ millions of cells per day. **Do not** fan this into Analytics Engine as one row per site-night — keep the existing campground-level AE datasets (`campsite_availability`, etc.) unchanged for Grafana coverage dashboards.
 
 Per-site detail lives in R2 (`sites/`). The Mac-side ingest decides how much of it to land in InfluxDB and at what cardinality (proposed: tag by `campground_id` + `campsite_id`, field `state` 0/1, scoped to a watchlist of target dates rather than all 180 nights — see Open Questions).
+
+## 6b. Request distribution / schedule generation
+
+As the fleet grows, the request pattern against each booking system must stay
+unobtrusive — evenly spread, interleaved, and varying day to day. The original
+plan paced sites in index order, which clustered all rec.gov requests into the
+front of the window and all goingtocamp into the tail, in the same order every
+run. `planSchedule` (`src/schedule.ts`) replaces that:
+
+- **Per-system even spread.** Items are grouped by booking system (`site.kind`).
+  Each group of N is laid over N equal slots of width `windowSec / N`; one
+  request per slot → even coverage with no bursts. Each system keeps its own
+  cadence regardless of the others' size.
+- **Interleaved.** Groups are merged and sorted by time, so requests alternate
+  across systems (rec → wa → rec …) instead of arriving in per-agency blocks.
+- **No fixed daily pattern.** The item→slot assignment is reshuffled and the
+  offset within each slot is jittered every run, so a given site is never
+  collected at the same time two days running.
+- **Scales & is generic.** Adding campsites just shrinks the slots; adding a new
+  booking system gives it its own independent cadence — no code change. The
+  function is pure (randomness injected) so it runs inside the replay-safe
+  `plan-schedule` Workflow step and is unit-tested with a seeded PRNG.
 
 ## 7. Volume & cost
 

--- a/backend/src/schedule.test.ts
+++ b/backend/src/schedule.test.ts
@@ -1,0 +1,100 @@
+import { expect, test, describe } from 'vitest';
+import { planSchedule } from './schedule';
+
+// Deterministic PRNG (mulberry32) so the distribution assertions are stable.
+function seeded(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// 39 rec + 22 wa, mirroring the real index split.
+function fixture() {
+  const sites = [];
+  for (let i = 0; i < 39; i++) sites.push({ id: `rec-${i}`, kind: 'rec' });
+  for (let i = 0; i < 22; i++) sites.push({ id: `wa-${i}`, kind: 'wa' });
+  return sites;
+}
+
+const WINDOW = 86400;
+const plan = (rand: () => number) => planSchedule(fixture(), { windowSec: WINDOW, groupBy: (s) => s.kind, rand });
+type Plan = ReturnType<typeof plan>;
+
+describe('planSchedule', () => {
+  test('every item appears exactly once', () => {
+    const out = plan(seeded(1));
+    expect(out).toHaveLength(61);
+    const ids = out.map((s) => s.item.id).sort();
+    expect(new Set(ids).size).toBe(61);
+  });
+
+  test('all offsets fall within the window and the result is time-ordered', () => {
+    const out = plan(seeded(2));
+    for (const s of out) {
+      expect(s.atSec).toBeGreaterThanOrEqual(0);
+      expect(s.atSec).toBeLessThan(WINDOW);
+    }
+    const times = out.map((s) => s.atSec);
+    expect(times).toEqual([...times].sort((a, b) => a - b));
+  });
+
+  test('each booking system is spread evenly across the whole window', () => {
+    const out = plan(seeded(3));
+    for (const kind of ['rec', 'wa']) {
+      const times = out.filter((s) => s.item.kind === kind).map((s) => s.atSec);
+      const firstHalf = times.filter((t) => t < WINDOW / 2).length;
+      // Even spread → roughly half the system's requests in each half of the day.
+      expect(Math.abs(firstHalf - times.length / 2)).toBeLessThanOrEqual(2);
+      // Coverage spans the window, not bunched in one corner.
+      expect(Math.min(...times)).toBeLessThan(WINDOW * 0.1);
+      expect(Math.max(...times)).toBeGreaterThan(WINDOW * 0.9);
+    }
+  });
+
+  test('systems are interleaved — no long single-system run', () => {
+    const out = plan(seeded(4));
+    let run = 1;
+    let maxRun = 1;
+    for (let i = 1; i < out.length; i++) {
+      run = out[i].item.kind === out[i - 1].item.kind ? run + 1 : 1;
+      maxRun = Math.max(maxRun, run);
+    }
+    // The old index-order plan had a run of 39. Interleaving keeps it short.
+    expect(maxRun).toBeLessThanOrEqual(5);
+  });
+
+  test('different runs produce different timing (no fixed daily pattern)', () => {
+    const a = plan(seeded(10));
+    const b = plan(seeded(20));
+    const at = (out: Plan, id: string) => out.find((s) => s.item.id === id)!.atSec;
+    // The same site is collected at a materially different time across runs.
+    const shifts = fixture().filter((_, i) => i % 7 === 0).map((s) => Math.abs(at(a, s.id) - at(b, s.id)));
+    expect(Math.max(...shifts)).toBeGreaterThan(600);
+  });
+
+  test('same seed is deterministic (replay-safe inside a Workflow step)', () => {
+    expect(plan(seeded(42))).toEqual(plan(seeded(42)));
+  });
+
+  test('scales: a larger fleet stays evenly spread', () => {
+    const big = [];
+    for (let i = 0; i < 500; i++) big.push({ id: `r${i}`, kind: 'rec' });
+    const out = planSchedule(big, { windowSec: WINDOW, groupBy: (s) => s.kind, rand: seeded(7) });
+    const times = out.map((s) => s.atSec);
+    // ~one per slot of width 86400/500 ≈ 173s; gaps stay bounded, never a burst.
+    let maxGap = 0;
+    for (let i = 1; i < times.length; i++) maxGap = Math.max(maxGap, times[i] - times[i - 1]);
+    expect(maxGap).toBeLessThan(WINDOW / 100);
+  });
+
+  test('windowSec <= 0 collapses to an immediate, unpaced run', () => {
+    const out = planSchedule(fixture(), { windowSec: 0, groupBy: (s) => s.kind, rand: seeded(5) });
+    expect(out).toHaveLength(61);
+    expect(out.every((s) => s.atSec === 0)).toBe(true);
+  });
+});

--- a/backend/src/schedule.ts
+++ b/backend/src/schedule.ts
@@ -1,0 +1,79 @@
+/**
+ * Collection schedule generation — plan a highly distributed request pattern.
+ *
+ * Goals:
+ *  1. Spread each booking system's requests EVENLY across the whole window so no
+ *     single host sees a burst. Each system gets its own cadence (windowSec / N),
+ *     independent of how many sites other systems have.
+ *  2. INTERLEAVE systems in time so requests don't arrive in per-agency blocks —
+ *     a rec.gov call, then a goingtocamp call, then rec.gov, etc.
+ *  3. Avoid an identifiable day-to-day pattern: which site lands in which time
+ *     slot is reshuffled every run, and the offset within each slot is jittered,
+ *     so a given site is never collected at the same time two days running.
+ *  4. Scale: generic over the grouping key, so adding campsites (or a whole new
+ *     booking system) just reshapes the cadence — no code change.
+ *
+ * The function is pure (randomness is injected) so it can run inside a Workflow
+ * `step.do` (its output is persisted → replay-safe) and be unit-tested with a
+ * seeded PRNG.
+ */
+
+export type Scheduled<T> = { item: T; atSec: number };
+
+/** Fisher–Yates shuffle into a new array, using the injected `rand`. */
+function shuffle<T>(arr: T[], rand: () => number): T[] {
+  const a = arr.slice();
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+/**
+ * Plan when to collect each item within `[0, windowSec)`.
+ *
+ * Items are grouped by `groupBy` (the booking system / host). Each group of N
+ * items is laid over N equal slots of width `windowSec / N`; each item is placed
+ * at a uniformly-random offset inside its own slot. This guarantees exactly one
+ * request per slot — even coverage with no clustering — while the in-slot jitter
+ * plus a per-run reshuffle of the item→slot assignment make the timing vary
+ * every run. Groups are then merged and sorted by time, interleaving systems.
+ *
+ * @returns items paired with an absolute offset (seconds from window start),
+ *          ordered by that offset. `windowSec <= 0` returns every item at 0
+ *          (immediate, unpaced run) in randomized order.
+ */
+export function planSchedule<T>(
+  items: T[],
+  opts: { windowSec: number; groupBy: (item: T) => string; rand?: () => number },
+): Scheduled<T>[] {
+  const { windowSec, groupBy, rand = Math.random } = opts;
+
+  const groups = new Map<string, T[]>();
+  for (const item of items) {
+    const key = groupBy(item);
+    const g = groups.get(key);
+    if (g) g.push(item);
+    else groups.set(key, [item]);
+  }
+
+  const planned: Scheduled<T>[] = [];
+  for (const group of groups.values()) {
+    const n = group.length;
+    const slot = windowSec > 0 ? windowSec / n : 0;
+    // Reshuffle which site occupies which slot so per-site timing isn't fixed.
+    const order = shuffle(group, rand);
+    for (let i = 0; i < n; i++) {
+      // Uniform offset inside slot i → even spread, randomized within the slot.
+      const at = slot > 0 ? Math.min(windowSec - 1, Math.round((i + rand()) * slot)) : 0;
+      planned.push({ item: order[i], atSec: at });
+    }
+  }
+
+  // Shuffle before the stable sort so equal-time ties interleave across systems
+  // instead of falling back to group insertion order.
+  const merged = shuffle(planned, rand);
+  merged.sort((a, b) => a.atSec - b.atSec);
+  return merged;
+}

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -14,6 +14,7 @@
 import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:workers";
 import index from "./campsites-index.json";
 import { fetchAvailability, type Counts } from "./availability";
+import { planSchedule } from "./schedule";
 
 export interface WfEnv {
   RAW: R2Bucket;
@@ -32,19 +33,25 @@ export class CampsiteCollectorWorkflow extends WorkflowEntrypoint<WfEnv, { date:
     const { date, limit, windowSec = 3600 } = event.payload;
     const sites = limit ? (index as Site[]).slice(0, limit) : (index as Site[]);
 
-    // Pace the run across ~windowSec with per-gap jitter (±50%), planned once
-    // inside a step (Math.random → replay-safe). The cron passes 86400 to spread
-    // samples evenly over 24h; not a synchronized burst against the sources.
-    const gaps = await step.do('plan-schedule', async () => {
-      const base = sites.length > 1 ? windowSec / sites.length : 0;
-      return sites.map(() => Math.max(0, Math.round(base * (0.5 + Math.random()))));
-    });
+    // Plan a highly distributed schedule across ~windowSec: each booking system
+    // (site.kind) spread evenly over the whole window on its own cadence, systems
+    // interleaved in time, and the per-site timing reshuffled every run so no
+    // identifiable per-agency pattern emerges. Planned once inside a step
+    // (Math.random → persisted → replay-safe). The cron passes 86400 (24h).
+    const schedule = await step.do('plan-schedule', async () =>
+      planSchedule(sites, { windowSec, groupBy: (s) => s.kind }),
+    );
 
     let ok = 0;
     let failed = 0;
     let empty = 0;
-    for (let i = 0; i < sites.length; i++) {
-      const site = sites[i];
+    let prevAt = 0;
+    for (let i = 0; i < schedule.length; i++) {
+      const { item: site, atSec } = schedule[i];
+      // Sleep to this site's planned offset (delta from the previous one).
+      const wait = atSec - prevAt;
+      if (wait > 0) await step.sleep(`pace ${i}`, `${wait} seconds`);
+      prevAt = atSec;
       try {
         const r = await step.do(
           `collect ${site.id}`,
@@ -111,10 +118,6 @@ export class CampsiteCollectorWorkflow extends WorkflowEntrypoint<WfEnv, { date:
           return { id: site.id, failed: true, error: String((err as any)?.message ?? err) };
         });
         failed++;
-      }
-      // Jittered tick between sites — spreads the run across the window.
-      if (i < sites.length - 1 && gaps[i] > 0) {
-        await step.sleep(`pace ${i}`, `${gaps[i]} seconds`);
       }
     }
     // One row per run (cached → resume-safe). AE is sampled/at-least-once — fine.


### PR DESCRIPTION
## Summary

Replaces the collector's index-order jittered pacing with **`planSchedule`** (`backend/src/schedule.ts`) — a reusable, generic schedule generator that distributes requests so each agency booking system sees an even, interleaved, day-to-day-varying pattern that scales as campsites are added.

### Problem with the old pacing
`plan-schedule` jittered even gaps over sites **in index order**. Since the index lists all rec.gov sites first, then all goingtocamp, this clustered ~39 rec.gov requests into the front ~64% of the window and ~22 goingtocamp into the tail — every run, in the same order. An identifiable per-booking-system pattern.

### `planSchedule`
- **Per-system even spread** — group by booking system (`site.kind`); lay each group of N over N equal slots of width `windowSec/N`, one request per slot. No bursts; each system on its own cadence regardless of the others' size.
- **Interleaved** — merge groups and sort by time, so requests alternate across systems instead of arriving in per-agency blocks.
- **No fixed daily pattern** — the item→slot assignment is reshuffled and the in-slot offset jittered every run, so a site is never collected at the same time two days running.
- **Scales & generic** — adding campsites shrinks slots; a new booking system gets its own cadence with no code change. Pure (randomness injected) so it runs inside the replay-safe `plan-schedule` Workflow step.

### Changes
- `src/schedule.ts` — new `planSchedule` + Fisher–Yates shuffle.
- `src/workflows.ts` — collector now follows the planned (interleaved, reshuffled) order, sleeping to each site's absolute offset.
- `src/schedule.test.ts` — spread, interleave (max same-system run ≤ 5 vs old 39), day-to-day variation, determinism, scaling to 500 sites, `window=0`.
- `CAMPSITE-PLAN.md` §6b documents the method.

## Verification
- `tsc --noEmit` clean; **14 backend tests pass**; `wrangler deploy --dry-run` bundles clean.

## Deploy
Backend deploys manually (no CI auto-deploy): `cd backend && npm run deploy`. Not deployed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)