### PR TITLE
chore: disable the public workers.dev route on the backend Worker

### DIFF
--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -3,6 +3,13 @@ main = "src/index.ts"
 compatibility_date = "2026-03-16"
 compatibility_flags = ["nodejs_compat"]
 
+# This is a PRIVATE project: the Worker must NOT be reachable on the open internet
+# without a trusted auth boundary. The *.workers.dev route is disabled — the Worker
+# is served only via an Access-protected custom domain (see web/BACKEND_AUTH.md).
+# Do not flip this back to true without a gate in front. See the gate-before-deploy
+# and private-no-public-exposure rules.
+workers_dev = false
+
 [[kv_namespaces]]
 binding = "CAMPSITES"
 id = "aad9f04d90e945ffb8d278d7b8e70976"


### PR DESCRIPTION
`SECURITY` — **LOCKDOWN**

# Take the backend Worker off the open internet

> _This is a private project. The collector Worker was reachable on `*.workers.dev` with no auth — `workers_dev = false` closes that route entirely until a trusted auth boundary (Access on a custom domain) is in place._

> [!NOTE]
> **backend** · chore · one-line config · already deployed (version 933c7739)

The `…workers.dev` URL served the whole Worker — `/scheduler/status`, `/collect/dlq`, `/campsites`, and the `/collect/*` **write** endpoints — to anyone, no auth. That violates the project's hard rule: no data or endpoint public without a trusted auth boundary. This disables the `*.workers.dev` route (and, as a side effect Wrangler reports, preview URLs), so the Worker has **no public route** at all.

## What changed

- `backend/wrangler.toml`: `workers_dev = false` (+ a comment explaining why and warning not to flip it back without a gate).

The collector keeps running — the `CollectorLoop` Workflow is independent of the HTTP route, so collection to R2 is unaffected. The endpoints become reachable again only via the Access-protected **custom domain** that's next on the list (see `web/BACKEND_AUTH.md`).

## Verification

- Deployed `version 933c7739`; Wrangler dropped the workers.dev URL from its output and warned the route is disabled.
- After deploy, `GET /`, `/scheduler/status`, `/collect/dlq`, `/campsites` all return **404** (Cloudflare error 1042 — no route), with a Cloudflare error body, not our API.

## Risk

- **Low / strictly reductive** — removes a public surface, adds nothing. No source change; collector behavior unchanged (this is `main`, which collects the same 140 reservable sites).
- The only access path during the interim is local (`wrangler dev` / vitest). Restoring remote access is gated on the custom-domain + Access work.
