### PR TITLE
feat(backend): /availability reports total remaining + per-season availability

### DIFF
--- a/backend/src/read-api.test.ts
+++ b/backend/src/read-api.test.ts
@@ -51,6 +51,25 @@ describe('/availability — aggregate map (the known reservation)', () => {
     const res = await app.request('/availability', {}, { RAW } as any);
     expect(res.status).toBe(400);
   });
+
+  test('reports total remaining availability + per-season breakdown (nights on/after date)', async () => {
+    const RAW = makeR2({
+      [`summary/2026-06-01/${MF_ID}.json`]: {
+        id: MF_ID,
+        by_date: {
+          '2026-05-01': { available: 9, reserved: 0, total: 9 }, // Spring, BEFORE date → excluded
+          '2026-06-05': { available: 2, reserved: 1, total: 3 }, // Summer
+          '2026-06-06': { available: 1, reserved: 2, total: 3 }, // Summer
+          '2026-09-23': { available: 4, reserved: 0, total: 4 }, // Fall
+        },
+      },
+    });
+    const res = await app.request('/availability?date=2026-06-05', {}, { RAW } as any);
+    const mf = ((await res.json()) as any[]).find((e) => e.guid === MF_GUID);
+    expect(mf.remaining).toBe(7); // 2+1+4 (05-01 excluded)
+    expect(mf.remainingTotal).toBe(10); // 3+3+4
+    expect(mf.remainingBySeason).toMatchObject({ Summer: 3, Fall: 4, Spring: 0, Winter: 0 });
+  });
 });
 
 describe('/availability/:guid — per-campground site list for a night', () => {

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -43,6 +43,15 @@ async function inventoryFor(env: ReadEnv): Promise<{ inventory: InventoryEntry[]
 const LOOKBACK_PARTITIONS = 30;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
+// Northern-hemisphere meteorological seasons, keyed off the month of a YYYY-MM-DD.
+function seasonOf(d: string): 'Winter' | 'Spring' | 'Summer' | 'Fall' {
+  const m = Number(d.slice(5, 7));
+  if (m === 12 || m <= 2) return 'Winter';
+  if (m <= 5) return 'Spring';
+  if (m <= 8) return 'Summer';
+  return 'Fall';
+}
+
 type Counts = { available: number; reserved: number; total: number };
 
 async function listAll(env: ReadEnv, opts: { prefix: string; delimiter?: string }) {
@@ -119,7 +128,23 @@ readApi.get('/availability', async (c) => {
     if (!collDate) continue;
     const snap = await getJson<{ by_date?: Record<string, Counts> }>(c.env, `summary/${collDate}/${e.id}.json`);
     if (!snap) continue;
-    const counts = snap.by_date?.[date] ?? null;
+    const byDate = snap.by_date ?? {};
+    const counts = byDate[date] ?? null;
+
+    // Total REMAINING availability for the campground: available campsite-nights summed
+    // across every captured night on/after `date`, plus a per-season breakdown. This is
+    // the map's default metric (and the little per-pin availability bar).
+    let remaining = 0;
+    let remainingTotal = 0;
+    const remainingBySeason = { Winter: 0, Spring: 0, Summer: 0, Fall: 0 };
+    for (const [d, cnt] of Object.entries(byDate)) {
+      if (d < date) continue;
+      const a = cnt?.available ?? 0;
+      remaining += a;
+      remainingTotal += cnt?.total ?? 0;
+      remainingBySeason[seasonOf(d)] += a;
+    }
+
     out.push({
       guid: e.guid,
       name: e.name,
@@ -129,6 +154,9 @@ readApi.get('/availability', async (c) => {
       available: counts?.available ?? null,
       reserved: counts?.reserved ?? null,
       total: counts?.total ?? null,
+      remaining,
+      remainingTotal,
+      remainingBySeason,
       collected_date: collDate,
     });
   }


### PR DESCRIPTION
`BACKEND` — **READ API**

# /availability learns the whole season, not just one night

> _The map could only color a campground by one night's open count. This adds total remaining availability — open campsite-nights summed across every captured night on/after the date, with a per-season breakdown — so the map can default to "how much is left this season" and draw a per-pin availability bar._

> [!NOTE]
> **backend** · feat · risk: low · additive fields, gated endpoint, one R2 read

The `/availability` handler already fetches each campground's full `summary` (every night's `{available, reserved, total}`) but only projected one night. It now also sums the remaining window.

## Added fields (per campground)

- **`remaining`** — open campsite-nights summed across captured nights on/after `date`.
- **`remainingTotal`** — total campsite-nights over the same window (for ratios).
- **`remainingBySeason`** — `{ Winter, Spring, Summer, Fall }` of the same open-night sum.

Existing `available` / `reserved` / `total` (single night) are unchanged.

## Verification

- 37 backend tests pass (typecheck clean), incl. a new case: a 4-night, multi-season summary → `remaining` excludes nights before `date`, and the Summer/Fall split is correct.

## Rollout

Deploy refreshes the gated Worker behind Cloudflare Access — additive fields only, no new surface. The frontend (per-location panes branch) defaults the map metric to `remaining` and draws the per-pin bar once this is live.
