### PR TITLE
feat(collector): inactive status, DLQ quarantine & exponential backoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,85 @@ The Robot Geographical Society is built on a modern, serverless stack designed f
 ### Backend & Infrastructure
 - **[Hono](https://hono.dev/)**: Small, fast, web framework built on Web Standards.
 - **[Cloudflare Workers](https://developers.cloudflare.com/workers/)**: Serverless execution environment for the backend API.
+- **[Cloudflare Workflows](https://developers.cloudflare.com/workflows/)**: Durable execution for the deadline-driven availability collector (`CollectorLoop`).
 - **[Cloudflare KV](https://developers.cloudflare.com/kv/)**: Low-latency, key-value data store for campsite metadata and reservation details.
+- **[Cloudflare R2](https://developers.cloudflare.com/r2/)**: Object store for collected availability snapshots, the collector heartbeat, and the dead-letter queue.
+- **[Workers Analytics Engine](https://developers.cloudflare.com/analytics/analytics-engine/)**: Time-series event sink for per-collection telemetry, queried by Grafana.
 
 ### Testing & Quality
 - **[Playwright](https://playwright.dev/)**: End-to-end and integration testing framework.
 - **[Vitest](https://vitest.dev/)**: Vite-native unit testing framework for components and API logic.
 - **[ESLint](https://eslint.org/)**: Pluggable JavaScript linting for code quality.
+
+## Collector Architecture
+
+The **availability collector** keeps each tracked campsite's reservation data fresh. It is a single durable Cloudflare Workflow (`CollectorLoop`) that self-schedules around one guarantee: **every campsite is refreshed within `MAX_STALENESS_DAYS` (default 2)** — no fixed cron. Each site carries a freshness deadline; every wake the loop collects only the sites whose deadline has arrived, reschedules them, writes a heartbeat, and sleeps until the next-earliest deadline. State rides in the Workflow payload and is periodically handed to a fresh instance via *continue-as-new* to bound step history; the R2 heartbeat is the recovery snapshot. See [`SCHEDULER-PLAN.md`](./SCHEDULER-PLAN.md).
+
+**Failure handling.** A failed collection backs off **exponentially** (10m → 20m → 40m …) so a transient upstream blip is retried progressively later instead of on a fixed cadence. After `INACTIVE_AFTER_FAILURES` (default 5) consecutive failures a site is **quarantined**: removed from the schedule, written to the **dead-letter queue** (`dlq/<id>.json` in R2), and emitted as an `inactive` state change. A daily **probe** re-tests quarantined sites; one success (or `POST /collect/reactivate?id=`) emits `reactivated` and resumes collection. This keeps a permanently-dead site from dominating the failure rate — the signal a healthy fleet is measured against.
+
+```mermaid
+flowchart TB
+  subgraph UP["Upstream booking systems"]
+    REC["recreation.gov API"]
+    WA["WA goingtocamp API"]
+  end
+
+  subgraph CF["Cloudflare Worker — robot-geographical-society-backend"]
+    direction TB
+    API["Hono HTTP API<br/>/collect/start · /scheduler/status<br/>/collect/site · /collect/dlq · /collect/reactivate · /watch"]
+
+    subgraph LOOP["CollectorLoop — durable, self-scheduling Workflow"]
+      direction TB
+      PLAN["plan wake<br/>select due sites · read DLQ · reconcile"]
+      COLLECT{"collect site<br/>(step.do, 3 retries)"}
+      OKP["ok → deadline = now + X ± jitter<br/>reset failure count"]
+      FAILP["fail → failures++<br/>exponential backoff (10m·20m·40m…)"]
+      QUAR["failures ≥ INACTIVE_AFTER_FAILURES<br/>→ quarantine (inactive)"]
+      PROBE["daily probe of inactive sites<br/>success → reactivated"]
+      HB["heartbeat + sleep to next deadline<br/>→ continue-as-new"]
+    end
+
+    R2[("R2 campsite-raw<br/>raw/ · summary/ · sites/<br/>dlq/&lt;id&gt;.json<br/>scheduler/heartbeat.json")]
+    AE[("Analytics Engine — campsite_collector<br/>status: ok · failed · inactive · reactivated")]
+  end
+
+  subgraph OBS["Observability — Mac mini (private observability repo)"]
+    ING["R2 → InfluxDB ingest<br/>(launchd, 07:30 daily)"]
+    INFLUX[("InfluxDB · campsites")]
+    GRAF["Grafana<br/>Collector History dashboard"]
+    DISC["Discord #alerts"]
+  end
+
+  REC --> COLLECT
+  WA --> COLLECT
+  API --> LOOP
+  PLAN --> COLLECT
+  COLLECT -->|ok| OKP
+  COLLECT -->|error| FAILP
+  FAILP --> QUAR
+  COLLECT -->|"raw / summary / sites"| R2
+  QUAR -->|"write dlq/"| R2
+  QUAR --> PROBE
+  PROBE -->|success| OKP
+  OKP --> HB
+  FAILP --> HB
+  PROBE --> HB
+  COLLECT --> AE
+  QUAR --> AE
+  PROBE --> AE
+  API -.->|"reactivate deletes dlq entry"| R2
+  R2 --> ING --> INFLUX --> GRAF
+  AE --> GRAF
+  GRAF -->|"failure ratio >25% · site quarantined · stale 34h"| DISC
+```
+
+**Storage & telemetry.** Each successful collection writes three R2 objects (`raw/` upstream payload, `summary/` campground aggregate, `sites/` per-individual-site breakdown) and a `campsite_collector` Analytics Engine row. The Mac-side ingest pulls the daily `summary/` snapshots into InfluxDB; Grafana's **Collector History** dashboard reads both InfluxDB (freshness) and the Analytics Engine (run history, failure ratio, quarantine state) and routes three alerts to Discord:
+
+| Alert | Condition | Meaning |
+|---|---|---|
+| Failure ratio high | failed ÷ attempts > 25% over 6h | a collector-wide problem, not one site |
+| Site quarantined | any `inactive` event in 20m | a campground dropped out of collection |
+| Collector stale | no snapshot in InfluxDB for 34h | the loop (or the daily ingest) has stalled |
 
 ## CI/CD & Testing Strategy
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import campsites from './campsites-index.json';
-import { collectSite, HEARTBEAT_KEY, type WfEnv } from './workflows';
+import { collectSite, HEARTBEAT_KEY, DLQ_PREFIX, listDlqIds, type WfEnv, type DlqEntry } from './workflows';
 
 // Cloudflare Workflows must be exported from the entry module by class name.
 export { CollectorLoop, HotDateWatchWorkflow } from './workflows';
@@ -73,8 +73,32 @@ app.get('/scheduler/status', async (c) => {
     ageSeconds: Math.round((now - hb.lastWakeMs) / 1000),
     collectedTotal: hb.collectedTotal,
     sites: hb.sites,
+    inactive: hb.inactive ?? 0,
     overdue: dueVals.filter((d) => d <= now).length,
   });
+});
+
+// The dead-letter queue: sites quarantined after too many consecutive failures.
+// Each entry is dlq/<id>.json in R2 (the source of truth for "inactive").
+app.get('/collect/dlq', async (c) => {
+  const list = await c.env.RAW.list({ prefix: DLQ_PREFIX });
+  const entries = await Promise.all(
+    list.objects.map(async (o) => (await c.env.RAW.get(o.key))?.json<DlqEntry>()),
+  );
+  const dlq = entries.filter(Boolean) as DlqEntry[];
+  return c.json({ count: dlq.length, sites: dlq.sort((a, b) => b.since - a.since) });
+});
+
+// Reactivate a quarantined site: drop its DLQ entry. The CollectorLoop reconciles
+// against the DLQ each wake, so the site is re-armed for collection on the next
+// wake (or sooner via the daily probe). No-op-safe if the id isn't quarantined.
+app.post('/collect/reactivate', async (c) => {
+  const id = c.req.query('id');
+  if (!id) return c.json({ error: 'need ?id=<campsite id>' }, 400);
+  const key = `${DLQ_PREFIX}${id}.json`;
+  const existed = (await c.env.RAW.head(key)) !== null;
+  await c.env.RAW.delete(key);
+  return c.json({ status: existed ? 'reactivated' : 'not-quarantined', id });
 });
 
 // Ad-hoc one-shot collection of a single campsite (backfill/debug) — independent

--- a/backend/src/scheduler.test.ts
+++ b/backend/src/scheduler.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, describe } from 'vitest';
-import { interleaveBySystem, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs } from './scheduler';
+import { interleaveBySystem, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs, retryBackoffMs } from './scheduler';
 
 const X = 2 * 86_400_000; // 2 days in ms
 const NOW = 1_700_000_000_000;
@@ -86,5 +86,54 @@ describe('jitterMs', () => {
     const resched = NOW + X + jitterMs('rec-7');
     expect(resched - NOW).toBeLessThanOrEqual(X + 30 * 60_000);
     expect(resched - NOW).toBeGreaterThanOrEqual(X - 30 * 60_000);
+  });
+});
+
+describe('retryBackoffMs (exponential)', () => {
+  const BASE = 10 * 60_000; // 10 min
+  const CAP = 6 * 3600_000; // 6 h
+
+  test('doubles per consecutive failure', () => {
+    expect(retryBackoffMs(1, BASE, CAP)).toBe(BASE); // 10m
+    expect(retryBackoffMs(2, BASE, CAP)).toBe(2 * BASE); // 20m
+    expect(retryBackoffMs(3, BASE, CAP)).toBe(4 * BASE); // 40m
+    expect(retryBackoffMs(4, BASE, CAP)).toBe(8 * BASE); // 80m
+  });
+
+  test('clamps at the cap and never overflows for large counts', () => {
+    expect(retryBackoffMs(99, BASE, CAP)).toBe(CAP);
+    expect(retryBackoffMs(1000, BASE, CAP)).toBe(CAP);
+    expect(Number.isFinite(retryBackoffMs(1000, BASE, CAP))).toBe(true);
+  });
+
+  test('treats fails<1 as the first attempt', () => {
+    expect(retryBackoffMs(0, BASE, CAP)).toBe(BASE);
+  });
+});
+
+describe('inactive-aware scheduling', () => {
+  const inactive = new Set(['rec-3', 'wa-7']);
+
+  test('seedDue excludes quarantined sites from the due map', () => {
+    const due = seedDue(fleet(), X, NOW, 8, inactive);
+    expect(Object.keys(due)).toHaveLength(138);
+    expect(due['rec-3']).toBeUndefined();
+    expect(due['wa-7']).toBeUndefined();
+  });
+
+  test('mergeDue never resurrects a quarantined site, even if it had a prior deadline', () => {
+    const prev = { 'rec-3': NOW + 500, 'rec-0': NOW + 999 };
+    const due = mergeDue(prev, fleet(), X, NOW, inactive);
+    expect(due['rec-3']).toBeUndefined(); // quarantined → dropped despite prev deadline
+    expect(due['rec-0']).toBe(NOW + 999); // active known site kept
+  });
+
+  test('selectDue ignores sites absent from due (not treated as infinitely overdue)', () => {
+    // wa-7 is in the fleet but not in due (quarantined) → must never be selected.
+    const due = seedDue(fleet(), X, NOW, 140, inactive); // all active sites due now
+    const picked = selectDue(due, fleet(), NOW, 30_000, 140);
+    expect(picked).not.toContain('wa-7');
+    expect(picked).not.toContain('rec-3');
+    expect(picked).toHaveLength(138);
   });
 });

--- a/backend/src/scheduler.ts
+++ b/backend/src/scheduler.ts
@@ -12,7 +12,22 @@
  */
 
 export type DueMap = Record<string, number>; // siteId → epoch ms deadline
+export type FailMap = Record<string, number>; // siteId → consecutive failure count
 type S = { id: string; kind: string };
+
+/**
+ * Exponential retry delay for a site that has failed `fails` times in a row
+ * (fails ≥ 1): baseMs, 2·baseMs, 4·baseMs … capped at capMs. A transient outage
+ * that recovers within an hour or so is retried progressively later instead of
+ * being hammered on a fixed cadence, so a single broken site can never make up a
+ * large share of collection attempts. The caller adds ±jitter to avoid lockstep.
+ */
+export function retryBackoffMs(fails: number, baseMs: number, capMs: number): number {
+  const n = Math.max(1, fails);
+  // 2^(n-1) without overflow at large n: clamp the exponent, then cap the result.
+  const factor = n - 1 >= 30 ? Infinity : 2 ** (n - 1);
+  return Math.min(capMs, baseMs * factor);
+}
 
 export function hashStr(s: string): number {
   let h = 2166136261 >>> 0;
@@ -50,8 +65,8 @@ export function interleaveBySystem<T extends S>(sites: T[]): T[] {
  * baseline), and spread the remainder uniformly across [now, now+X) so steady
  * state is evenly distributed and interleaved across systems.
  */
-export function seedDue<T extends S>(sites: T[], X: number, now: number, prime = 8): DueMap {
-  const order = interleaveBySystem(sites);
+export function seedDue<T extends S>(sites: T[], X: number, now: number, prime = 8, inactive?: Set<string>): DueMap {
+  const order = interleaveBySystem(activeOnly(sites, inactive));
   const due: DueMap = {};
   order.forEach((s, r) => {
     due[s.id] = r < prime ? now : now + Math.round((r / order.length) * X);
@@ -59,9 +74,13 @@ export function seedDue<T extends S>(sites: T[], X: number, now: number, prime =
   return due;
 }
 
-/** Recovery: keep deadlines for known sites; spread any new sites across [now, now+X). */
-export function mergeDue<T extends S>(prev: DueMap, sites: T[], X: number, now: number): DueMap {
-  const order = interleaveBySystem(sites);
+/**
+ * Recovery: keep deadlines for known sites; spread any new sites across [now, now+X).
+ * Inactive (quarantined) sites are excluded entirely — they live in the DLQ, not the
+ * due map, so a restart never resurrects a site we deliberately disabled.
+ */
+export function mergeDue<T extends S>(prev: DueMap, sites: T[], X: number, now: number, inactive?: Set<string>): DueMap {
+  const order = interleaveBySystem(activeOnly(sites, inactive));
   const due: DueMap = {};
   order.forEach((s, r) => {
     due[s.id] = s.id in prev ? prev[s.id] : now + Math.round((r / order.length) * X);
@@ -69,11 +88,20 @@ export function mergeDue<T extends S>(prev: DueMap, sites: T[], X: number, now: 
   return due;
 }
 
-/** Sites whose deadline is within `now + slackMs`, soonest-first, capped at maxBatch. */
+/** Drop quarantined sites from a fleet list. */
+function activeOnly<T extends S>(sites: T[], inactive?: Set<string>): T[] {
+  return inactive && inactive.size ? sites.filter((s) => !inactive.has(s.id)) : sites;
+}
+
+/**
+ * Sites whose deadline is within `now + slackMs`, soonest-first, capped at maxBatch.
+ * A site absent from `due` (e.g. quarantined) is never selected — absence is not
+ * "infinitely overdue".
+ */
 export function selectDue<T extends S>(due: DueMap, sites: T[], now: number, slackMs: number, maxBatch: number): string[] {
   return sites
-    .filter((s) => (due[s.id] ?? 0) <= now + slackMs)
-    .sort((a, b) => (due[a.id] ?? 0) - (due[b.id] ?? 0))
+    .filter((s) => due[s.id] !== undefined && due[s.id] <= now + slackMs)
+    .sort((a, b) => due[a.id] - due[b.id])
     .slice(0, maxBatch)
     .map((s) => s.id);
 }

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -13,12 +13,13 @@
 import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:workers";
 import index from "./campsites-index.json";
 import { fetchAvailability, type Counts } from "./availability";
-import { type DueMap, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs } from "./scheduler";
+import { type DueMap, type FailMap, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs, retryBackoffMs } from "./scheduler";
 
 export interface WfEnv {
   RAW: R2Bucket;
   COLLECTOR_WF: Workflow; // self-reference for continue-as-new
   MAX_STALENESS_DAYS?: string;
+  INACTIVE_AFTER_FAILURES?: string; // consecutive failures before a site is quarantined
   COLLECTOR_AE?: AnalyticsEngineDataset; // per-site coverage → Grafana
   RUNS_AE?: AnalyticsEngineDataset; // (kept for compatibility)
   AVAIL_AE?: AnalyticsEngineDataset; // per-site availability rollup
@@ -28,6 +29,7 @@ export interface WfEnv {
 type Site = { id: string; kind: "rec" | "wa"; ref: string | number; name: string; agency: string };
 
 export const HEARTBEAT_KEY = "scheduler/heartbeat.json";
+export const DLQ_PREFIX = "dlq/"; // dlq/<siteId>.json — presence == site is quarantined
 
 // Loop tuning.
 const SLACK_MS = 30_000; // collect anything due within 30s of a wake
@@ -38,9 +40,43 @@ const SLACK_MS = 30_000; // collect anything due within 30s of a wake
 const MAX_BATCH = 1;
 const MIN_SLEEP_MS = 15_000; // never busy-loop
 const MAX_SLEEP_MS = 6 * 60 * 60_000; // wake at least every 6h (heartbeat liveness)
-const RETRY_BACKOFF_MS = 10 * 60_000; // failed site retried soon, not a full X later
+// Failed sites back off exponentially: 10m, 20m, 40m … capped. A transient outage
+// that recovers within the hour is retried progressively later instead of on a
+// fixed cadence, so one broken site can't dominate the collection-attempt rate.
+const RETRY_BASE_MS = 10 * 60_000;
+const RETRY_CAP_MS = 6 * 60 * 60_000;
+const INACTIVE_AFTER_DEFAULT = 5; // consecutive failures → quarantine to the DLQ
+const PROBE_INTERVAL_MS = 24 * 60 * 60_000; // re-test a quarantined site ~once/day
 const ITER_BUDGET = 50; // wakes per instance before continue-as-new
 const PRIME = 8; // cold-start: collect this many immediately for a prompt baseline
+
+export type DlqEntry = {
+  id: string;
+  name: string;
+  agency: string;
+  kind: string;
+  since: number;
+  sinceISO: string;
+  failures: number;
+  lastError: string;
+};
+
+const dlqKey = (id: string) => `${DLQ_PREFIX}${id}.json`;
+
+/** The set of quarantined site ids — R2 is the source of truth (inspectable, durable). */
+export async function listDlqIds(env: WfEnv): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let cursor: string | undefined;
+  do {
+    const r: R2Objects = await env.RAW.list({ prefix: DLQ_PREFIX, cursor });
+    for (const o of r.objects) {
+      const id = o.key.slice(DLQ_PREFIX.length).replace(/\.json$/, "");
+      if (id) ids.add(id);
+    }
+    cursor = r.truncated ? r.cursor : undefined;
+  } while (cursor);
+  return ids;
+}
 
 // --- shared per-site collection (used by the loop and the ad-hoc endpoint) -----
 
@@ -76,21 +112,45 @@ export async function collectSite(env: WfEnv, site: Site, date: string) {
   return { id: site.id, dates: Object.keys(a.by).length };
 }
 
-async function bootstrapDue(env: WfEnv, sites: Site[], X: number, now: number): Promise<DueMap> {
+// siteId → next-probe epoch ms. Presence marks the loop's view that a site is
+// quarantined; the authoritative set is the DLQ in R2 (the two are reconciled
+// each wake, so deleting a dlq/<id>.json reactivates the site).
+type ProbeMap = Record<string, number>;
+
+async function bootstrap(
+  env: WfEnv,
+  sites: Site[],
+  X: number,
+  now: number,
+): Promise<{ due: DueMap; fails: FailMap; probe: ProbeMap }> {
+  const inactive = await listDlqIds(env);
   // Recovery: resume from the last heartbeat snapshot in R2 (seed any new sites).
   try {
     const hb = await env.RAW.get(HEARTBEAT_KEY);
     if (hb) {
       const j: any = await hb.json();
-      if (j?.due && typeof j.due === "object") return mergeDue(j.due, sites, X, now);
+      if (j?.due && typeof j.due === "object") {
+        const probe: ProbeMap = {};
+        for (const id of inactive) probe[id] = j.probe?.[id] ?? now + PROBE_INTERVAL_MS;
+        return { due: mergeDue(j.due, sites, X, now, inactive), fails: j.fails ?? {}, probe };
+      }
     }
   } catch {
     /* fall through to a cold seed */
   }
-  return seedDue(sites, X, now, PRIME);
+  const probe: ProbeMap = {};
+  for (const id of inactive) probe[id] = now + PROBE_INTERVAL_MS;
+  return { due: seedDue(sites, X, now, PRIME, inactive), fails: {}, probe };
 }
 
-async function writeHeartbeat(env: WfEnv, nowMs: number, collectedTotal: number, due: DueMap) {
+async function writeHeartbeat(
+  env: WfEnv,
+  nowMs: number,
+  collectedTotal: number,
+  due: DueMap,
+  fails: FailMap,
+  probe: ProbeMap,
+) {
   await env.RAW.put(
     HEARTBEAT_KEY,
     JSON.stringify({
@@ -98,34 +158,63 @@ async function writeHeartbeat(env: WfEnv, nowMs: number, collectedTotal: number,
       lastWakeISO: new Date(nowMs).toISOString(),
       collectedTotal,
       sites: Object.keys(due).length,
+      inactive: Object.keys(probe).length,
       dueWithinHour: Object.values(due).filter((d) => d <= nowMs + 3_600_000).length,
       due,
+      fails,
+      probe,
     }),
   );
 }
 
 // --- 1. Deadline-driven durable loop -------------------------------------------
 
-type LoopPayload = { due?: DueMap; collectedTotal?: number };
+type LoopPayload = { due?: DueMap; collectedTotal?: number; fails?: FailMap; probe?: ProbeMap };
 
 export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
   async run(event: WorkflowEvent<LoopPayload>, step: WorkflowStep) {
     const sites = index as Site[];
     const X = (Number(this.env.MAX_STALENESS_DAYS ?? "2") || 2) * 86_400_000;
+    const inactiveAfter = Math.max(1, Number(this.env.INACTIVE_AFTER_FAILURES ?? "") || INACTIVE_AFTER_DEFAULT);
+    const ae = this.env.COLLECTOR_AE;
+    const mark = (id: string, date: string, agency: string, kind: string, name: string, status: string, d1 = 0) =>
+      ae?.writeDataPoint({ indexes: [id], blobs: [date, agency, kind, name, status], doubles: [d1, 0] });
 
-    let due = event.payload?.due;
-    if (!due) due = await step.do("bootstrap", () => bootstrapDue(this.env, sites, X, Date.now()));
+    let { due, fails, probe } = event.payload?.due
+      ? { due: event.payload.due, fails: event.payload.fails ?? {}, probe: event.payload.probe ?? {} }
+      : await step.do("bootstrap", () => bootstrap(this.env, sites, X, Date.now()));
     let collectedTotal = event.payload?.collectedTotal ?? 0;
 
     for (let i = 0; i < ITER_BUDGET; i++) {
-      // Decide the due batch inside a step so `now`/selection are checkpointed.
+      // Decide the wake's work inside a step so `now`/selection/DLQ read are
+      // checkpointed (replay-safe). The DLQ list is authoritative for quarantine.
       const plan = await step.do(`plan-${i}`, async () => {
         const now = Date.now();
-        return { now, dueIds: selectDue(due!, sites, now, SLACK_MS, MAX_BATCH) };
+        return { now, inactiveIds: [...(await listDlqIds(this.env))], dueIds: selectDue(due, sites, now, SLACK_MS, MAX_BATCH) };
       });
-
       const date = new Date(plan.now).toISOString().slice(0, 10);
+      const inactiveSet = new Set(plan.inactiveIds);
+
+      // Reconcile loop state with the DLQ: a site we'd quarantined that's no longer
+      // in the DLQ was reactivated out-of-band (manual /collect/reactivate or a hand
+      // delete) → re-arm it now. Conversely adopt any externally-added quarantine.
+      for (const id of Object.keys(probe)) {
+        if (!inactiveSet.has(id)) {
+          const site = sites.find((s) => s.id === id);
+          delete probe[id];
+          fails[id] = 0;
+          due[id] = plan.now; // collect promptly to confirm recovery
+          if (site) await step.do(`reactivate-${i}-${id}`, async () => (mark(id, date, site.agency, site.kind, site.name, "reactivated"), { id }));
+        }
+      }
+      for (const id of inactiveSet) {
+        if (!(id in probe)) probe[id] = plan.now + PROBE_INTERVAL_MS;
+        delete due[id];
+      }
+
+      // Normal due collections (exponential backoff on failure; quarantine at the cap).
       for (const id of plan.dueIds) {
+        if (inactiveSet.has(id)) continue;
         const site = sites.find((s) => s.id === id)!;
         try {
           await step.do(
@@ -134,34 +223,70 @@ export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
             () => collectSite(this.env, site, date),
           );
           due[id] = plan.now + X + jitterMs(id);
+          fails[id] = 0;
           collectedTotal++;
         } catch (err) {
-          await step.do(`fail-${i}-${id}`, async () => {
-            this.env.COLLECTOR_AE?.writeDataPoint({
-              indexes: [site.id],
-              blobs: [date, site.agency, site.kind, site.name, "failed"],
-              doubles: [0, 0],
+          const n = (fails[id] ?? 0) + 1;
+          fails[id] = n;
+          const lastError = String((err as any)?.message ?? err);
+          if (n >= inactiveAfter) {
+            // Quarantine: stop collecting it, record to the DLQ, emit an "inactive"
+            // state change. A daily probe (and manual reactivation) can revive it.
+            await step.do(`inactive-${i}-${id}`, async () => {
+              const entry: DlqEntry = {
+                id, name: site.name, agency: site.agency, kind: site.kind,
+                since: plan.now, sinceISO: new Date(plan.now).toISOString(), failures: n, lastError,
+              };
+              await this.env.RAW.put(dlqKey(id), JSON.stringify(entry));
+              mark(id, date, site.agency, site.kind, site.name, "inactive", n);
+              return entry;
             });
-            return { id, error: String((err as any)?.message ?? err) };
-          });
-          due[id] = plan.now + RETRY_BACKOFF_MS; // retry soon, don't go a full X stale
+            delete due[id];
+            delete fails[id];
+            probe[id] = plan.now + PROBE_INTERVAL_MS;
+          } else {
+            await step.do(`fail-${i}-${id}`, async () => (mark(id, date, site.agency, site.kind, site.name, "failed"), { id, error: lastError, fails: n }));
+            due[id] = plan.now + retryBackoffMs(n, RETRY_BASE_MS, RETRY_CAP_MS) + jitterMs(id);
+          }
         }
       }
 
-      await step.do(`heartbeat-${i}`, () => writeHeartbeat(this.env, plan.now, collectedTotal, due!));
+      // At most one quarantined site re-tested per wake (cheap liveness probe).
+      const probeId = Object.keys(probe)
+        .filter((id) => probe[id] <= plan.now && !plan.dueIds.includes(id))
+        .sort((a, b) => probe[a] - probe[b])[0];
+      if (probeId) {
+        const site = sites.find((s) => s.id === probeId)!;
+        try {
+          await step.do(`probe-${i}-${probeId}`, { retries: { limit: 1, delay: "10 seconds", backoff: "constant" }, timeout: "2 minutes" }, () => collectSite(this.env, site, date));
+          await step.do(`probe-ok-${i}-${probeId}`, async () => {
+            await this.env.RAW.delete(dlqKey(probeId));
+            mark(probeId, date, site.agency, site.kind, site.name, "reactivated");
+            return { id: probeId };
+          });
+          delete probe[probeId];
+          fails[probeId] = 0;
+          due[probeId] = plan.now + X + jitterMs(probeId);
+          collectedTotal++;
+        } catch {
+          await step.do(`probe-fail-${i}-${probeId}`, async () => (mark(probeId, date, site.agency, site.kind, site.name, "failed"), { id: probeId }));
+          probe[probeId] = plan.now + PROBE_INTERVAL_MS;
+        }
+      }
 
-      const sleepMs = await step.do(`next-${i}`, async () =>
-        nextSleepMs(due!, Date.now(), MIN_SLEEP_MS, MAX_SLEEP_MS),
-      );
+      await step.do(`heartbeat-${i}`, () => writeHeartbeat(this.env, plan.now, collectedTotal, due, fails, probe));
+
+      // Wake at the soonest of any due deadline or probe time (disjoint key sets).
+      const sleepMs = await step.do(`next-${i}`, async () => nextSleepMs({ ...due, ...probe }, Date.now(), MIN_SLEEP_MS, MAX_SLEEP_MS));
       await step.sleep(`wait-${i}`, sleepMs);
     }
 
     // continue-as-new: hand the live state to a fresh instance, bounding history.
     await step.do("continue-as-new", async () => {
-      await this.env.COLLECTOR_WF.create({ params: { due, collectedTotal } });
+      await this.env.COLLECTOR_WF.create({ params: { due, collectedTotal, fails, probe } });
       return { handedOff: true };
     });
-    return { handedOff: true, sites: Object.keys(due).length, collectedTotal };
+    return { handedOff: true, sites: Object.keys(due).length, inactive: Object.keys(probe).length, collectedTotal };
   }
 }
 

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -17,8 +17,9 @@ bucket_name = "campsite-raw"
 
 # Per-run/per-site collector coverage → queried by the observability "Collector
 # history" Grafana dashboard via the AE SQL API. Schema:
-#   index=site.id  blob1=date blob2=agency blob3=kind blob4=name blob5=status(ok|failed)
-#   double1=datesCollected  double2=durationMs
+#   index=site.id  blob1=date blob2=agency blob3=kind blob4=name
+#   blob5=status(ok|failed|inactive|reactivated)  double1=datesCollected (or failure
+#   count on an "inactive" row)  double2=durationMs
 [[analytics_engine_datasets]]
 binding = "COLLECTOR_AE"
 dataset = "campsite_collector"
@@ -46,6 +47,14 @@ dataset = "campsite_watch"
 [vars]
 # The one knob: every campsite is refreshed within this many days. No fixed schedule.
 MAX_STALENESS_DAYS = "2"
+
+# Consecutive failures before a site is quarantined: removed from the schedule,
+# written to the DLQ (dlq/<id>.json in R2), and emitted as an "inactive" state
+# change in the campsite_collector AE dataset. Failed sites back off exponentially
+# (10m, 20m, 40m, …) until they reach this count, so a permanently-dead site stops
+# being retried instead of failing ~144×/day. A daily probe (or POST
+# /collect/reactivate?id=) can revive it.
+INACTIVE_AFTER_FAILURES = "5"
 
 # No cron. The CollectorLoop self-perpetuates via continue-as-new; a hard crash
 # is surfaced by Grafana → Discord staleness alerting (observability repo), and a


### PR DESCRIPTION
## Why

A failing collection previously retried on a **fixed 10-minute cadence forever**. Two recreation.gov campgrounds (Heart O' the Hills #247585, Buck Creek #232135) started returning HTTP 404 on 2026-05-31 and, retried ~144×/day each, produced **~290 failures / 2 days — more failures than successes**. Failing jobs should never be a large share of collections; that ratio is a system-health signal, so the fix makes failure handling self-limiting.

## What

- **Exponential retry backoff** (`scheduler.ts:retryBackoffMs`) — 10m → 20m → 40m … capped, keyed on consecutive failures. A transient outage that recovers within the hour is retried progressively later instead of hammered.
- **`inactive` status + DLQ quarantine** — after `INACTIVE_AFTER_FAILURES` (default **5**) consecutive failures, a site is removed from the schedule, written to the DLQ (`dlq/<id>.json` in R2 — the source of truth for "inactive"), and emitted as an `inactive` state change to the `campsite_collector` AE dataset.
- **Daily probe + reactivation** — quarantined sites are re-tested ~daily; success emits `reactivated` and resumes collection. The loop reconciles against the DLQ each wake, so `POST /collect/reactivate?id=` (or deleting the R2 object) revives a site.
- Quarantine-aware `seedDue`/`mergeDue`/`selectDue` — a restart never resurrects a disabled site; an absent deadline is no longer treated as overdue.
- New endpoints `GET /collect/dlq`, `POST /collect/reactivate`; `/scheduler/status` reports inactive count. New var `INACTIVE_AFTER_FAILURES`.
- README: **Collector Architecture** section + mermaid diagram.

## Observability (separate PR)

Dashboard graphs (failure ratio, inactive table, state changes) + Discord alerts (failure ratio >25%/6h, site quarantined) live in `tommyroar/observability-config#…`.

## Tests

22/22 pass, `tsc --noEmit` clean. Added coverage for backoff (doubling, cap, overflow) and inactive-aware scheduling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)