### PR TITLE
chore: Make Every PR Read Like a Front Page — Anywhere Claude Runs

### DIFF
--- a/.github/pr-framework/PR_FRAMEWORK.md
+++ b/.github/pr-framework/PR_FRAMEWORK.md
@@ -1,0 +1,175 @@
+# PR Framework — the "Newspaper / Information-Pyramid" PR description
+
+> Canonical reference for **any agent** writing a GitHub pull-request description in
+> Tommy's workspaces. Read this before composing a PR body, then validate the body
+> with `validate_pr.py` (next to this file) before opening or updating the PR.
+
+## The one rule
+
+A PR description is **one single descriptive panel** — a newspaper front page that
+renders top-to-bottom as a self-contained *information pyramid*: the most newsworthy
+facts first, supporting detail below, fine print last. It reads cleanly on an **iPad
+mini portrait** at **1–2 pages** (up to 4 only for very complex code changes; see the
+length budget below), with no horizontal scroll.
+
+A reader who only sees the first screen should already understand **what changed, why,
+and the blast radius.** Everything below is progressive disclosure.
+
+## Information pyramid (top → bottom) — written like a Wired feature
+
+Voice: confident, present-tense, declarative editorial prose. Lead with the stakes, not
+the implementation. Use the magazine furniture below; keep it within the length budget.
+
+0. **Kicker** *(optional)* — one short rubric line above the headline, e.g.
+   `` `BACKEND` — **DESIGN DISPATCH** `` (≤ 48 chars). Sets the section/category.
+1. **Headline** — one `#` line: evocative but accurate (a real title, not "Update X").
+   **The PR title mirrors this headline, prefixed with the change type** from the
+   masthead — e.g. `docs: <headline>` — so it stays changelog/squash-friendly. The
+   on-push worker syncs it (`gh pr edit --title`) automatically on every rebuild.
+2. **Dek (standfirst)** — an *italic* `> _…_` blockquote, 1–2 sentences that set the
+   stakes. This is the lede panel and must stand alone. (A `> **TL;DR**` also counts.)
+3. **Masthead** — a `> [!NOTE]` strip: `area · type · risk · closes #N`
+   (drop `closes` if no issue).
+4. **Lede + Why** — a short narrative paragraph that hooks the reader and states the
+   problem/motivation. This is the opening of the article, not a bullet.
+5. **What changed** — scannable bullets, grouped. Punchy subheads (`## The bet:…`)
+   beat generic ones. Drop in a **pull quote** (`> _"…"_`) to highlight the key idea.
+6. **How it flows** — **mermaid diagram(s)** of any new or changed flow. Strongly
+   preferred over prose for control/data/state flow. Omit only if no flow changed
+   (and say so explicitly).
+7. **Screens & wireframes** — every available image, before/after, mockup. All with
+   alt text. Use `<img width>` to keep within the column; `<picture>` for light/dark.
+8. **Verification** — how it was tested (commands, screenshots, checks).
+9. **Risk & rollout** — the fine print: migrations, flags, rollback, follow-ups.
+
+Sections 4–9 are dropped only when genuinely empty; never pad. Order is fixed so every
+PR reads the same way.
+
+## Media is the priority
+
+- **Always** include available images, wireframes, and mockups — a PR that has visuals
+  and omits them fails the spirit of this framework.
+- **Prefer mermaid diagrams** for any new flow (sequence, flowchart, state, ER, class,
+  gantt). Text-described flows should be promoted to diagrams.
+- **Orient flow/graph diagrams vertically** (`flowchart TD` / top-down), not `LR` —
+  horizontal diagrams overflow the narrow iPad-mini portrait column. (Validator warns
+  on `LR`/`RL`.)
+- **Use a task list** (`- [ ]`) for checkpoints / multi-step plans, so progress is
+  trackable right in the PR.
+- Use GeoJSON/TopoJSON code blocks for geo changes; ASCII-STL for 3D where relevant.
+- Size images with `<img width="…">` so they never force horizontal scroll on a narrow
+  (≈680px content) column. Provide alt text on every image for readability and a11y.
+- **Private repos:** inline images only render if they are **user-attachments** (drag-
+  dropped into the web composer → `github.com/user-attachments/…`). A `raw.github
+  usercontent`/`blob?raw=true` URL to a committed file will **not** render (and the
+  auto-refresh can't mint attachment URLs). So on a private repo, **link** committed
+  figures by their `blob/<sha>/…` URL with a descriptive caption instead of embedding —
+  authenticated collaborators can open them. Public repos can embed normally.
+
+## The iPad-mini length budget (tiered)
+
+GitHub does not paginate, so length is a **rendered-height budget**, enforced by
+`validate_pr.py` (≈ **1000px** usable height per page, ≈ **80 chars/line**):
+
+- **Default: up to 2 pages** at a comfortable density. 1–2 pages is the target — don't
+  pad to fill, don't cram past it. The validator FAILs above the budget.
+- **Complex changes: up to 4 pages**, with **2× the rewrite token budget**.
+- **Complexity is measured on non-prose churn only.** Pure text/docs edits — `.md`,
+  `.markdown`, `.mdx`, `.txt`, `.rst`, `.org`, `.adoc`, including **Obsidian-vault
+  PRs** — do **not** count toward complexity. So a big docs/vault PR stays at the
+  2-page default and is kept tight; only substantial *code/structural* change
+  (> ~400 non-prose lines or > ~15 non-prose files) unlocks the 4-page tier.
+- The tier is decided by the on-push worker from the diff and passed to the validator
+  as `--max-pages` (env `PR_NEWSPAPER_MAX_PAGES`); manual runs default to 2.
+
+## Authoring checklist
+
+- [ ] Optional kicker line; one evocative `#` headline; an italic `> _dek_` under it.
+- [ ] `> [!NOTE]` masthead strip with area / type / risk / closes.
+- [ ] Wired voice: narrative lede, punchy subheads, a pull quote; confident + present-tense.
+- [ ] Pyramid order preserved (Why → What → Flow → Screens → Verification → Risk).
+- [ ] Every available image embedded, width-bounded, with alt text.
+- [ ] New/changed flows shown as mermaid (or an explicit "no flow change" note).
+- [ ] No heading-level skips (don't jump `#` → `###`).
+- [ ] Paragraphs short; no wall-of-text blocks.
+- [ ] `validate_pr.py` passes within the page budget (2 default; 4 for complex code).
+
+## Template
+
+Copy this, fill it, delete unused sections (don't leave empty headers):
+
+```markdown
+`<AREA>` — **<RUBRIC>**
+
+# <Evocative but accurate headline — a real title, not "Update X">
+
+> _<Dek: 1–2 italic sentences setting the stakes. Stands alone as the lede.>_
+
+> [!NOTE]
+> **<area>** · feat · risk: low · closes #000
+
+<Narrative lede: a short paragraph that hooks the reader and states the problem/why.>
+
+## <Punchy subhead for the core idea>
+- <Grouped, scannable bullets, one idea each.>
+
+> _"<Pull quote — the single line that captures the point.>"_
+
+## How it flows
+```mermaid
+flowchart TD
+  A[User] --> B{New gate}
+  B -->|ok| C[Result]
+  B -->|blocked| D[Error]
+```
+
+## Checkpoints
+- [ ] <Step one — independently shippable, with its acceptance gate.>
+- [ ] <Step two.>
+
+## Screens & wireframes
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="<dark-url>">
+  <img width="640" alt="<describe the screen>" src="<light-url>">
+</picture>
+
+## Verification
+- <Commands run / tests / manual checks, with outcomes.>
+
+## Risk & rollout
+- <Migrations, feature flags, rollback plan, follow-ups.>
+```
+
+## Rebuild policy — the newspaper is always regenerated, never patched
+
+The description is a living front page: it is **rebuilt from scratch**, never appended
+to. Two triggers force a full rebuild (`gh pr edit <n> --body-file …` + re-run
+`validate_pr.py`):
+
+1. **Every commit pushed to the PR branch.** After any push that adds commits to an
+   open PR, regenerate the entire newspaper from the *current full diff* (`base...head`),
+   so headline, panel, what-changed, flow diagrams, and screens always reflect the
+   complete change — not the latest commit alone. Refresh in place; do not add a
+   "Update:" section or a changelog of commits.
+
+2. **Readability feedback** (hard to read, doesn't fit, buries the lede, missing
+   visuals) → also a **full rebuild**, **not** a comment, reply, or append on the PR.
+
+Either way the body is edited in place and stays a single clean panel; it is never
+patched by accretion. After a force-push/rebase, regenerate the same way.
+
+`refresh_pr.sh` (next to this file) is the on-commit entry point: it regenerates the
+body, validates it, and edits the PR. Wire it into your push flow (e.g. a `pre-push`
+hook or `/dev` deploy step) so the refresh is automatic.
+
+## Usage
+
+```sh
+# Write the body to a file, then:
+python3 ~/.claude/pr-framework/validate_pr.py path/to/pr-body.md
+# or pipe:
+cat pr-body.md | python3 ~/.claude/pr-framework/validate_pr.py -
+# Then open / rebuild the PR:
+gh pr create  --body-file pr-body.md
+gh pr edit N  --body-file pr-body.md   # feedback → full rebuild, not a comment
+```

--- a/.github/pr-framework/README.md
+++ b/.github/pr-framework/README.md
@@ -1,0 +1,29 @@
+# PR newspaper framework (vendored)
+
+Portable copy of the "newspaper / information-pyramid" PR-description framework, so it
+travels with the repo and works anywhere Claude Code runs — **including claude.ai/code
+(web) and cloud agents**, which clone this repo but do **not** have a developer's local
+`~/.claude/` setup or git hooks.
+
+## Files
+- **`PR_FRAMEWORK.md`** — the rules, voice, and copy-paste template.
+- **`validate_pr.py`** — readability + length validator (no dependencies, stdlib only).
+
+## How any agent should use it
+1. Read `PR_FRAMEWORK.md` and write the PR body to a file.
+2. Validate: `python3 .github/pr-framework/validate_pr.py <body.md> [--max-pages N]`
+   (default 2 pages; 4 for very complex *code* changes).
+3. Apply: `gh pr edit <n> --body-file <body.md>` and set the title to the headline,
+   prefixed with the change type (e.g. `feat: <headline>`).
+4. **Regenerate the whole description from the full diff** on every push and on any
+   readability feedback — never append a comment or an "Update" section.
+
+## Local vs. web
+On a developer machine a global git pre-push hook (in `~/.claude/pr-framework/`)
+regenerates the description automatically. That hook does **not** run in web/cloud — there,
+follow the steps above by hand. A `pull_request` GitHub Action could automate it later
+(regenerate → validate → `gh pr edit`), gated on a Claude/Anthropic repo secret.
+
+## Note for this (private) repo
+Inline images only render from GitHub **user-attachments**, not from committed files.
+Link figures by their `blob/<sha>/…` URL with a caption instead of embedding.

--- a/.github/pr-framework/validate_pr.py
+++ b/.github/pr-framework/validate_pr.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""
+validate_pr.py — readability + iPad-mini length validator for PR descriptions.
+
+Enforces the "Newspaper / Information-Pyramid" PR framework (see PR_FRAMEWORK.md):
+a single descriptive panel at a comfortable density. Default budget is 2 iPad-mini
+pages; very complex *code* changes may use up to 4 (the caller passes --max-pages).
+
+Usage:
+    python3 validate_pr.py path/to/pr-body.md [--max-pages N]
+    cat pr-body.md | python3 validate_pr.py - [--max-pages N]
+    PR_NEWSPAPER_MAX_PAGES=4 python3 validate_pr.py body.md   # env also works
+
+Exit code 0 = PASS (possibly with warnings); 1 = FAIL (over budget / hard errors).
+"""
+
+import math
+import os
+import re
+import sys
+
+# --- Rendered-height model (iPad mini portrait, GitHub markdown column) ----------
+PAGE_PX = 1000          # usable content height per "page"
+COL_CHARS = 80          # approx characters per line in the content column
+LINE_PX = 24            # body line height
+H_PX = {1: 64, 2: 48, 3: 38, 4: 32, 5: 32, 6: 32}
+PARA_MARGIN = 16
+IMG_PX = 320            # assumed rendered height per image
+MERMAID_PX = 360        # assumed rendered height per diagram
+TABLE_ROW_PX = 36
+CODE_LINE_PX = 20
+CODE_PAD = 32
+WALL_OF_TEXT_LINES = 7  # a single paragraph taller than this warns
+
+MERMAID_KEYWORDS = (
+    "flowchart", "graph", "sequenceDiagram", "classDiagram", "stateDiagram",
+    "stateDiagram-v2", "erDiagram", "journey", "gantt", "pie", "mindmap",
+    "timeline", "gitGraph", "quadrantChart", "requirementDiagram", "C4Context",
+    "sankey-beta", "xychart-beta", "block-beta",
+)
+
+errors, warnings = [], []
+
+
+def wrapped_lines(text):
+    text = text.strip()
+    if not text:
+        return 0
+    return max(1, math.ceil(len(text) / COL_CHARS))
+
+
+def parse(md):
+    """Return (blocks, h1s, headings) where blocks are (kind, px, meta)."""
+    lines = md.split("\n")
+    blocks, h1s, headings = [], [], []
+    i, n = 0, len(lines)
+    para = []
+
+    def flush_para():
+        if para:
+            text = " ".join(p.strip() for p in para)
+            nlines = wrapped_lines(text)
+            blocks.append(("prose", nlines * LINE_PX + PARA_MARGIN,
+                           {"lines": nlines, "text": text}))
+            para.clear()
+
+    while i < n:
+        line = lines[i]
+        fence = re.match(r"^\s*```(\w*)", line)
+        if fence:
+            flush_para()
+            lang = fence.group(1).lower()
+            body, i = [], i + 1
+            while i < n and not re.match(r"^\s*```", lines[i]):
+                body.append(lines[i]); i += 1
+            i += 1  # closing fence
+            if lang == "mermaid":
+                first = next((b.strip() for b in body if b.strip()), "")
+                ok = first.startswith(MERMAID_KEYWORDS)
+                blocks.append(("mermaid", MERMAID_PX, {"first": first, "ok": ok}))
+            else:
+                long_line = max((len(b) for b in body), default=0)
+                blocks.append(("code", len(body) * CODE_LINE_PX + CODE_PAD,
+                               {"long": long_line, "lang": lang}))
+            continue
+
+        h = re.match(r"^(#{1,6})\s+(.*)", line)
+        if h:
+            flush_para()
+            level = len(h.group(1))
+            headings.append((level, h.group(2).strip(), len(blocks)))
+            if level == 1:
+                h1s.append(len(blocks))
+            blocks.append(("heading", H_PX[level], {"level": level,
+                                                     "text": h.group(2).strip()}))
+            i += 1
+            continue
+
+        # table: a line with >=2 pipes followed by a |---| separator
+        if "|" in line and i + 1 < n and re.match(r"^\s*\|?[\s:\-|]+\|", lines[i + 1]):
+            flush_para()
+            rows = 0
+            while i < n and "|" in lines[i]:
+                rows += 1; i += 1
+            blocks.append(("table", rows * TABLE_ROW_PX + 8, {"rows": rows}))
+            continue
+
+        # standalone image (markdown or html)
+        md_img = re.search(r"!\[(.*?)\]\((.*?)\)", line)
+        html_img = re.search(r"<img\b([^>]*)>", line, re.I)
+        if md_img or html_img:
+            flush_para()
+            if md_img:
+                alt = md_img.group(1).strip()
+                blocks.append(("image", IMG_PX,
+                               {"alt": alt, "width": True, "html": False}))
+            else:
+                attrs = html_img.group(1)
+                alt_m = re.search(r'alt\s*=\s*"([^"]*)"', attrs, re.I)
+                alt = alt_m.group(1).strip() if alt_m else ""
+                width = bool(re.search(r'width\s*=', attrs, re.I))
+                blocks.append(("image", IMG_PX,
+                               {"alt": alt, "width": width, "html": True}))
+            i += 1
+            continue
+
+        if line.strip() == "":
+            flush_para()
+            i += 1
+            continue
+
+        # blockquotes / list items / plain text all accrue as prose lines
+        if re.match(r"^\s*([>\-*+]|\d+\.)\s", line):
+            flush_para()
+            content = re.sub(r"^\s*([>\-*+]|\d+\.)\s", "", line)
+            nlines = wrapped_lines(content)
+            blocks.append(("prose", nlines * LINE_PX + 4,
+                           {"lines": nlines, "text": line.strip()}))
+            i += 1
+            continue
+
+        para.append(line)
+        i += 1
+
+    flush_para()
+    return blocks, h1s, headings
+
+
+def has_panel(md):
+    # The panel/lede may be an explicit TL;DR, or a Wired-style "dek" (standfirst): an
+    # emphasized blockquote that isn't a GitHub [!ALERT] masthead.
+    if re.search(r"^\s*>\s*\*\*TL;DR\*\*", md, re.M | re.I):
+        return True
+    if re.search(r"^\s*>.*tl;dr", md, re.M | re.I):
+        return True
+    for m in re.finditer(r"^\s*>\s*(?!\[!)(.+)$", md, re.M):
+        if re.search(r"(\*\*|__|_[^_]|\*[^*])", m.group(1)):  # bold or italic = a dek
+            return True
+    return False
+
+
+def has_masthead(md):
+    return bool(re.search(r"^\s*>\s*\[!(NOTE|TIP|IMPORTANT)\]", md, re.M))
+
+
+def main():
+    # Args: a file (or '-' for stdin), optional --max-pages N (env fallback, default 2).
+    max_pages = int(os.environ.get("PR_NEWSPAPER_MAX_PAGES", "2"))
+    src = None
+    argv, i = sys.argv[1:], 0
+    while i < len(argv):
+        if argv[i] == "--max-pages" and i + 1 < len(argv):
+            max_pages = int(argv[i + 1]); i += 2; continue
+        src = argv[i]; i += 1
+    if not src:
+        print("usage: validate_pr.py <file|-> [--max-pages N]"); return 2
+    md = sys.stdin.read() if src == "-" else open(src, encoding="utf-8").read()
+
+    blocks, h1s, headings = parse(md)
+
+    # --- structural checks ---
+    if len(h1s) == 0:
+        errors.append("No `#` headline — the panel needs a single H1 outcome line.")
+    elif len(h1s) > 1:
+        errors.append(f"{len(h1s)} H1 headings — a PR panel has exactly one headline.")
+    elif h1s[0] != 0:
+        # A single short "kicker"/rubric line above the headline is magazine style, OK.
+        kicker_ok = (h1s[0] == 1 and blocks[0][0] == "prose"
+                     and len(blocks[0][2].get("text", "")) <= 48)
+        if not kicker_ok:
+            warnings.append("H1 should lead (a single short kicker line above it is fine).")
+
+    if not has_panel(md):
+        errors.append("No `> **TL;DR**` panel — add the single descriptive lede "
+                      "blockquote under the headline.")
+    if not has_masthead(md):
+        warnings.append("No `> [!NOTE]` masthead strip (area · type · risk · closes #).")
+
+    # heading-skip check
+    prev = 0
+    for level, text, _ in headings:
+        if prev and level > prev + 1:
+            errors.append(f"Heading skip: jumped to H{level} ('{text}') after H{prev}.")
+        prev = level
+
+    # media / readability checks
+    n_img = n_mermaid = 0
+    for kind, _px, meta in blocks:
+        if kind == "image":
+            n_img += 1
+            if not meta["alt"]:
+                errors.append("Image without alt text — every image needs alt text.")
+            if meta["html"] and not meta["width"]:
+                warnings.append("<img> without width= may overflow the narrow column; "
+                                "add width=\"…\".")
+        elif kind == "mermaid":
+            n_mermaid += 1
+            if not meta["ok"]:
+                errors.append(f"Mermaid block doesn't start with a known diagram type "
+                              f"(got '{meta['first'][:30]}').")
+            elif re.match(r"(flowchart|graph)\s+(LR|RL)\b", meta["first"]):
+                warnings.append("Horizontal mermaid (LR/RL) overflows the narrow iPad-mini "
+                                "column — orient it vertically (`flowchart TD`).")
+        elif kind == "code" and meta["long"] > COL_CHARS + 20:
+            warnings.append(f"Code line {meta['long']} chars wide — risks horizontal "
+                            f"scroll on iPad mini.")
+        elif kind == "prose" and meta["lines"] > WALL_OF_TEXT_LINES:
+            warnings.append(f"Wall of text ({meta['lines']} lines): break it up — "
+                            f"\"{meta['text'][:40]}…\"")
+
+    if n_mermaid == 0 and not re.search(r"no\s+flow\s+change", md, re.I):
+        warnings.append("No mermaid diagram and no 'no flow change' note — model new "
+                        "flows as diagrams (preferred).")
+    if n_img == 0:
+        warnings.append("No images/wireframes embedded — include all available visuals.")
+
+    # --- length budget (tiered iPad-mini pages; default 2, complex code change up to 4) ---
+    total_px = sum(px for _k, px, _m in blocks)
+    prose_px = sum(px for k, px, _m in blocks if k in ("prose", "heading"))
+    pages = max(1, math.ceil(total_px / PAGE_PX))
+
+    if pages > max_pages:
+        errors.append(
+            f"~{pages} pages (~{total_px}px) exceeds the {max_pages}-page budget. "
+            f"Trim to fit; the 4-page tier is only for very complex *code* changes "
+            f"(pure text/docs churn doesn't qualify).")
+    elif pages == max_pages and max_pages == 2:
+        warnings.append(f"At the {max_pages}-page default — fine, but keep it dense, "
+                        f"not padded.")
+
+    # --- report ---
+    print("PR description readability report")
+    print("=" * 40)
+    print(f"  budget           : {max_pages} iPad-mini page(s)")
+    print(f"  estimated height : ~{total_px}px  (~{pages} page(s))")
+    print(f"  prose-only       : ~{prose_px}px")
+    print(f"  images           : {n_img}")
+    print(f"  mermaid diagrams : {n_mermaid}")
+    print(f"  headings         : {len(headings)}")
+    print()
+    for w in warnings:
+        print(f"  ⚠  {w}")
+    for e in errors:
+        print(f"  ✗  {e}")
+    print()
+    if errors:
+        print(f"FAIL — {len(errors)} error(s), {len(warnings)} warning(s). "
+              f"Rebuild the description, don't append.")
+        return 1
+    print(f"PASS — {pages}/{max_pages} page(s), {len(warnings)} warning(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,19 @@ The data sync notebook lives at `data/sync_campsites.ipynb` and runs via `uv` wi
 - **Password:** `booknote`
 - **Context:** See `data/NOTEBOOKS.md` for full details
 
+## Pull request descriptions
+
+PR descriptions follow the "newspaper / information-pyramid" framework vendored at
+**[`.github/pr-framework/`](.github/pr-framework/)** — a single Wired-style panel
+(kicker → headline → dek → masthead → narrative lede → punchy sections → vertical mermaid
+/ linked figures → checkpoint task list → verification → risk) that fits **1–2 iPad-mini
+pages** (4 for very complex code changes). Build the body to `PR_FRAMEWORK.md`, validate
+with `python3 .github/pr-framework/validate_pr.py <body.md>`, then `gh pr edit
+--body-file`. **Regenerate the whole description from the full diff** on every push and on
+readability feedback — never append. The PR **title mirrors the headline, prefixed with
+the change type** (e.g. `feat: …`). This repo is **private**, so link committed figures
+by their `blob/<sha>/…` URL rather than embedding (inline images need user-attachments).
+
 ## Development Protocol
 
 See **[ISSUES.md](./ISSUES.md)** for the full issue lifecycle protocol (workspace isolation, verification steps, PR process, and deployment).


### PR DESCRIPTION
`TOOLING` — **PROCESS**

# Make Every PR Read Like a Front Page — Anywhere Claude Runs

> _Vendors the "newspaper" PR-description framework into the repo so it travels with the clone — and works in Claude Code web/cloud, not just one laptop._

> [!NOTE]
> **tooling/pr-framework** · chore · risk: none · docs + a stdlib validator

PR descriptions here follow a single-panel, Wired-style "information pyramid." Until now that lived only in a developer's `~/.claude/`, invisible to claude.ai/code and cloud agents that just clone the repo. This moves the source of truth into `.github/pr-framework/`.

## What lands
- `.github/pr-framework/PR_FRAMEWORK.md` — rules, voice, and the copy-paste template.
- `.github/pr-framework/validate_pr.py` — stdlib readability + length validator.
- `.github/pr-framework/README.md` — how any agent (web/cloud/local) should use it.
- `CLAUDE.md` — a "Pull request descriptions" section pointing here.

> _"The framework is only real if it's in the repo."_

## How it's used
- [x] Read `PR_FRAMEWORK.md`, write the body, validate, `gh pr edit --body-file`.
- [x] Title mirrors the headline, prefixed with the change type.
- [ ] _(later)_ a `pull_request` Action to regenerate + validate automatically.

## Does it hold up?
- `python3 .github/pr-framework/validate_pr.py <body.md>` runs with no dependencies.
- This PR's own description was written to the framework and passes the validator.

## The fine print
- No runtime/app impact — docs + a dev tool under `.github/`.
- The local git-hook auto-refresh stays a personal convenience; web follows it by hand.
- Private repo, so any figures are linked by `blob/<sha>` URL, not embedded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)