### PR TITLE
ci: adopt the shared PR-newspaper gate

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,49 @@
+<!--
+  PRs in Tommy's repos follow the "newspaper / information-pyramid" framework:
+  one self-contained front page that reads top-to-bottom on an iPad-mini portrait
+  display (1–2 pages; up to 4 for very complex *code* changes). Most newsworthy
+  facts first, supporting detail below, fine print last.
+
+  Full rules + voice: github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md
+  CI (the `pr-newspaper` workflow) validates this body — readability + page budget,
+  no model in the loop. An agent that opens/updates the PR regenerates the body
+  from the *full* diff; it is rebuilt from scratch, never appended to.
+
+  Fill the panel below and DELETE any section that is genuinely empty (don't leave
+  empty headers, and don't pad to fill the budget).
+-->
+
+`<AREA>` — **<RUBRIC>**
+
+# <Evocative but accurate headline — a real title, not "Update X">
+
+> _<Dek: 1–2 italic sentences setting the stakes. Stands alone as the lede.>_
+
+> [!NOTE]
+> **<area>** · feat · risk: low · closes #000
+
+<Narrative lede: a short paragraph that hooks the reader and states the problem / why.>
+
+## <Punchy subhead for the core idea>
+- <Grouped, scannable bullets, one idea each.>
+
+> _"<Pull quote — the single line that captures the point.>"_
+
+## How it flows
+```mermaid
+flowchart TD
+  A[Start] --> B{New gate}
+  B -->|ok| C[Result]
+  B -->|blocked| D[Error]
+```
+<!-- Omit only if no flow changed — and say so explicitly. Orient TD (top-down), not LR. -->
+
+## Screens & wireframes
+<!-- Every available image/wireframe/mockup, width-bounded, with alt text.
+     Private repo: link committed figures by blob URL (raw URLs don't render). -->
+
+## Verification
+- <Commands run / tests / manual checks, with outcomes.>
+
+## Risk & rollout
+- <Migrations, feature flags, rollback plan, follow-ups.>

--- a/.github/workflows/pr-newspaper.yml
+++ b/.github/workflows/pr-newspaper.yml
@@ -1,0 +1,10 @@
+name: PR newspaper
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+jobs:
+  newspaper:
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: tommyroar/pr-newspaper/.github/workflows/validate.yml@main

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,3 +66,11 @@ by their `blob/<sha>/…` URL rather than embedding (inline images need user-att
 ## Development Protocol
 
 See **[ISSUES.md](./ISSUES.md)** for the full issue lifecycle protocol (workspace isolation, verification steps, PR process, and deployment).
+## Pull requests — the "newspaper" framework
+
+PR descriptions follow the **newspaper / information-pyramid** format: one self-contained
+front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
+verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
+up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
+Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).


### PR DESCRIPTION
`CI` — **WORKFLOW DISPATCH**

# A newspaper gate for robot-geographical-society

> _PR descriptions here now validate against the shared newspaper framework — automatically, with no model in the loop._

> [!NOTE]
> **ci** · chore · risk: low

This wires `robot-geographical-society` into the account-wide PR "newspaper" framework. A small caller workflow invokes the shared reusable validator in `tommyroar/pr-newspaper`, which checks every PR body for readability and the iPad-mini page budget. Generation still happens once, by whoever opens the PR; this only enforces the shape.

## What changed
- `.github/workflows/pr-newspaper.yml` — calls the shared reusable `validate.yml` on opened/edited/reopened.
- `.github/pull_request_template.md` — vendored newspaper skeleton (private repo can't inherit the public default).
- A "newspaper" pointer added to `CLAUDE.md` so agents (incl. Claude Code web) follow the format.

## How it flows
```mermaid
flowchart TD
  A[PR opened/edited] --> B[caller workflow]
  B -->|uses:| C[tommyroar/pr-newspaper reusable]
  C --> D[validate_pr.py: readability + page budget]
  D -->|pass| E[green check]
  D -->|fail| F[fix the body]
```

## Verification
- This PR's own run exercises the gate end-to-end.

## Risk & rollout
- Validation triggers on opened/edited/reopened only — existing open PRs aren't retroactively blocked.
- Rollback: delete the caller workflow.