### PR TITLE
feat(backend): make KV the collector's runtime inventory source of truth

### DIFF
--- a/.github/workflows/deploy-kv.yaml
+++ b/.github/workflows/deploy-kv.yaml
@@ -1,0 +1,42 @@
+name: Deploy inventory to KV
+
+# When the authoritative inventory changes on main (the camping-vault pydoit job
+# lands it via the bot/inventory-sync PR), push it to the live CAMPSITES KV under the
+# `_inventory` key. The collector + read API read that key at runtime (with the
+# bundled JSON as fallback), so a refreshed inventory takes effect without a Worker
+# redeploy. See backend/src/inventory.ts.
+on:
+  push:
+    branches: [main]
+    paths:
+      - backend/src/campsites-index.json
+  workflow_dispatch: {}
+
+jobs:
+  deploy-kv:
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      # Account id is not sensitive (see CLAUDE.md); a scoped KV-write token is.
+      CLOUDFLARE_ACCOUNT_ID: d7adee58513c1b2f770ccaac90cf114f
+    steps:
+      - uses: actions/checkout@v4
+
+      # Stay green before the token is configured: skip the write if the secret is unset.
+      - id: gate
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "CLOUDFLARE_API_TOKEN not set — skipping live KV write (configure the vended KV-write token to enable)."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Write _inventory to the live CAMPSITES KV
+        if: steps.gate.outputs.go == 'true'
+        working-directory: backend
+        run: |
+          npx --yes wrangler@4 kv key put _inventory \
+            --path src/campsites-index.json \
+            --binding CAMPSITES \
+            --remote

--- a/backend/scripts/generate-seed.cjs
+++ b/backend/scripts/generate-seed.cjs
@@ -31,5 +31,15 @@ const seedData = data.features.map((feature) => {
   };
 });
 
+// The collector + read API read the whole inventory from KV under a single
+// `_inventory` key (src/inventory.ts) — KV is the runtime source of truth, the
+// bundled campsites-index.json is the fallback. Seed that key from the same
+// committed inventory so local/CI KV matches what a deploy pushes to remote KV
+// (.github/workflows/deploy-kv.yaml).
+const inventory = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../src/campsites-index.json'), 'utf8'),
+);
+seedData.push({ key: '_inventory', value: JSON.stringify(inventory) });
+
 fs.writeFileSync(outputPath, JSON.stringify(seedData, null, 2), 'utf8');
-console.log(`Generated seed data for ${seedData.length} campsites in ${outputPath}`);
+console.log(`Generated seed for ${seedData.length - 1} campsites + the _inventory key in ${outputPath}`);

--- a/backend/src/inventory.test.ts
+++ b/backend/src/inventory.test.ts
@@ -1,0 +1,43 @@
+import { expect, test, describe } from 'vitest';
+import { loadInventory, bundledInventory, INVENTORY_KEY } from './inventory';
+
+// A KVNamespace stub that serves one `_inventory` value (or throws / returns null).
+function kvStub(value: unknown, { key = INVENTORY_KEY } = {}) {
+  return {
+    get: async (k: string) => (k === key ? value : null),
+  } as unknown as KVNamespace;
+}
+
+const CUSTOM = [
+  { id: '999', guid: 'guid-from-kv', name: 'KV Camp', kind: 'rec', ref: '999', agency: 'usfs', collect: true },
+];
+
+describe('loadInventory — KV is the source of truth, bundled is the fallback', () => {
+  test('prefers the KV _inventory when present', async () => {
+    const inv = await loadInventory(kvStub(CUSTOM));
+    expect(inv).toEqual(CUSTOM);
+    expect(inv).not.toBe(bundledInventory);
+  });
+
+  test('falls back to the bundled inventory when KV has no namespace', async () => {
+    const inv = await loadInventory(undefined);
+    expect(inv).toBe(bundledInventory);
+    expect(inv.length).toBeGreaterThan(0);
+  });
+
+  test('falls back when KV returns null (unseeded key)', async () => {
+    const inv = await loadInventory(kvStub(null));
+    expect(inv).toBe(bundledInventory);
+  });
+
+  test('falls back when KV returns an empty array', async () => {
+    const inv = await loadInventory(kvStub([]));
+    expect(inv).toBe(bundledInventory);
+  });
+
+  test('falls back when the KV get throws', async () => {
+    const throwing = { get: async () => { throw new Error('kv down'); } } as unknown as KVNamespace;
+    const inv = await loadInventory(throwing);
+    expect(inv).toBe(bundledInventory);
+  });
+});

--- a/backend/src/inventory.ts
+++ b/backend/src/inventory.ts
@@ -1,0 +1,48 @@
+/**
+ * The campsite inventory — which sites exist, their provider mapping (kind + ref/id),
+ * guid, geo, and the `collect` flag. This is the **collector's source of truth**.
+ *
+ * KV (`CAMPSITES` under the single `_inventory` key) is authoritative at runtime; the
+ * bundled `campsites-index.json` is the fallback used when KV is empty/unavailable.
+ * The KV copy is refreshed on deploy (`.github/workflows/deploy-kv.yaml`) from the
+ * inventory the camping-vault pydoit job lands in the repo — so the collector picks up
+ * inventory changes **without a Worker redeploy**, while a fresh/empty KV still works
+ * off the bundled fallback.
+ */
+import bundled from './campsites-index.json';
+
+// Single KV key holding the whole inventory array (one get, not 156 keys). Underscored
+// so it can't collide with a campsite slug used by GET /campsite/:id.
+export const INVENTORY_KEY = '_inventory';
+
+export type InventoryEntry = {
+  id: string;
+  guid: string;
+  name: string;
+  kind?: 'rec' | 'wa';
+  ref?: string | number;
+  agency?: string;
+  agency_full?: string;
+  lat?: number | null;
+  lng?: number | null;
+  collect?: boolean | null;
+};
+
+export const bundledInventory = bundled as unknown as InventoryEntry[];
+
+/**
+ * Load the inventory, preferring the KV copy and falling back to the bundled JSON.
+ * Any KV miss/parse error/empty array falls back, so a Worker with an unseeded KV
+ * still collects off the build-time inventory.
+ */
+export async function loadInventory(kv?: KVNamespace): Promise<InventoryEntry[]> {
+  if (kv) {
+    try {
+      const fromKv = await kv.get<InventoryEntry[]>(INVENTORY_KEY, { type: 'json' });
+      if (Array.isArray(fromKv) && fromKv.length > 0) return fromKv;
+    } catch {
+      // fall through to the bundled fallback
+    }
+  }
+  return bundledInventory;
+}

--- a/backend/src/read-api.test.ts
+++ b/backend/src/read-api.test.ts
@@ -140,4 +140,21 @@ describe('/collectors — fleet health (current state, no history)', () => {
     expect(overdue?.state).toBe('overdue');
     expect(overdue?.fails).toBe(2);
   });
+
+  test('reads the inventory from KV (_inventory) when present, not the bundled JSON', async () => {
+    const RAW = seedWithHeartbeat();
+    // KV serves a one-entry inventory — /collectors must reflect *that*, proving KV is
+    // the runtime source of truth (the bundled JSON has 156 entries).
+    const CAMPSITES = {
+      get: async (k: string) =>
+        k === '_inventory'
+          ? [{ id: '777', guid: 'guid-kv-only', name: 'KV-only Camp', kind: 'rec', ref: '777', agency: 'usfs', collect: true }]
+          : null,
+    } as unknown as KVNamespace;
+
+    const res = await app.request(`/collectors?now=${NOW}`, {}, { RAW, CAMPSITES } as any);
+    const body = (await res.json()) as any[];
+    expect(body).toHaveLength(1);
+    expect(body[0]).toMatchObject({ guid: 'guid-kv-only', name: 'KV-only Camp' });
+  });
 });

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -22,23 +22,19 @@
  * the WEBAPP_PLAN flags for the Cache-API/rollup optimization is /availability?date=).
  */
 import { Hono } from 'hono';
-import index from './campsites-index.json';
+import { loadInventory, type InventoryEntry } from './inventory';
 
-type ReadEnv = { RAW: R2Bucket };
+// CAMPSITES (KV) holds the authoritative inventory under `_inventory`; RAW (R2) holds
+// the collected snapshots. The inventory is read per request (loadInventory) so a
+// deploy that refreshes KV is reflected without a Worker redeploy.
+type ReadEnv = { RAW: R2Bucket; CAMPSITES?: KVNamespace };
 
-type InventoryEntry = {
-  id: string;
-  guid: string;
-  name: string;
-  agency?: string;
-  agency_full?: string;
-  lat?: number | null;
-  lng?: number | null;
-  collect?: boolean | null;
-};
-
-const INVENTORY = index as unknown as InventoryEntry[];
-const BY_GUID = new Map(INVENTORY.map((e) => [e.guid, e]));
+// Per-request inventory + guid index. Rebuilding the Map each request is negligible
+// next to the R2 fan-out these handlers already do.
+async function inventoryFor(env: ReadEnv): Promise<{ inventory: InventoryEntry[]; byGuid: Map<string, InventoryEntry> }> {
+  const inventory = await loadInventory(env.CAMPSITES);
+  return { inventory, byGuid: new Map(inventory.map((e) => [e.guid, e])) };
+}
 
 // How many recent date-partitions to scan when resolving the newest snapshot per
 // site. Collection cadence is ~daily within MAX_STALENESS_DAYS, but a quarantined
@@ -112,12 +108,13 @@ readApi.get('/availability', async (c) => {
   if (!date || !DATE_RE.test(date)) return c.json({ error: 'need ?date=YYYY-MM-DD' }, 400);
   const pinned = c.req.query('collected');
 
+  const { inventory } = await inventoryFor(c.env);
   const latest = pinned
-    ? new Map(INVENTORY.map((e) => [e.id, pinned]))
+    ? new Map(inventory.map((e) => [e.id, pinned]))
     : await latestByProvider(c.env, 'summary');
 
   const out: any[] = [];
-  for (const e of INVENTORY) {
+  for (const e of inventory) {
     const collDate = latest.get(e.id);
     if (!collDate) continue;
     const snap = await getJson<{ by_date?: Record<string, Counts> }>(c.env, `summary/${collDate}/${e.id}.json`);
@@ -141,7 +138,8 @@ readApi.get('/availability', async (c) => {
 // GET /availability/:guid/site/:siteId — one site's per-night status calendar.
 // :siteId is the internal R2 site id (e.g. 81835), NOT the human label ("24").
 readApi.get('/availability/:guid/site/:siteId', async (c) => {
-  const entry = BY_GUID.get(c.req.param('guid'));
+  const { byGuid } = await inventoryFor(c.env);
+  const entry = byGuid.get(c.req.param('guid'));
   if (!entry) return c.json({ error: 'unknown guid' }, 404);
   const siteId = c.req.param('siteId');
 
@@ -168,7 +166,8 @@ readApi.get('/availability/:guid/site/:siteId', async (c) => {
 // The "individual site number" filter resolves the human `label` ("24") → siteId
 // against this list, so we surface both.
 readApi.get('/availability/:guid', async (c) => {
-  const entry = BY_GUID.get(c.req.param('guid'));
+  const { byGuid } = await inventoryFor(c.env);
+  const entry = byGuid.get(c.req.param('guid'));
   if (!entry) return c.json({ error: 'unknown guid' }, 404);
   const date = c.req.query('date');
   if (!date || !DATE_RE.test(date)) return c.json({ error: 'need ?date=YYYY-MM-DD' }, 400);
@@ -203,7 +202,8 @@ readApi.get('/collectors', async (c) => {
 
   const lastDates = await latestByProvider(c.env, 'summary');
 
-  const out = INVENTORY.map((e) => {
+  const { inventory } = await inventoryFor(c.env);
+  const out = inventory.map((e) => {
     const collect = e.collect !== false;
     const lastCollectedDate = lastDates.get(e.id) ?? null;
     const ageDays = lastCollectedDate ? Math.floor((now - Date.parse(lastCollectedDate)) / 86_400_000) : null;

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -11,12 +11,13 @@
  *  2. HotDateWatchWorkflow — adaptive dense watcher for one (campsite, target_date).
  */
 import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:workers";
-import index from "./campsites-index.json";
+import { loadInventory } from "./inventory";
 import { fetchAvailability, type Counts } from "./availability";
 import { type DueMap, type FailMap, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs, retryBackoffMs } from "./scheduler";
 
 export interface WfEnv {
   RAW: R2Bucket;
+  CAMPSITES?: KVNamespace; // inventory source of truth (_inventory key); bundled fallback
   COLLECTOR_WF: Workflow; // self-reference for continue-as-new
   MAX_STALENESS_DAYS?: string;
   INACTIVE_AFTER_FAILURES?: string; // consecutive failures before a site is quarantined
@@ -175,7 +176,12 @@ type LoopPayload = { due?: DueMap; collectedTotal?: number; fails?: FailMap; pro
 
 export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
   async run(event: WorkflowEvent<LoopPayload>, step: WorkflowStep) {
-    const sites = (index as unknown as Site[]).filter((s) => s.collect !== false);
+    // Load the inventory from KV (bundled fallback) inside a step so the snapshot is
+    // checkpointed for this run's lifetime — replay-safe. Each continue-as-new re-runs
+    // this and picks up an inventory refreshed in KV since, with no Worker redeploy.
+    const sites = await step.do("load-inventory", async () =>
+      (await loadInventory(this.env.CAMPSITES) as unknown as Site[]).filter((s) => s.collect !== false),
+    );
     const X = (Number(this.env.MAX_STALENESS_DAYS ?? "2") || 2) * 86_400_000;
     const inactiveAfter = Math.max(1, Number(this.env.INACTIVE_AFTER_FAILURES ?? "") || INACTIVE_AFTER_DEFAULT);
     const ae = this.env.COLLECTOR_AE;


### PR DESCRIPTION
`BACKEND` — **SOURCE OF TRUTH**

# KV becomes the inventory the collector reads

> _The inventory was baked into the Worker at build time, so changing which campgrounds get collected meant a redeploy. This makes the CAMPSITES KV the runtime source of truth — the daily vault→inventory job's merge refreshes KV, and the collector picks it up on its own._

> [!NOTE]
> **backend** · feat · risk: low · safe before KV is populated (bundled fallback) · CI write is gated on a secret

The camping-vault pydoit job already lands an enriched `campsites-index.json` via the `bot/inventory-sync` PR, and CI derives the map GeoJSON from it. But the **collector** read that file as a bundled import — so a fresh inventory only took effect on the next Worker deploy. This closes that loop: the collector and read API read the inventory from KV, and merging the inventory to main writes KV.

## What changed

- **`inventory.ts`** — `loadInventory(kv)`: KV-first (`_inventory` key, one get for the whole array), **bundled `campsites-index.json` as fallback** on any miss/parse-error/empty. A Worker with an unseeded KV still collects.
- **`workflows.ts`** — the `CollectorLoop` loads the inventory inside a **checkpointed step** (replay-safe); each continue-as-new picks up a refreshed inventory with no redeploy.
- **`read-api.ts`** — loads the inventory per request, so `/availability` + `/collectors` reflect a KV refresh immediately.
- **`generate-seed.cjs`** — emits the `_inventory` key, so local/CI KV matches what a deploy pushes.
- **`deploy-kv.yaml`** — on merge to main touching `campsites-index.json`, writes `_inventory` to the **live** KV (`wrangler kv key put --remote`). **Gated** to skip if `CLOUDFLARE_API_TOKEN` is unset, so it stays green until the token is wired.

## How the refresh flows

```mermaid
flowchart TD
  V["camping vault"] --> P["pydoit job (Nomad)"]
  P --> PR["bot/inventory-sync PR"]
  PR -->|merge to main| CI["deploy-kv CI"]
  CI -->|wrangler kv key put _inventory --remote| KV[("CAMPSITES KV")]
  KV -->|loadInventory, bundled fallback| C["CollectorLoop + read API"]
```

## Verification

- **36 backend tests** pass (5 new in `inventory.test.ts` covering KV-vs-fallback precedence + a `read-api` case proving `/collectors` reflects a KV-provided inventory); `tsc --noEmit` clean.
- `generate-seed.cjs` → 156 campsites + the `_inventory` key (156 entries) in `kv-seed.json`; CI seeds it `--local`, so the e2e `/collectors` probe now reads from KV.

## Risk & rollout — one-time setup to activate

Merging is safe immediately (fallback + gated workflow). To turn on the live refresh, a **vended KV-write token** is wired as the repo secret (config staged in `cloudflare-tfvend`):

- [ ] `terraform apply` in `cloudflare-tfvend` to mint `rgs-kv-write` (verify the KV permission-group id first)
- [ ] `gh secret set CLOUDFLARE_API_TOKEN` from the vended token
- [ ] one-time `wrangler kv key put _inventory --path backend/src/campsites-index.json --binding CAMPSITES --remote` to seed live KV now

Least-privilege: the token is scoped to Workers KV Storage Write on this account only — no Access, R2, or Worker-deploy rights.
