### PR TITLE
chore(collector): drop the liveness supervisor cron

### DIFF
--- a/SCHEDULER-PLAN.md
+++ b/SCHEDULER-PLAN.md
@@ -60,16 +60,15 @@ loop:
 
 This is exactly *"Workflow payload + R2-derived"*: the loop owns the live state; the heartbeat (written every wake) is the durable R2 snapshot the supervisor recovers from. No new bucket, KV, or DO.
 
-## 5. Liveness — tiny weekly supervisor
+## 5. Liveness — alert, don't auto-restart
 
-A self-looping Workflow could die on an uncaught error and stop silently. A minimal safety net:
+The loop self-perpetuates via continue-as-new, so the only failure mode is a hard crash (an uncaught error that skips continue-as-new). Rather than carry a cron+supervisor to auto-restart it, we **alert a human and let them restart**:
 
-- Each loop iteration writes a **heartbeat** (`{ instanceId, lastWakeMs }`) to a fixed R2 key (e.g. `scheduler/heartbeat.json`).
-- A **weekly cron** (`0 0 * * 1`) runs a ~10-line supervisor: read the heartbeat; if it's older than a threshold (e.g. > 1 day), start a fresh `CollectorLoop` (which R2-reconstructs `due[]`).
+- Each loop iteration writes a **heartbeat** (`{ instanceId, lastWakeMs, collectedTotal, due }`) to `scheduler/heartbeat.json` in R2.
+- **No cron.** Staleness is surfaced by **Grafana → Discord** alerting (separate observability repo): if the newest collection per site ages past the SLA (queried from the `campsite_collector` Analytics Engine dataset), it fires a Discord alert.
+- A human restarts with `POST /collect/start?force=1` (the `force` bypass is needed because a stale heartbeat can still read "alive" when no instance is actually running).
 
-This cron does **not** schedule collection — it only ensures the loop exists. One tick a week. (If you'd rather have zero crons, drop it and rely purely on continue-as-new.)
-
-**SLA caveat:** a weekly supervisor means a hard crash (uncaught error that skips continue-as-new) could go up to ~7 days before restart — looser than the 2-day staleness target. Continue-as-new makes such crashes rare, so weekly is cheap insurance; if you want the supervisor itself to uphold the SLA, tighten it to **daily** (`0 0 * * *`). Easy one-line change.
+This trades automatic recovery for a simpler system with no scheduling primitive at all — appropriate because continue-as-new makes crashes rare, and a stalled collector is a human-noticed event, not a silent one.
 
 ## 6. Batching, fairness, failure
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -50,12 +50,15 @@ app.get('/campsites', async (c) => {
   return c.json(list.keys.map((k) => k.name));
 });
 
-// Start the deadline-driven collector loop (no-op if one is already alive).
+// Start the deadline-driven collector loop. No-op if a fresh heartbeat shows one
+// already alive, unless ?force=1 (use after a crash/terminate, e.g. in response to
+// a staleness alert — the heartbeat can read "alive" even when no instance runs).
 app.post('/collect/start', async (c) => {
+  const force = c.req.query('force') === '1';
   const { alive, hb } = await loopAlive(c.env);
-  if (alive) return c.json({ status: 'already-running', lastWakeISO: hb?.lastWakeISO });
+  if (alive && !force) return c.json({ status: 'already-running', lastWakeISO: hb?.lastWakeISO });
   const i = await c.env.COLLECTOR_WF.create({ params: {} });
-  return c.json({ status: 'started', instanceId: i.id });
+  return c.json({ status: 'started', instanceId: i.id, forced: force });
 });
 
 // Freshness/observability snapshot (the loop's heartbeat).
@@ -100,16 +103,7 @@ app.post('/watch', async (c) => {
   return c.json({ workflow: 'campsite-hot-date-watch', instanceId: i.id, watching: site.name, targetDate: date, every });
 });
 
-export default {
-  fetch: app.fetch,
-  // Weekly liveness supervisor — NOT a collection schedule. It only restarts the
-  // self-scheduling CollectorLoop if its heartbeat shows it has died.
-  async scheduled(event: ScheduledEvent, env: Bindings, ctx: ExecutionContext) {
-    ctx.waitUntil(
-      (async () => {
-        const { alive } = await loopAlive(env);
-        if (!alive) await env.COLLECTOR_WF.create({ params: {} });
-      })(),
-    );
-  },
-};
+// No scheduled() handler / cron. The CollectorLoop self-perpetuates via
+// continue-as-new; staleness is surfaced by Grafana → Discord alerting (see the
+// observability repo), and a human restarts with POST /collect/start?force=1.
+export default { fetch: app.fetch };

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -47,10 +47,9 @@ dataset = "campsite_watch"
 # The one knob: every campsite is refreshed within this many days. No fixed schedule.
 MAX_STALENESS_DAYS = "2"
 
-[triggers]
-# Weekly LIVENESS supervisor — not a collection schedule. Restarts the
-# self-scheduling CollectorLoop only if its heartbeat shows it has died.
-crons = ["0 0 * * 1"]
+# No cron. The CollectorLoop self-perpetuates via continue-as-new; a hard crash
+# is surfaced by Grafana → Discord staleness alerting (observability repo), and a
+# human restarts it with POST /collect/start?force=1.
 
 # Deadline-driven durable collector loop (self-schedules via step.sleep,
 # continues-as-new to bound history).


### PR DESCRIPTION
Removes the weekly supervisor cron entirely. The `CollectorLoop` self-perpetuates via continue-as-new, so the only failure mode is a hard crash — and instead of auto-restarting it, we **alert a human** (next PR: Grafana → Discord staleness alert) who restarts with `POST /collect/start?force=1`.

- `wrangler.toml`: remove `[triggers]`/`crons` — **no cron at all** now.
- `index.ts`: drop the `scheduled()` supervisor; add `?force=1` to `/collect/start` (needed because a stale heartbeat can read "alive" when no instance is actually running — hit this during the last restart).
- `SCHEDULER-PLAN.md` §5 rewritten: *alert, don't auto-restart*.

Pairs with a separate observability PR that wires the Discord staleness alert off the `campsite_collector` Analytics Engine dataset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)