### PR TITLE
feat(collector): collect one site per wake (MAX_BATCH=1)

### DIFF
--- a/SCHEDULER-PLAN.md
+++ b/SCHEDULER-PLAN.md
@@ -73,7 +73,7 @@ This cron does **not** schedule collection — it only ensures the loop exists. 
 
 ## 6. Batching, fairness, failure
 
-- **Batch size:** with even-spread deadlines, ~1 site/wake. A `MAX_BATCH` cap (e.g. 8) guards against deadline pile-ups (e.g. right after a forced refresh-all); overflow just shortens the next sleep.
+- **One site per wake (`MAX_BATCH = 1`):** maximally distributed. In steady state only ~1 site is due per wake anyway, so this changes nothing there; it only affects transients — the cold-start prime and post-downtime pile-ups drip out one-at-a-time (paced by `MIN_SLEEP` ≈ 15s) instead of bursting. A full 140-site catch-up clears in ~35min, far inside the 2-day SLA, so there's no reason to collect more than one at once.
 - **Booking-system fairness:** tiny mixed batches mean no per-host bursts inherently. Deadlines are seeded interleaved across systems, and `± jitter` on each reschedule prevents lockstep — so the distribution property `planSchedule` gave us falls out *without* a fixed window.
 - **Failures:** a failed collection sets `due = now + RETRY_BACKOFF` (minutes), not `now + X`, so it's retried soon and never silently goes stale. `step.do` retries handle transient errors first; the deadline backoff is the outer safety net.
 

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -31,7 +31,11 @@ export const HEARTBEAT_KEY = "scheduler/heartbeat.json";
 
 // Loop tuning.
 const SLACK_MS = 30_000; // collect anything due within 30s of a wake
-const MAX_BATCH = 8; // cap collections per wake (guards deadline pile-ups)
+// Collect one site per wake — maximally distributed. In steady state only ~1
+// site is ever due per wake anyway; this also drips the cold-start prime and any
+// post-downtime pile-up out one-at-a-time (paced by MIN_SLEEP) instead of in a
+// burst. A full 140-site catch-up still clears in ~35min, far inside the SLA.
+const MAX_BATCH = 1;
 const MIN_SLEEP_MS = 15_000; // never busy-loop
 const MAX_SLEEP_MS = 6 * 60 * 60_000; // wake at least every 6h (heartbeat liveness)
 const RETRY_BACKOFF_MS = 10 * 60_000; // failed site retried soon, not a full X later


### PR DESCRIPTION
Per review: collecting up to 8 sites per wake was a premature optimization. In steady state only ~1 site is ever due per wake, so the cap never bound there. Setting `MAX_BATCH = 1` makes the **transients** (cold-start prime, post-downtime pile-up) maximally distributed — one-at-a-time, paced by `MIN_SLEEP` (~15s) — instead of a burst. A full 140-site catch-up still clears in ~35min, far inside the 2-day SLA.

No behavior change in steady state; doc §6 updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)