### PR TITLE
fix(ci): deploy-kv needs --preview false for the CAMPSITES write

### DIFF
--- a/.github/workflows/deploy-kv.yaml
+++ b/.github/workflows/deploy-kv.yaml
@@ -39,4 +39,5 @@ jobs:
           npx --yes wrangler@4 kv key put _inventory \
             --path src/campsites-index.json \
             --binding CAMPSITES \
+            --preview false \
             --remote


### PR DESCRIPTION
`CI` — **HOTFIX**

# deploy-kv writes the production namespace, not a guess

> _The `deploy-kv` workflow's `wrangler kv key put` would fail: the CAMPSITES binding declares both a namespace id and a preview id, so wrangler refuses to write without an explicit target. This adds `--preview false`._

> [!NOTE]
> **ci** · fix · risk: none · one-line workflow change

`wrangler kv key put _inventory … --binding CAMPSITES --remote` errors with _"CAMPSITES has both a namespace ID and a preview ID. Specify --preview or --preview false"_. The deploy must target the production namespace, so `--preview false` is added.

Caught while populating live KV by hand for the first time — that manual `kv key put` (with `--preview false`) succeeded and the live `_inventory` key now holds 156 entries, so the corrected command is verified against the real namespace.

## Verification

- `wrangler kv key put _inventory --path src/campsites-index.json --binding CAMPSITES --preview false --remote` → wrote the production namespace; `kv key get` reads back 156 entries.
- The gated backend `/collectors` now returns 156 sourced from the live KV `_inventory`.
