### PR TITLE
feat: route the frontend + e2e through the Access-authenticated /api proxy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,13 @@ jobs:
           VITE_MAPBOX_ACCESS_TOKEN: pk.eyJ1Ijoiam9lIiwiYSI6ImNsamVnZzFpZzAwZHYzZ214ZzFqZzFqZzEifQ.fake-token
           CI: true
           WRANGLER_SEND_METRICS: false
+          # Drive the e2e through the authenticated /api proxy. The Vite proxy targets
+          # the local wrangler-dev backend and attaches these Access service-token
+          # headers (exercising the production auth wiring). The local backend ignores
+          # them — real creds live in web/.env.local for dev against the gated backend.
+          BACKEND_URL: http://127.0.0.1:8787
+          CF_ACCESS_CLIENT_ID: ci-dummy.access
+          CF_ACCESS_CLIENT_SECRET: ci-dummy-secret
         run: |
           # Use 127.0.0.1 for everything. Wait-on will ensure ports are open and responding correctly.
           ./node_modules/.bin/concurrently --success first --kill-others \

--- a/web/.env.local.example
+++ b/web/.env.local.example
@@ -1,0 +1,15 @@
+# Local dev → deployed Worker backend (behind Cloudflare Access). Copy to
+# `web/.env.local` (gitignored) and fill in. See web/BACKEND_AUTH.md for setup.
+#
+# These are read by vite.config.js in Node (the dev server) and are NEVER bundled
+# into the browser — only VITE_-prefixed vars are. Do NOT prefix these with VITE_.
+
+# The deployed Worker origin. Unset → the app talks to a local `wrangler dev`
+# backend instead (no proxy), which is the default for CI/e2e.
+BACKEND_URL=https://robot-geographical-society-backend.<your-subdomain>.workers.dev
+
+# Cloudflare Access service token (Zero Trust → Access → Service Auth → Service
+# Tokens). The Vite proxy sends these as request headers so local dev authenticates
+# to the Access-protected Worker without a human login.
+CF_ACCESS_CLIENT_ID=<client-id>.access
+CF_ACCESS_CLIENT_SECRET=<client-secret>

--- a/web/BACKEND_AUTH.md
+++ b/web/BACKEND_AUTH.md
@@ -1,0 +1,86 @@
+# Local Vite against the deployed Worker (Cloudflare Access)
+
+How the local dev frontend talks to the **deployed** Worker backend without ever
+putting a credential in the browser bundle.
+
+## The shape
+
+```
+browser ──/api/availability──▶ Vite dev server ──+CF-Access service token──▶ Cloudflare Access ──▶ Worker
+ (no token)                     (Node, holds token)                          (validates, forwards)
+```
+
+The browser only ever calls the **same-origin** `/api/...` path. The Vite dev server
+(`vite.config.js`) proxies that to the deployed Worker and attaches a Cloudflare
+Access **service token** as request headers — server-side, in Node. Because only
+`VITE_`-prefixed env vars are inlined into the client bundle, the token
+(`CF_ACCESS_CLIENT_*`, `BACKEND_URL`) never reaches the browser. The proxy also
+sidesteps CORS (every browser request is same-origin).
+
+In production the same browser code points at `VITE_BACKEND_URL` and authenticates
+via an Access **SSO cookie** the browser carries automatically — so the service
+token is a dev-only artifact, and the app code is identical in both modes (it goes
+through `apiBase()` in `src/apiBase.js`).
+
+> Auth-rule note: this does not contradict the workspace "never mint tokens" rule —
+> that rule is about CLI auth (don't mint a Cloudflare API token / GitHub PAT when
+> the OAuth code flow covers it). You still `wrangler login` via OAuth to deploy. An
+> Access **service token** is the intended machine-to-machine credential, issued by
+> Access for exactly this purpose.
+
+## One-time setup
+
+### 1. Deploy the Worker
+
+```sh
+cd backend && npx wrangler deploy
+```
+
+Note the printed URL, e.g. `https://robot-geographical-society-backend.<sub>.workers.dev`.
+
+### 2. Put a Cloudflare Access application in front of it
+
+In the Zero Trust dashboard (one.dash.cloudflare.com → Access → Applications →
+**Add an application** → **Self-hosted**):
+
+- **Application domain:** the Worker hostname from step 1 (or a custom route/subdomain
+  bound to it).
+- **Policies:** add two —
+  - an **Allow** policy with an *Emails* / *identity* rule for human SSO (you), and
+  - a **Service Auth** policy with a *Service Token* rule (created next) so the dev
+    proxy can authenticate non-interactively.
+
+> Requires Zero Trust enabled on the account (free tier is fine) and a team domain
+> (`<team>.cloudflareaccess.com`).
+
+### 3. Create the service token
+
+Zero Trust → Access → **Service Auth** → **Service Tokens** → *Create*. Copy the
+**Client ID** and **Client Secret** (the secret is shown once). Make sure the
+application's Service Auth policy references this token.
+
+### 4. Wire local dev
+
+```sh
+cp web/.env.local.example web/.env.local   # gitignored
+# fill in BACKEND_URL, CF_ACCESS_CLIENT_ID, CF_ACCESS_CLIENT_SECRET
+cd web && npm run dev
+```
+
+Frontend calls `${apiBase()}/availability?...` → `/api/availability` → proxied to the
+Worker with the service-token headers. Unset `BACKEND_URL` to fall back to a local
+`wrangler dev` backend (the CI/e2e default — no proxy, no token).
+
+## Production (later)
+
+Deploy the frontend to Cloudflare Pages behind the **same** Access application; human
+visitors get an SSO login and the browser carries the Access JWT cookie. Set
+`VITE_BACKEND_URL` to the Worker origin at build time. No service token in prod.
+
+## Optional hardening: verify the Access JWT in the Worker
+
+Access blocks unauthenticated requests at the edge, so the Worker only sees vetted
+traffic. For defense in depth (so a leaked direct Worker URL still can't be hit),
+verify the `Cf-Access-Jwt-Assertion` header against your team's public keys at
+`https://<team>.cloudflareaccess.com/cdn-cgi/access/certs`, scoped to the read
+routes. Add this once the read endpoints (PR #79) land on `main`.

--- a/web/e2e/campsite.test.js
+++ b/web/e2e/campsite.test.js
@@ -1,22 +1,26 @@
 import { test, expect } from '@playwright/test';
 
 const BASE_URL = 'http://127.0.0.1:5173';
-const BACKEND_URL = 'http://127.0.0.1:8787';
+// Reach the backend the way the app does: through the same-origin `/api` proxy on
+// the Vite dev server, which attaches the Cloudflare Access service token
+// (CF_ACCESS_CLIENT_ID/SECRET, set in CI) and forwards to the backend. This
+// exercises the authenticated path end-to-end instead of hitting :8787 directly.
+const API_URL = `${BASE_URL}/api`;
 
 test.describe('Robot Geographical Society - Integration', () => {
-  test('backend should be reachable and return campsite data', async ({ request }) => {
-    // Retry logic for backend readiness
+  test('backend is reachable through the authenticated /api proxy', async ({ request }) => {
+    // Retry logic for backend/proxy readiness
     let response;
     for (let i = 0; i < 5; i++) {
         try {
-            response = await request.get(`${BACKEND_URL}/campsite/blm/fishtrap-recreation-area`);
+            response = await request.get(`${API_URL}/campsite/blm/fishtrap-recreation-area`);
             if (response.ok()) break;
         } catch (e) {
-            console.log(`Backend attempt ${i+1} failed: ${e.message}`);
+            console.log(`Proxy attempt ${i+1} failed: ${e.message}`);
         }
         await new Promise(r => setTimeout(r, 2000));
     }
-    
+
     expect(response?.ok()).toBeTruthy();
     const data = await response.json();
     expect(data.name).toBe('Fishtrap Recreation Area');

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -90,7 +90,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -440,7 +439,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -464,7 +462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1762,7 +1759,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2019,7 +2017,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2348,7 +2345,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2854,7 +2850,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3159,7 +3156,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4421,7 +4417,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -4616,6 +4611,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -5090,7 +5086,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5206,6 +5201,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -5221,6 +5217,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -5281,7 +5278,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5291,7 +5287,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5304,7 +5299,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -6039,7 +6035,6 @@
       "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.15.0",
@@ -6340,7 +6335,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import mapboxgl from 'mapbox-gl';
 import campsiteData from '../../data/campsites.json';
+import { apiBase } from './apiBase';
 
 const AGENCY_COLORS = {
   'wa-state-parks': '#A6E22E',
@@ -227,11 +228,9 @@ export default function App() {
         return;
     }
 
-    const backendUrl = window.location.hostname === 'localhost' 
-      ? 'http://localhost:8787' 
-      : `http://${window.location.hostname}:8787`;
-
-    fetch(`${backendUrl}/campsite/${id}`)
+    // Go through the same-origin `/api` proxy (apiBase). In dev the proxy attaches
+    // the Access service token server-side; in prod it targets the gated backend.
+    fetch(`${apiBase()}/campsite/${id}`)
       .then((res) => {
         if (!res.ok) throw new Error('Failed to fetch details');
         return res.json();

--- a/web/src/apiBase.js
+++ b/web/src/apiBase.js
@@ -1,0 +1,21 @@
+/**
+ * Base URL for Worker backend calls — the single switch between dev and prod so the
+ * browser never holds a backend credential. Build request URLs as
+ * `` `${apiBase()}/availability?...` `` (no `/api` segment in the path you write).
+ *
+ * - **Dev:** returns `'/api'` → requests go to the same-origin `/api/...` path, which
+ *   the Vite dev server proxies to the deployed Worker (stripping the `/api` prefix)
+ *   and attaches the Cloudflare Access service token as request headers
+ *   *server-side* — the token is never in the bundle. See web/BACKEND_AUTH.md.
+ * - **Prod:** returns `VITE_BACKEND_URL` (the deployed Worker origin), so the URL is
+ *   `<backend>/availability`. The deployed frontend authenticates via an Access SSO
+ *   cookie the browser carries automatically — again, no token in JS. Falls back to
+ *   `'/api'` (same-origin routing) when `VITE_BACKEND_URL` is unset.
+ */
+export function apiBase() {
+  // Dev always goes through the proxy so the Access service token is applied
+  // server-side, even if VITE_BACKEND_URL happens to be set.
+  if (import.meta.env.DEV) return '/api';
+  const explicit = import.meta.env.VITE_BACKEND_URL;
+  return explicit ? explicit.replace(/\/+$/, '') : '/api';
+}

--- a/web/src/apiBase.test.js
+++ b/web/src/apiBase.test.js
@@ -1,0 +1,31 @@
+import { describe, test, expect, afterEach } from 'vitest';
+import { apiBase } from './apiBase';
+
+const orig = { ...import.meta.env };
+afterEach(() => {
+  import.meta.env.DEV = orig.DEV;
+  // import.meta.env stringifies assigned values ("undefined" !== undefined), so
+  // restore an absent var by deleting it rather than assigning.
+  if (orig.VITE_BACKEND_URL === undefined) delete import.meta.env.VITE_BACKEND_URL;
+  else import.meta.env.VITE_BACKEND_URL = orig.VITE_BACKEND_URL;
+});
+
+describe('apiBase', () => {
+  test('dev → same-origin /api proxy (token applied server-side), even if a URL is set', () => {
+    import.meta.env.DEV = true;
+    import.meta.env.VITE_BACKEND_URL = 'https://example.workers.dev';
+    expect(apiBase()).toBe('/api');
+  });
+
+  test('prod → the deployed backend origin, trailing slash trimmed', () => {
+    import.meta.env.DEV = false;
+    import.meta.env.VITE_BACKEND_URL = 'https://example.workers.dev/';
+    expect(apiBase()).toBe('https://example.workers.dev');
+  });
+
+  test('prod with no backend url → same-origin /api fallback', () => {
+    import.meta.env.DEV = false;
+    delete import.meta.env.VITE_BACKEND_URL; // a genuinely unset var is `undefined`, not "undefined"
+    expect(apiBase()).toBe('/api');
+  });
+});

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -1,17 +1,47 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    allowedHosts: true,
-    fs: {
-      allow: ['..'],
+// https://vitejs.dev/config/
+export default defineConfig(({ mode }) => {
+  // Load ALL env vars (the empty prefix includes non-VITE_ secrets). These are read
+  // here in Node, for the dev server only — they are NEVER inlined into the client
+  // bundle (only VITE_-prefixed vars are). This is what keeps the backend token off
+  // the browser. See web/BACKEND_AUTH.md.
+  const env = loadEnv(mode, process.cwd(), '');
+  const backend = env.BACKEND_URL;
+
+  // Same-origin `/api` proxy → the deployed Worker. When the Worker sits behind
+  // Cloudflare Access, the dev server attaches a service token as request headers
+  // here (server-side), so the browser authenticates without ever holding the
+  // secret. No BACKEND_URL set → no proxy: the app talks to the local `wrangler
+  // dev` backend directly, exactly as before (unchanged for CI/e2e).
+  const proxy = backend
+    ? {
+        '/api': {
+          target: backend,
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/api/, ''),
+          headers: {
+            ...(env.CF_ACCESS_CLIENT_ID && { 'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID }),
+            ...(env.CF_ACCESS_CLIENT_SECRET && { 'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET }),
+          },
+        },
+      }
+    : undefined;
+
+  return {
+    plugins: [react()],
+    server: {
+      allowedHosts: true,
+      fs: {
+        allow: ['..'],
+      },
+      proxy,
     },
-  },
-  test: {
-    environment: 'jsdom',
-    setupFiles: ['./src/setupTests.js'],
-    globals: true,
-  },
+    test: {
+      environment: 'jsdom',
+      setupFiles: ['./src/setupTests.js'],
+      globals: true,
+    },
+  };
 });

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -8,26 +8,24 @@ export default defineConfig(({ mode }) => {
   // bundle (only VITE_-prefixed vars are). This is what keeps the backend token off
   // the browser. See web/BACKEND_AUTH.md.
   const env = loadEnv(mode, process.cwd(), '');
-  const backend = env.BACKEND_URL;
-
-  // Same-origin `/api` proxy → the deployed Worker. When the Worker sits behind
-  // Cloudflare Access, the dev server attaches a service token as request headers
-  // here (server-side), so the browser authenticates without ever holding the
-  // secret. No BACKEND_URL set → no proxy: the app talks to the local `wrangler
-  // dev` backend directly, exactly as before (unchanged for CI/e2e).
-  const proxy = backend
-    ? {
-        '/api': {
-          target: backend,
-          changeOrigin: true,
-          rewrite: (p) => p.replace(/^\/api/, ''),
-          headers: {
-            ...(env.CF_ACCESS_CLIENT_ID && { 'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID }),
-            ...(env.CF_ACCESS_CLIENT_SECRET && { 'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET }),
-          },
-        },
-      }
-    : undefined;
+  // The app always talks to the backend via the same-origin `/api` proxy (see
+  // src/apiBase.js). Target the deployed Access-protected Worker when BACKEND_URL is
+  // set, else a local `wrangler dev` backend. When the Access service-token creds are
+  // present (CF_ACCESS_CLIENT_ID/SECRET), the dev server attaches them as request
+  // headers here — server-side, so the browser never holds the secret, and the same
+  // path works against the gated backend. See web/BACKEND_AUTH.md.
+  const backend = env.BACKEND_URL || 'http://127.0.0.1:8787';
+  const proxy = {
+    '/api': {
+      target: backend,
+      changeOrigin: true,
+      rewrite: (p) => p.replace(/^\/api/, ''),
+      headers: {
+        ...(env.CF_ACCESS_CLIENT_ID && { 'CF-Access-Client-Id': env.CF_ACCESS_CLIENT_ID }),
+        ...(env.CF_ACCESS_CLIENT_SECRET && { 'CF-Access-Client-Secret': env.CF_ACCESS_CLIENT_SECRET }),
+      },
+    },
+  };
 
   return {
     plugins: [react()],


### PR DESCRIPTION
`WEB` — **AUTH WIRING**

# One authenticated path: app and e2e both reach the backend through `/api`

> _The backend is now behind Cloudflare Access. This routes the frontend — and the e2e — through a same-origin `/api` proxy that attaches the Access service token server-side, so the browser never holds a credential and every call takes the same authenticated path._

> [!NOTE]
> **web** · feat · risk: low · app + e2e through the proxy; token never in the bundle

The token-off-the-browser principle: secrets live in the Vite dev server (Node), never in the client bundle (only `VITE_`-prefixed vars are inlined). The browser calls same-origin `/api/*`; Vite attaches the service token and forwards to the backend — local `wrangler dev` by default, the Access-gated `api.robogeosociety.xyz` when `BACKEND_URL` is set.

## What's wired

- **`vite.config.js`** — the `/api` proxy is always configured: it strips `/api`, targets `BACKEND_URL` (default `127.0.0.1:8787`), and attaches `CF-Access-Client-Id/Secret` when present. CORS-free (same-origin), token server-side.
- **`src/apiBase.js`** (+ test) — the single dev/prod switch: `/api` in dev (proxied), `VITE_BACKEND_URL` in prod (Access SSO cookie). No token in JS either way.
- **`App.jsx`** — fetches campsite details via `apiBase()` instead of a hardcoded `:8787`, so the app takes the authenticated path.
- **e2e** — the backend check now goes through the Vite `/api` proxy, exercising the authenticated path end-to-end; `ci.yaml` sets `BACKEND_URL` + dummy service-token creds so the proxy attaches the headers (the local backend ignores them).
- **`.env.local.example` + `BACKEND_AUTH.md`** — the Cloudflare Access setup; real creds for dev against the gated backend come from `infra/access` (`make envfile`).

## How a call flows

```mermaid
flowchart TD
  B["browser / e2e — /api/campsite"] -->|no token| V["Vite dev server (Node)"]
  V -->|+ service token| BK[("backend (local wrangler dev,\nor gated api.robogeosociety.xyz)")]
```

## Verification & risk

- **`npm run lint`** clean · **`npm test -- --run`** 11/11 · **`vite build`** green. Full Playwright e2e runs in CI through the proxy.
- **Non-breaking** — the proxy defaults to the local backend, so dev/e2e behave as before, just via `/api`. No token in the bundle (only the dev server holds it).
- Pairs with the live Access boundary (#82) and the read endpoints (#79): the same `/api` path reaches the gated backend in real dev via `web/.env.local`.
