### PR TITLE
feat(collector): enrich WA campsite loops from the maps API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,25 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
   - `npm run build` — production build
 - **Campsite data:** `data/campsites.json` — GeoJSON FeatureCollection
 
+## Availability data (per-site, per-date)
+
+The collector (`backend/`) banks daily availability snapshots to the `campsite-raw` R2 bucket. Three objects per campground per collection day, **keyed by provider id** — rec.gov campground id (e.g. `233864`) or WA goingtocamp resourceLocation id (negative, e.g. `-2147483476`); **not** the `usfs/…`/`wa/…` slug from `campsites.json`:
+
+- `raw/<date>/<agency>/<id>.json` — untouched upstream payload (audit)
+- `summary/<date>/<id>.json` — campground rollup: `by_date → {available, reserved, total}`
+- `sites/<date>/<id>.json` — **per individual site**: `sites[siteId] → {label, loop, type, use, by_date}`, where `by_date["YYYY-MM-DD"]` is `"available" | "reserved" | "other"`
+
+"Remaining availability by site and date" is therefore a direct lookup in `sites/`. The `sites/` shape is normalized identically across rec.gov and WA. Caveats (verified against live R2, 2026-06):
+
+- **Daily granularity** — one status per night. Booking velocity = diff successive daily snapshots.
+- **Staleness ≤ ~2 days** — the collector refreshes one site per wake across the freshness window, so any one campground may be 1–2 days behind.
+- **WA leaves `type`/`use` null** (rec.gov populates them); `loop` is enriched from the goingtocamp maps API, `label` from the resources API.
+- **Window length varies by source** — seasonal USFS sites end at season close (~Sept); WA runs the full ~6 months forward.
+- **`"other"`** = neither bookable nor a confirmed reservation (not-yet-released / not-reservable); seen on rec.gov.
+- Quarantined sites live in `dlq/<id>.json` and stop collecting until reactivated.
+
+Collection owns → R2; the `observability` repo owns R2 → InfluxDB → Grafana. See `backend/README.md`.
+
 ## Jupyter Notebook (campsite data sync)
 
 The data sync notebook lives at `data/sync_campsites.ipynb` and runs via `uv` with the `data/` project.

--- a/backend/README.md
+++ b/backend/README.md
@@ -39,8 +39,31 @@ flowchart LR
 | `scheduled()` | cron trigger | create the daily collector workflow |
 | `CampsiteCollectorWorkflow` | Workflow `COLLECTOR_WF` | one `step.do` per site (per-step retry/resume) → R2 |
 | `HotDateWatchWorkflow` | Workflow `WATCH_WF` | adaptive `step.sleep` watch of one (site, date) → R2 `watch/` |
-| `RAW` | R2 `campsite-raw` | `raw/`, `summary/<date>/<id>.json`, `watch/<date>/<id>/<ts>.json` |
+| `RAW` | R2 `campsite-raw` | `raw/`, `summary/<date>/<id>.json`, `sites/<date>/<id>.json`, `watch/<date>/<id>/<ts>.json`, `dlq/<id>.json` |
 | `CAMPSITES` | KV | the campsite API |
+
+## R2 object layout
+
+Objects are **keyed by provider id** — rec.gov campground id (e.g. `233864`) or WA
+goingtocamp resourceLocation id (negative, e.g. `-2147483476`) — **not** the
+`usfs/…`/`wa/…` slug from `campsites.json`.
+
+| Prefix | Shape | Notes |
+|---|---|---|
+| `raw/<date>/<agency>/<id>.json` | untouched upstream payload | audit trail; two un-normalized schemas (rec.gov vs goingtocamp) |
+| `summary/<date>/<id>.json` | `{id,name,agency,kind, by_date: {date → {available,reserved,total}}}` | campground rollup; consumed by the Mac ingest |
+| `sites/<date>/<id>.json` | `{id,name,agency,kind,collected_date, sites: {siteId → {label,loop,type,use, by_date}}}` | **per individual site**; `by_date[date]` ∈ `available\|reserved\|other` |
+| `watch/<date>/<id>/<ts>.json` | dense adaptive watch point | hot-date burn-down |
+| `dlq/<id>.json` | quarantine marker | presence == site skipped until reactivated |
+
+`summary/` and `sites/` are normalized **identically across both providers** —
+read either through one code path keyed on `by_date[date]`. Verified against live
+R2 (2026-06); caveats for consumers:
+
+- **Daily granularity** for both sources — one status per night. (Booking velocity = diff successive daily `sites/` snapshots.)
+- **WA leaves `type`/`use` null** (rec.gov populates them). WA `loop` is enriched from the maps API (`map.localizedValues[0].title`); `label` from the resources API. Don't assume `type` is present.
+- **Window length varies**: seasonal USFS sites end at season close (~Sept); WA runs the full ~6 months forward.
+- **`"other"`** = neither bookable nor a confirmed reservation (not-yet-released / not-reservable); observed on rec.gov.
 
 ## Data flow — daily snapshot
 
@@ -58,7 +81,7 @@ sequenceDiagram
   loop step.do per site — durable, retried independently
     WF->>S: plain fetch availability (next 6 months)
     S-->>WF: JSON (per-site per-date status)
-    WF->>R2: PUT raw/<date>/<agency>/<id>.json + summary/<date>/<id>.json
+    WF->>R2: PUT raw/ + summary/<date>/<id>.json + sites/<date>/<id>.json
   end
   Note over M,G: later that morning (decoupled)
   M->>R2: GET summary/<date>/*

--- a/backend/src/availability.test.ts
+++ b/backend/src/availability.test.ts
@@ -69,7 +69,7 @@ describe('fetchWaAvailability daily granularity + labels', () => {
   test('produces per-night statuses keyed by date, with resolved site labels', async () => {
     const fetchMock = vi.fn(async (url: string) => {
       let body: unknown = {};
-      if (url.includes('/api/maps?')) body = [{ mapId: 111 }];
+      if (url.includes('/api/maps?')) body = [{ mapId: 111, localizedValues: [{ title: 'Overflow' }] }];
       else if (url.includes('/api/resourcelocation/resources')) body = { r1: { localizedValues: [{ name: 'A01' }] } };
       else if (url.includes('/api/availability/map'))
         // codes: 0=available, 1=reserved, 3=other → three consecutive nights
@@ -82,6 +82,8 @@ describe('fetchWaAvailability daily granularity + labels', () => {
 
     // Label resolved from /api/resourcelocation/resources.
     expect(bySite['r1'].label).toBe('A01');
+    // Loop enriched from the maps API (map.localizedValues[0].title).
+    expect(bySite['r1'].loop).toBe('Overflow');
     // Daily (not monthly) per-night statuses, one key per night.
     expect(bySite['r1'].by_date).toEqual({
       '2026-07-01': 'available',

--- a/backend/src/availability.ts
+++ b/backend/src/availability.ts
@@ -11,7 +11,7 @@ export type Counts = { available: number; reserved: number; total: number };
 export type ByDate = Record<string, Counts>;
 
 // Per-individual-campsite detail — preserved instead of collapsed into Counts.
-// `by_date` mirrors the aggregate's keys (daily for rec.gov, monthly for WA).
+// `by_date` mirrors the aggregate's keys (daily for both rec.gov and WA).
 export type SiteStatus = "available" | "reserved" | "other";
 export type PerSite = {
   label: string | null; // site number / loop label (e.g. "A012"); null until enriched (WA)
@@ -94,7 +94,14 @@ function addDaysISO(iso: string, n: number): string {
 export async function fetchWaAvailability(ref: number | string, months = 6, start = new Date()) {
   const base = "https://washington.goingtocamp.com";
   const maps = await getJson(`${base}/api/maps?resourceLocationId=${ref}&bookingCategoryId=0`, `${base}/`);
-  const mapIds = (Array.isArray(maps) ? maps : []).map((m: any) => m.mapId).filter(Boolean);
+  const mapsArr: any[] = Array.isArray(maps) ? maps : [];
+  const mapIds = mapsArr.map((m) => m.mapId).filter(Boolean);
+
+  // A "map" is a loop/area; its title is the loop name (e.g. "Overflow").
+  const loopByMapId: Record<string, string | null> = {};
+  for (const m of mapsArr) {
+    if (m?.mapId != null) loopByMapId[m.mapId] = m?.localizedValues?.[0]?.title ?? null;
+  }
 
   // Resolve per-resource site labels once per park (resourceId → site name, e.g. "A12").
   const labels: Record<string, string | null> = {};
@@ -121,7 +128,7 @@ export async function fetchWaAvailability(ref: number | string, months = 6, star
         raw[`${startISO}:${mapId}`] = data;
         for (const [rid, arr] of Object.entries<any>(data.resourceAvailabilities ?? {})) {
           if (!Array.isArray(arr) || !arr.length) continue;
-          const ps = (bySite[rid] ??= { label: labels[rid] ?? null, loop: null, type: null, use: null, by_date: {} });
+          const ps = (bySite[rid] ??= { label: labels[rid] ?? null, loop: loopByMapId[mapId] ?? null, type: null, use: null, by_date: {} });
           for (let i = 0; i < arr.length; i++) {
             const day = addDaysISO(startISO, i);
             if (day >= end) break; // boundary night belongs to the next month's query


### PR DESCRIPTION
## What

WA goingtocamp per-site availability records had `loop: null` while rec.gov populated it. The loop/area name was already present in the `/api/maps` response we fetch and then discard — each "map" is a loop, with `localizedValues[0].title` as its name (e.g. **"Overflow"**). This builds a `mapId → title` lookup and stamps it onto each site when recording availability.

**No new API calls** — purely uses data already in the pipeline. Not a static LUT (which would be brittle and redundant, since the source has it).

## Changes

- `backend/src/availability.ts` — build `loopByMapId` from the maps response; set `loop` (was hardcoded `null`). Fix stale comment: WA `by_date` is daily, not monthly.
- `backend/src/availability.test.ts` — extend WA mock with a map title; assert `loop === 'Overflow'`.
- `CLAUDE.md` / `backend/README.md` — document the per-site/per-date `sites/<date>/<id>.json` R2 dataset, full R2 object layout, cross-provider normalization, and caveats.

## Verification

- `npm run typecheck` — clean
- `npm test` — 22/22 pass (incl. new loop assertion)
- Confirmed live: Beacon Rock's `/api/maps` returns `title: "Overflow"` (desc *"Sites OF1-OF2, E1-E2"*)

## Notes

- Takes effect on the **next collection** per site — existing WA `sites/` objects keep `loop: null` until re-collected (≤2 days for active sites).
- Still null for WA: `type` / `use` (not in the maps API — would need the resources payload inspected separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)