### PR TITLE
feat: availability + collector-health read endpoints (webapp CP1, test-first)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,12 @@ jobs:
         working-directory: web
         run: npx playwright install --with-deps chromium
 
+      - name: Backend unit tests + typecheck
+        working-directory: backend
+        run: |
+          npx vitest run
+          npm run typecheck
+
       - name: Sync data and Seed KV
         run: |
           node scripts/sync-geojson.js

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import campsites from './campsites-index.json';
 import { collectSite, HEARTBEAT_KEY, DLQ_PREFIX, listDlqIds, type WfEnv, type DlqEntry } from './workflows';
+import { readApi } from './read-api';
 
 // Cloudflare Workflows must be exported from the entry module by class name.
 export { CollectorLoop, HotDateWatchWorkflow } from './workflows';
@@ -25,6 +26,9 @@ export const app = new Hono<{ Bindings: Bindings }>();
 app.use('/*', cors());
 
 app.get('/', (c) => c.text('Robot Geographical Society Backend API'));
+
+// Read-only availability + collector-health endpoints (the two-view webapp).
+app.route('/', readApi);
 
 // GET /campsite/:id - Fetch individual campsite details (agency-prefixed slash ids).
 app.get('/campsite/:id{.+}', async (c) => {

--- a/backend/src/read-api.test.ts
+++ b/backend/src/read-api.test.ts
@@ -1,0 +1,143 @@
+import { expect, test, describe } from 'vitest';
+import { app } from './index';
+import { makeR2 } from '../test/stubs/r2';
+
+// --- Ground-truth fixture (a known reservation) --------------------------------
+// Middle Fork (USFS), night 2026-06-05: a real vault booking — Site 24 (internal
+// siteId 81835) reserved that night; campground aggregate 0 available / 23 reserved
+// / 35 total (+12 "other"). Verified against live R2. See WEBAPP_PLAN.md. The
+// inventory ships the canonical guid/slug for this campground; the collector keys
+// R2 on the provider id (rec.gov 234501).
+const MF_GUID = '0c89950f-d0dc-594e-b48d-b1a5293027aa';
+const MF_ID = '234501';
+const DATE = '2026-06-05';
+
+function seedR2() {
+  return makeR2({
+    [`summary/${DATE}/${MF_ID}.json`]: {
+      id: MF_ID, name: 'Middle Fork', agency: 'usfs', kind: 'rec',
+      by_date: { [DATE]: { available: 0, reserved: 23, total: 35 } },
+    },
+    [`sites/${DATE}/${MF_ID}.json`]: {
+      id: MF_ID, name: 'Middle Fork', agency: 'usfs', kind: 'rec', collected_date: DATE,
+      sites: {
+        '81835': {
+          label: '24', loop: 'AREA MIDDLE FORK CAMPGROUND', type: 'STANDARD NONELECTRIC', use: 'Overnight',
+          by_date: { [DATE]: 'reserved', '2026-06-06': 'available' },
+        },
+        '81840': {
+          label: '25', loop: 'AREA MIDDLE FORK CAMPGROUND', type: 'STANDARD NONELECTRIC', use: 'Overnight',
+          by_date: { [DATE]: 'available' },
+        },
+      },
+    },
+  });
+}
+
+describe('/availability — aggregate map (the known reservation)', () => {
+  test('GET /availability?date= returns the night aggregate keyed by guid', async () => {
+    const RAW = seedR2();
+    const res = await app.request(`/availability?date=${DATE}`, {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const mf = (body as any[]).find((e) => e.guid === MF_GUID);
+    expect(mf).toMatchObject({
+      guid: MF_GUID, name: 'Middle Fork', available: 0, reserved: 23, total: 35, collected_date: DATE,
+    });
+  });
+
+  test('GET /availability requires a ?date=', async () => {
+    const RAW = seedR2();
+    const res = await app.request('/availability', {}, { RAW } as any);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe('/availability/:guid — per-campground site list for a night', () => {
+  test('lists sites with the human label and that night’s status', async () => {
+    const RAW = seedR2();
+    const res = await app.request(`/availability/${MF_GUID}?date=${DATE}`, {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.guid).toBe(MF_GUID);
+    const site24 = body.sites.find((s: any) => s.siteId === '81835');
+    expect(site24).toMatchObject({
+      siteId: '81835', label: '24', loop: 'AREA MIDDLE FORK CAMPGROUND', status: 'reserved',
+    });
+  });
+
+  test('unknown guid → 404', async () => {
+    const RAW = seedR2();
+    const res = await app.request(`/availability/not-a-guid?date=${DATE}`, {}, { RAW } as any);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('/availability/:guid/site/:siteId — one site’s calendar', () => {
+  test('returns the per-night status calendar (siteId is the internal id, not the label)', async () => {
+    const RAW = seedR2();
+    const res = await app.request(`/availability/${MF_GUID}/site/81835`, {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.siteId).toBe('81835');
+    expect(body.label).toBe('24');
+    expect(body.by_date[DATE]).toBe('reserved');
+    expect(body.by_date['2026-06-06']).toBe('available');
+  });
+
+  test('unknown siteId → 404', async () => {
+    const RAW = seedR2();
+    const res = await app.request(`/availability/${MF_GUID}/site/99999`, {}, { RAW } as any);
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('/collectors — fleet health (current state, no history)', () => {
+  // A heartbeat where Middle Fork is healthy (due in the future, no failures) and
+  // some other rec site is overdue + failing.
+  const NOW = Date.parse('2026-06-06T00:00:00Z');
+  function seedWithHeartbeat() {
+    const RAW = seedR2();
+    RAW.put('scheduler/heartbeat.json', {
+      lastWakeMs: NOW - 60_000,
+      lastWakeISO: new Date(NOW - 60_000).toISOString(),
+      collectedTotal: 999,
+      sites: 140,
+      due: { [MF_ID]: NOW + 86_400_000, '246855': NOW - 3_600_000 },
+      fails: { '246855': 2 },
+    });
+    return RAW;
+  }
+
+  test('colors each inventory site by state', async () => {
+    const RAW = seedWithHeartbeat();
+    // Quarantine one site via the DLQ.
+    RAW.put('dlq/246855.json', { id: '246855', name: 'Colonial Creek North', agency: 'nps', kind: 'rec', since: NOW, sinceISO: '', failures: 5, lastError: 'x' });
+    const res = await app.request(`/collectors?now=${NOW}`, {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any[];
+
+    const mf = body.find((c) => c.guid === MF_GUID);
+    expect(mf).toMatchObject({ state: 'healthy', collect: true, lastCollectedDate: DATE });
+
+    // collect:false (BLM) → disabled regardless of heartbeat.
+    const disabled = body.find((c) => c.guid === 'fc77ed90-72f0-5ece-a818-93153d2140b7');
+    expect(disabled).toMatchObject({ state: 'disabled', collect: false });
+
+    // In the DLQ → quarantined (wins over overdue/failing).
+    const quarantined = body.find((c) => c.guid === '526a9c1d-814b-5019-991b-1abb73c7340d');
+    expect(quarantined?.state).toBe('quarantined');
+
+    // Every inventory entry is represented.
+    expect(body.length).toBe(156);
+  });
+
+  test('overdue/failing when due has passed and no DLQ entry', async () => {
+    const RAW = seedWithHeartbeat(); // 246855 due in the past + fails:2, not quarantined
+    const res = await app.request(`/collectors?now=${NOW}`, {}, { RAW } as any);
+    const body = (await res.json()) as any[];
+    const overdue = body.find((c) => c.guid === '526a9c1d-814b-5019-991b-1abb73c7340d');
+    expect(overdue?.state).toBe('overdue');
+    expect(overdue?.fails).toBe(2);
+  });
+});

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -1,0 +1,241 @@
+/**
+ * Read-only availability + collector-health endpoints for the two-view webapp
+ * (see WEBAPP_PLAN.md). These read the banked R2 snapshots the collector writes —
+ * they never hit the upstream providers.
+ *
+ * Id model: the browser keys everything on the canonical **guid**; the inventory
+ * (`campsites-index.json`) maps `guid → provider id` (rec.gov campground id or WA
+ * resourceLocation id), and R2 is keyed by provider id. The Worker does that
+ * translation so the frontend never sees provider-id quirks.
+ *
+ * R2 layout (keyed by provider id):
+ *   summary/<collectionDate>/<id>.json → { by_date: { night → {available,reserved,total} } }
+ *   sites/<collectionDate>/<id>.json   → { collected_date, sites: { siteId → {label,loop,type,use,by_date} } }
+ *   dlq/<id>.json                      → quarantine marker
+ *   scheduler/heartbeat.json           → { due:{id→deadlineMs}, fails:{id→count}, lastWakeMs }
+ *
+ * "Freshness": a campground is collected on its own cadence, so the newest snapshot
+ * for a given id may sit in any recent date-partition. We resolve newest-per-id by
+ * walking the partitions newest→oldest (bounded lookback). The per-date rollup
+ * `summary/<date>/_index.json` (checkpoint 2) will collapse the bulk fan-out to one
+ * read; until then the bulk endpoints fan out (cheap for /collectors, the one place
+ * the WEBAPP_PLAN flags for the Cache-API/rollup optimization is /availability?date=).
+ */
+import { Hono } from 'hono';
+import index from './campsites-index.json';
+
+type ReadEnv = { RAW: R2Bucket };
+
+type InventoryEntry = {
+  id: string;
+  guid: string;
+  name: string;
+  agency?: string;
+  agency_full?: string;
+  lat?: number | null;
+  lng?: number | null;
+  collect?: boolean | null;
+};
+
+const INVENTORY = index as unknown as InventoryEntry[];
+const BY_GUID = new Map(INVENTORY.map((e) => [e.guid, e]));
+
+// How many recent date-partitions to scan when resolving the newest snapshot per
+// site. Collection cadence is ~daily within MAX_STALENESS_DAYS, but a quarantined
+// or long-stale site can sit further back; 30 partitions is a generous bound that
+// keeps the listing cheap.
+const LOOKBACK_PARTITIONS = 30;
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+type Counts = { available: number; reserved: number; total: number };
+
+async function listAll(env: ReadEnv, opts: { prefix: string; delimiter?: string }) {
+  const objects: { key: string }[] = [];
+  const delimited: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const r: any = await env.RAW.list({ ...opts, cursor } as any);
+    objects.push(...(r.objects ?? []));
+    delimited.push(...(r.delimitedPrefixes ?? []));
+    cursor = r.truncated ? r.cursor : undefined;
+  } while (cursor);
+  return { objects, delimitedPrefixes: delimited };
+}
+
+/** Recent collection-date partitions under `top/`, newest first (bounded). */
+async function partitionDates(env: ReadEnv, top: 'summary' | 'sites'): Promise<string[]> {
+  const root = `${top}/`;
+  const { delimitedPrefixes } = await listAll(env, { prefix: root, delimiter: '/' });
+  return delimitedPrefixes
+    .map((p) => p.slice(root.length).replace(/\/$/, ''))
+    .filter((d) => DATE_RE.test(d))
+    .sort()
+    .reverse()
+    .slice(0, LOOKBACK_PARTITIONS);
+}
+
+/** newest collection-date per provider id (newest-partition-wins). */
+async function latestByProvider(env: ReadEnv, top: 'summary' | 'sites'): Promise<Map<string, string>> {
+  const root = `${top}/`;
+  const latest = new Map<string, string>();
+  for (const d of await partitionDates(env, top)) {
+    const { objects } = await listAll(env, { prefix: `${root}${d}/` });
+    for (const o of objects) {
+      const id = o.key.slice(`${root}${d}/`.length).replace(/\.json$/, '');
+      if (id && id !== '_index' && !latest.has(id)) latest.set(id, d);
+    }
+  }
+  return latest;
+}
+
+/** newest collection-date that has a snapshot for one specific provider id. */
+async function latestPartitionFor(env: ReadEnv, top: 'summary' | 'sites', id: string): Promise<string | null> {
+  const root = `${top}/`;
+  for (const d of await partitionDates(env, top)) {
+    if (await env.RAW.head(`${root}${d}/${id}.json`)) return d;
+  }
+  return null;
+}
+
+async function getJson<T>(env: ReadEnv, key: string): Promise<T | null> {
+  const obj = await env.RAW.get(key);
+  return obj ? ((await obj.json()) as T) : null;
+}
+
+export const readApi = new Hono<{ Bindings: ReadEnv }>();
+
+// GET /availability?date=YYYY-MM-DD[&collected=YYYY-MM-DD]
+// Every campground's aggregate availability for the requested night, keyed by guid,
+// projected from each site's freshest summary snapshot.
+readApi.get('/availability', async (c) => {
+  const date = c.req.query('date');
+  if (!date || !DATE_RE.test(date)) return c.json({ error: 'need ?date=YYYY-MM-DD' }, 400);
+  const pinned = c.req.query('collected');
+
+  const latest = pinned
+    ? new Map(INVENTORY.map((e) => [e.id, pinned]))
+    : await latestByProvider(c.env, 'summary');
+
+  const out: any[] = [];
+  for (const e of INVENTORY) {
+    const collDate = latest.get(e.id);
+    if (!collDate) continue;
+    const snap = await getJson<{ by_date?: Record<string, Counts> }>(c.env, `summary/${collDate}/${e.id}.json`);
+    if (!snap) continue;
+    const counts = snap.by_date?.[date] ?? null;
+    out.push({
+      guid: e.guid,
+      name: e.name,
+      agency: e.agency_full ?? e.agency ?? null,
+      lat: e.lat ?? null,
+      lng: e.lng ?? null,
+      available: counts?.available ?? null,
+      reserved: counts?.reserved ?? null,
+      total: counts?.total ?? null,
+      collected_date: collDate,
+    });
+  }
+  return c.json(out);
+});
+
+// GET /availability/:guid/site/:siteId — one site's per-night status calendar.
+// :siteId is the internal R2 site id (e.g. 81835), NOT the human label ("24").
+readApi.get('/availability/:guid/site/:siteId', async (c) => {
+  const entry = BY_GUID.get(c.req.param('guid'));
+  if (!entry) return c.json({ error: 'unknown guid' }, 404);
+  const siteId = c.req.param('siteId');
+
+  const collDate = await latestPartitionFor(c.env, 'sites', entry.id);
+  const snap = collDate
+    ? await getJson<{ sites?: Record<string, any> }>(c.env, `sites/${collDate}/${entry.id}.json`)
+    : null;
+  const site = snap?.sites?.[siteId];
+  if (!site) return c.json({ error: 'site not found' }, 404);
+
+  return c.json({
+    guid: entry.guid,
+    siteId,
+    label: site.label ?? null,
+    loop: site.loop ?? null,
+    type: site.type ?? null,
+    use: site.use ?? null,
+    collected_date: collDate,
+    by_date: site.by_date ?? {},
+  });
+});
+
+// GET /availability/:guid?date= — the per-campground site list for one night.
+// The "individual site number" filter resolves the human `label` ("24") → siteId
+// against this list, so we surface both.
+readApi.get('/availability/:guid', async (c) => {
+  const entry = BY_GUID.get(c.req.param('guid'));
+  if (!entry) return c.json({ error: 'unknown guid' }, 404);
+  const date = c.req.query('date');
+  if (!date || !DATE_RE.test(date)) return c.json({ error: 'need ?date=YYYY-MM-DD' }, 400);
+
+  const collDate = await latestPartitionFor(c.env, 'sites', entry.id);
+  const snap = collDate
+    ? await getJson<{ sites?: Record<string, any> }>(c.env, `sites/${collDate}/${entry.id}.json`)
+    : null;
+
+  const sites = Object.entries(snap?.sites ?? {}).map(([siteId, s]: [string, any]) => ({
+    siteId,
+    label: s.label ?? null,
+    loop: s.loop ?? null,
+    type: s.type ?? null,
+    use: s.use ?? null,
+    status: s.by_date?.[date] ?? null,
+  }));
+  return c.json({ guid: entry.guid, name: entry.name, date, collected_date: collDate, sites });
+});
+
+// GET /collectors[?now=ms] — fleet health, current state only (no run-history;
+// that's the InfluxDB-backed /collectors/:guid/history, deferred). One row per
+// inventory site, colored by state.
+readApi.get('/collectors', async (c) => {
+  const now = Number(c.req.query('now')) || Date.now();
+  const hb = (await getJson<any>(c.env, 'scheduler/heartbeat.json')) ?? {};
+  const due: Record<string, number> = hb.due ?? {};
+  const fails: Record<string, number> = hb.fails ?? {};
+
+  const { objects } = await listAll(c.env, { prefix: 'dlq/' });
+  const quarantined = new Set(objects.map((o) => o.key.slice('dlq/'.length).replace(/\.json$/, '')));
+
+  const lastDates = await latestByProvider(c.env, 'summary');
+
+  const out = INVENTORY.map((e) => {
+    const collect = e.collect !== false;
+    const lastCollectedDate = lastDates.get(e.id) ?? null;
+    const ageDays = lastCollectedDate ? Math.floor((now - Date.parse(lastCollectedDate)) / 86_400_000) : null;
+    const deadline = due[e.id];
+    const fail = fails[e.id] ?? 0;
+
+    let state: 'disabled' | 'quarantined' | 'overdue' | 'healthy';
+    if (!collect) state = 'disabled';
+    else if (quarantined.has(e.id)) state = 'quarantined';
+    else if ((deadline != null && deadline <= now) || fail > 0) state = 'overdue';
+    else state = 'healthy';
+
+    return {
+      guid: e.guid,
+      name: e.name,
+      agency: e.agency_full ?? e.agency ?? null,
+      lat: e.lat ?? null,
+      lng: e.lng ?? null,
+      collect,
+      state,
+      lastCollectedDate,
+      ageDays,
+      dueMs: deadline != null ? deadline - now : null,
+      fails: fail,
+    };
+  });
+  return c.json(out);
+});
+
+// GET /collectors/:guid/history — run-history sparkline. Deferred: reads the
+// observability InfluxDB (localhost:8086) and only wires up once the app runs
+// against a local server. Returns 501 until then.
+readApi.get('/collectors/:guid/history', (c) =>
+  c.json({ error: 'run-history not implemented yet (InfluxDB-backed; pending local wiring)' }, 501),
+);

--- a/backend/test/stubs/r2.ts
+++ b/backend/test/stubs/r2.ts
@@ -1,0 +1,45 @@
+// Minimal in-memory R2Bucket stub for read-endpoint tests. Supports the subset
+// the read API uses: get/head/put/delete and list() with a prefix + optional
+// delimiter (for date-partition discovery). Values are stored as JSON strings;
+// get() returns an object exposing json()/text() like the real R2ObjectBody.
+export type Seed = Record<string, unknown>;
+
+export function makeR2(seed: Seed = {}) {
+  const store = new Map<string, string>();
+  const enc = (v: unknown) => (typeof v === 'string' ? v : JSON.stringify(v));
+  for (const [k, v] of Object.entries(seed)) store.set(k, enc(v));
+
+  return {
+    _store: store,
+    async get(key: string) {
+      if (!store.has(key)) return null;
+      const body = store.get(key)!;
+      return { text: async () => body, json: async () => JSON.parse(body) };
+    },
+    async head(key: string) {
+      return store.has(key) ? ({ key } as any) : null;
+    },
+    async put(key: string, value: unknown) {
+      store.set(key, enc(value));
+    },
+    async delete(key: string) {
+      store.delete(key);
+    },
+    async list(opts: { prefix?: string; delimiter?: string; cursor?: string } = {}) {
+      const prefix = opts.prefix ?? '';
+      const keys = [...store.keys()].filter((k) => k.startsWith(prefix)).sort();
+      if (opts.delimiter) {
+        const delimited = new Set<string>();
+        const objects: { key: string }[] = [];
+        for (const k of keys) {
+          const rest = k.slice(prefix.length);
+          const i = rest.indexOf(opts.delimiter);
+          if (i >= 0) delimited.add(prefix + rest.slice(0, i + opts.delimiter.length));
+          else objects.push({ key: k });
+        }
+        return { objects, delimitedPrefixes: [...delimited], truncated: false };
+      }
+      return { objects: keys.map((key) => ({ key })), delimitedPrefixes: [], truncated: false };
+    },
+  };
+}


### PR DESCRIPTION
`BACKEND` — **CHECKPOINT 1**

# The maps get a backend: availability + collector health, keyed by guid

> _Five read-only Worker endpoints that turn the collector's banked R2 snapshots into what the two-view webapp needs — what's open on a night, and how healthy the fleet is — built test-first against a known reservation._

> [!NOTE]
> **backend** · feat · risk: low · 439+ lines, all additive · existing routes untouched

Checkpoint 1 of [`WEBAPP_PLAN.md`](https://github.com/tommyroar/robot-geographical-society/blob/feat/webapp-cloudflare-capture/WEBAPP_PLAN.md). The collector banks per-night `summary/` and per-site `sites/` to R2 (plus a heartbeat and DLQ) — but nothing served it. These do, and the browser only ever speaks **`guid`**: the Worker resolves `guid → provider id` against the inventory and reads R2 (keyed by provider id), so the frontend never sees a rec.gov/WA id quirk.

## The endpoints

| Route | Returns | Reads |
|---|---|---|
| `GET /availability?date=` | per-night aggregate for every campground, by `guid` | `summary/` |
| `GET /availability/:guid?date=` | that campground's site list (label · loop · status) | `sites/` |
| `GET /availability/:guid/site/:siteId` | one site's per-night status calendar | `sites/` |
| `GET /collectors[?now=]` | fleet health — one row per site, state-colored | heartbeat · `dlq/` · `summary/` |
| `GET /collectors/:guid/history` | **501** — InfluxDB-backed, deferred | — |

Each campground is collected on its own cadence, so the resolver walks date-partitions newest→oldest and takes newest-per-id; the `summary/<date>/_index.json` rollup (checkpoint 2) will collapse the `/availability?date=` fan-out to one read.

## Built test-first against a known reservation

`read-api.test.ts` encodes the live-verified vault fixture — **Middle Fork, Site 24, night 2026-06-05** — written **red before the handlers existed**:

- `?date=2026-06-05` → Middle Fork (`guid 0c89950f…`) = `{available:0, reserved:23, total:35}`.
- `/availability/:guid?date=` → list has `{siteId:"81835", label:"24", status:"reserved"}`.
- `/availability/:guid/site/81835` → `by_date["2026-06-05"] == "reserved"`.

Writing it first pinned the contract nuance the plan flagged: **`:siteId` is the internal R2 id (`81835`), not the human label (`"24"`)** — so `/availability/:guid` exposes `label` and the picker resolves label→siteId. `/collectors` is asserted across all four states (healthy · overdue · quarantined · disabled).

```mermaid
flowchart TD
  REQ["guid + date"] --> INV["inventory: guid → provider id"]
  INV --> RES["newest-partition-per-id"] --> R2[("R2 summary/ · sites/")]
  HB["heartbeat · dlq/"] --> OUT["JSON for the map"]
  R2 --> OUT
```

## Status

- [x] resolver + four R2-only endpoints · `/collectors` four states · test-first fixture
- [x] backend vitest + typecheck now gate in CI
- [ ] _(cp2)_ collector `_index.json` rollup · _(deferred)_ `/history` via local InfluxDB

## Verification & risk

- **`npx vitest run`** → 30/30 green (8 new); **`typecheck`** clean. Additive only — prior routes/tests untouched.
- **CI gap closed**: `ci.yaml` previously ran only web tests + the `wrangler dev` e2e — the backend suite was never gated; added a backend step.
- **Not yet against `--remote` live R2** (needs interactive Cloudflare auth, per the local-only posture) — fixture values are already live-verified and frozen in the test; a `wrangler dev --remote` smoke is the recommended next check.
