### PR TITLE
feat(infra): Access gate + social IdPs for the deployed frontend

### DIFF
--- a/infra/access/frontend.tf
+++ b/infra/access/frontend.tf
@@ -1,0 +1,38 @@
+# The trusted auth boundary for the DEPLOYED frontend (Cloudflare Pages). The Pages
+# app is reachable at two custom subdomains and the *.pages.dev alias; every one must
+# require an Owner SSO login before serving the app. This is a PRIVATE project — no
+# unauthenticated path. The /api/* Pages Function reaches the backend over an internal
+# service binding, so the only gate prod users see is this SSO login.
+locals {
+  # All hostnames the Pages project answers on. The pages.dev alias is derived from
+  # the Pages project name (robot-geographical-society-web) and MUST be gated too, or
+  # the app would be publicly reachable there.
+  frontend_hostnames = [
+    "campsites.robogeosociety.xyz",
+    "collectors.robogeosociety.xyz",
+    "robot-geographical-society-web.pages.dev",
+    # Per-deployment/preview URLs are <hash>.robot-geographical-society-web.pages.dev —
+    # a DIFFERENT hostname than the apex above, so they need their own wildcard gate or
+    # the deployment is publicly reachable (and /api would proxy backend data).
+    "*.robot-geographical-society-web.pages.dev",
+  ]
+}
+
+resource "cloudflare_zero_trust_access_application" "frontend" {
+  for_each             = toset(local.frontend_hostnames)
+  account_id           = var.account_id
+  name                 = "RGS frontend (${each.value})"
+  domain               = each.value
+  type                 = "self_hosted"
+  session_duration     = "24h"
+  app_launcher_visible = false
+
+  policies = [
+    {
+      name       = "Owner SSO"
+      decision   = "allow"
+      precedence = 1
+      include    = [{ email = { email = var.allow_email } }]
+    },
+  ]
+}

--- a/infra/access/idp.tf
+++ b/infra/access/idp.tf
@@ -1,0 +1,29 @@
+# Social identity providers for the Access login, alongside the built-in one-time-PIN
+# (email OTP stays available). A login via any of these returns the user's email, which
+# the existing Owner-SSO policies match on, and which the app's RBAC maps to a role.
+#
+# Client IDs are not secret (they appear in OAuth redirects) → committed here.
+# Client SECRETS are sensitive vars — never committed, never the dashboard. Pass at
+# apply via `TF_VAR_github_client_secret=…` / `TF_VAR_google_client_secret=…`.
+
+resource "cloudflare_zero_trust_access_identity_provider" "github" {
+  account_id = var.account_id
+  name       = "GitHub"
+  type       = "github"
+  config = {
+    client_id     = "Ov23lidku36t1OHH7wPz"
+    client_secret = var.github_client_secret
+  }
+}
+
+# Reuses the repurposed Grafana Google OAuth client (see the Human task) rather than a
+# new one — its lifecycle is now coupled to Access.
+resource "cloudflare_zero_trust_access_identity_provider" "google" {
+  account_id = var.account_id
+  name       = "Google"
+  type       = "google"
+  config = {
+    client_id     = "803168508280-3q5oqrnuvp6fb2k61bu7q7k7tc79ogkm.apps.googleusercontent.com"
+    client_secret = var.google_client_secret
+  }
+}

--- a/infra/access/variables.tf
+++ b/infra/access/variables.tf
@@ -15,3 +15,20 @@ variable "allow_email" {
   type        = string
   default     = "tommy.b.doerr@gmail.com"
 }
+
+# Social IdP client secrets — sensitive, never committed. Pass at apply via
+# TF_VAR_github_client_secret / TF_VAR_google_client_secret (empty default so a
+# targeted apply of one IdP doesn't require the other's secret).
+variable "github_client_secret" {
+  description = "GitHub OAuth app client secret for the Access GitHub IdP."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth client secret for the Access Google IdP."
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
`INFRA` — **ACCESS**

# Track the live Access gate + social IdPs for the frontend

> _The Pages deploy's Access boundary was applied to Cloudflare but never committed. This lands the IaC: the frontend Access apps (including the wildcard that gates per-deployment URLs) and the GitHub + Google social IdPs._

> [!NOTE]
> **infra** · feat · risk: low · IaC only (already applied)

## What's tracked

- **frontend.tf** — self-hosted Access apps gating every frontend hostname with Owner-SSO: `campsites.`/`collectors.robogeosociety.xyz`, the apex `*.pages.dev`, **and** the wildcard `*.robot-geographical-society-web.pages.dev` — without the wildcard a per-deployment hash URL is publicly reachable (incl. `/api` data).
- **idp.tf** — GitHub + Google social IdPs alongside the built-in one-time-PIN. GitHub is applied; Google awaits its client secret. Client ids are committed (not secret); secrets are sensitive `TF_VAR_*`, never committed.
- **variables.tf** — the `github_client_secret` / `google_client_secret` sensitive vars.

## Verification

- `terraform plan` clean; applied with the cloudflare-tfvend admin token (now carrying Identity Providers Write). Unauthenticated → 302 on every frontend hostname.
