### PR TITLE
chore(backend): drop remainingBySeason from /availability

### DIFF
--- a/backend/src/read-api.test.ts
+++ b/backend/src/read-api.test.ts
@@ -52,15 +52,15 @@ describe('/availability — aggregate map (the known reservation)', () => {
     expect(res.status).toBe(400);
   });
 
-  test('reports total remaining availability + per-season breakdown (nights on/after date)', async () => {
+  test('reports total remaining availability (nights on/after date)', async () => {
     const RAW = makeR2({
       [`summary/2026-06-01/${MF_ID}.json`]: {
         id: MF_ID,
         by_date: {
-          '2026-05-01': { available: 9, reserved: 0, total: 9 }, // Spring, BEFORE date → excluded
-          '2026-06-05': { available: 2, reserved: 1, total: 3 }, // Summer
-          '2026-06-06': { available: 1, reserved: 2, total: 3 }, // Summer
-          '2026-09-23': { available: 4, reserved: 0, total: 4 }, // Fall
+          '2026-05-01': { available: 9, reserved: 0, total: 9 }, // BEFORE date → excluded
+          '2026-06-05': { available: 2, reserved: 1, total: 3 },
+          '2026-06-06': { available: 1, reserved: 2, total: 3 },
+          '2026-09-23': { available: 4, reserved: 0, total: 4 },
         },
       },
     });
@@ -68,7 +68,7 @@ describe('/availability — aggregate map (the known reservation)', () => {
     const mf = ((await res.json()) as any[]).find((e) => e.guid === MF_GUID);
     expect(mf.remaining).toBe(7); // 2+1+4 (05-01 excluded)
     expect(mf.remainingTotal).toBe(10); // 3+3+4
-    expect(mf.remainingBySeason).toMatchObject({ Summer: 3, Fall: 4, Spring: 0, Winter: 0 });
+    expect(mf.remainingBySeason).toBeUndefined();
   });
 });
 

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -43,15 +43,6 @@ async function inventoryFor(env: ReadEnv): Promise<{ inventory: InventoryEntry[]
 const LOOKBACK_PARTITIONS = 30;
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-// Northern-hemisphere meteorological seasons, keyed off the month of a YYYY-MM-DD.
-function seasonOf(d: string): 'Winter' | 'Spring' | 'Summer' | 'Fall' {
-  const m = Number(d.slice(5, 7));
-  if (m === 12 || m <= 2) return 'Winter';
-  if (m <= 5) return 'Spring';
-  if (m <= 8) return 'Summer';
-  return 'Fall';
-}
-
 type Counts = { available: number; reserved: number; total: number };
 
 async function listAll(env: ReadEnv, opts: { prefix: string; delimiter?: string }) {
@@ -132,17 +123,14 @@ readApi.get('/availability', async (c) => {
     const counts = byDate[date] ?? null;
 
     // Total REMAINING availability for the campground: available campsite-nights summed
-    // across every captured night on/after `date`, plus a per-season breakdown. This is
-    // the map's default metric (and the little per-pin availability bar).
+    // across every captured night on/after `date`. This is the map's default metric
+    // (and the per-pin availability disc).
     let remaining = 0;
     let remainingTotal = 0;
-    const remainingBySeason = { Winter: 0, Spring: 0, Summer: 0, Fall: 0 };
     for (const [d, cnt] of Object.entries(byDate)) {
       if (d < date) continue;
-      const a = cnt?.available ?? 0;
-      remaining += a;
+      remaining += cnt?.available ?? 0;
       remainingTotal += cnt?.total ?? 0;
-      remainingBySeason[seasonOf(d)] += a;
     }
 
     out.push({
@@ -156,7 +144,6 @@ readApi.get('/availability', async (c) => {
       total: counts?.total ?? null,
       remaining,
       remainingTotal,
-      remainingBySeason,
       collected_date: collDate,
     });
   }


### PR DESCRIPTION
`BACKEND` — **CLEANUP**

# /availability drops the unused per-season breakdown

> _The frontend stopped reading `remainingBySeason` when the map became a single rest-of-year availability disc. This removes the field (and the season helper) from the API — `remaining` and `remainingTotal` are unchanged._

> [!NOTE]
> **backend** · chore · risk: low · removes one response field, gated endpoint

## What changed

- `/availability` no longer computes or returns **`remainingBySeason`**; the `seasonOf` helper is gone. Per campground it still reports `available`/`reserved`/`total` (single night) and `remaining`/`remainingTotal` (rest of year).

## Verification

- 37 backend tests pass (typecheck clean); the totals test now asserts `remainingBySeason` is `undefined`.

## Rollout

Deploy refreshes the gated Worker behind Cloudflare Access — one field removed, no new surface. No consumer depends on the field (the frontend already ignores it).
