### PR TITLE
fix: Stop launchd From Tripping Over `node`: a PATH-Proof Service Runner

### DIFF
--- a/scripts/service-runner.sh
+++ b/scripts/service-runner.sh
@@ -2,7 +2,10 @@
 # Robot Geographical Society - Service Runner for launchd
 
 # Ensure common brew/node paths are in PATH for launchd
-export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+NODE=/opt/homebrew/bin/node
+NPX=/opt/homebrew/bin/npx
 
 # Ensure we are in the project root
 cd "$(dirname "$0")/.."
@@ -10,17 +13,13 @@ PROJECT_ROOT=$(pwd)
 
 # Sync and Seed before starting
 echo "Syncing data..."
-node scripts/sync-geojson.js
+$NODE scripts/sync-geojson.js
 
 echo "Seeding KV..."
 cd backend
-node scripts/generate-seed.cjs
-npx wrangler kv bulk put kv-seed.json --binding CAMPSITES --local --preview false
+$NODE scripts/generate-seed.cjs
+$NPX wrangler kv bulk put kv-seed.json --binding CAMPSITES --local --preview false
 
 # Start both services in the foreground
 echo "Starting services..."
-npx concurrently \
-  --names "backend,frontend" \
-  --prefix-colors "magenta,cyan" \
-  "cd $PROJECT_ROOT/backend && npx wrangler dev --port 8787 --local --ip 0.0.0.0" \
-  "cd $PROJECT_ROOT/web && npx vite --port 5173 --host 0.0.0.0"
+$NPX concurrently --names "backend,frontend" --prefix-colors "magenta,cyan" "cd $PROJECT_ROOT/backend && $NPX wrangler dev --port 8787 --local --ip 0.0.0.0" "cd $PROJECT_ROOT/web && $NPX vite --port 5173 --host 0.0.0.0"


### PR DESCRIPTION
`DEV` — **INFRA FIX**

# Stop launchd From Tripping Over `node`: a PATH-Proof Service Runner

> _The local-dev LaunchAgent runs `service-runner.sh` with launchd's bare PATH, where `node`/`npx` aren't found. This pins absolute paths so sync, seed, and the dev stack start reliably._

> [!NOTE]
> **scripts/dev** · fix · risk: low · 1 file, local-dev only

`com.robot.geographical.society` (a macOS LaunchAgent) starts the local stack via `scripts/service-runner.sh`. launchd doesn't inherit your shell PATH, so bare `node`/`npx` silently fail and the services never come up.

## The fix
- Resolve `NODE=/opt/homebrew/bin/node`, `NPX=/opt/homebrew/bin/npx` and use them.
- Add `/opt/homebrew/sbin` to the exported PATH.
- No behavior change when run from an interactive shell.

> _"launchd starts with a minimal PATH — hardcode the tools it needs."_

## Does it hold up?
- `bash -n scripts/service-runner.sh` passes.
- Same script the plist already invokes; only PATH/binary resolution changed.

## The fine print
- Local development only — no app, collector, or Worker runtime impact.
- Mirrors the launchd/Nomad minimal-PATH gotcha noted in the workspace docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)