### PR TITLE
feat: app-level RBAC over Cloudflare Access (admin gates mutations)

### DIFF
--- a/backend/src/auth.ts
+++ b/backend/src/auth.ts
@@ -1,0 +1,65 @@
+import type { Context, Next } from 'hono';
+
+// App-level RBAC over Cloudflare Access. Every request that reaches the Worker has
+// already passed Access (public hostnames are gated; the only other path — the Pages
+// Function service binding — runs behind the Access-gated Pages app), and Access
+// stamps a verified identity in the `Cf-Access-Jwt-Assertion` header. We read the
+// email from it and map it to a role:
+//   - the vended service token (local dev proxy / Tailscale) → admin (it's the owner's)
+//   - the BOOTSTRAP_ADMIN email → admin (deterministic first admin)
+//   - an email with a `role:<email>` = "admin" KV entry → admin
+//   - anyone else authenticated → viewer
+// Reads are open to any authenticated user; mutations require admin (see adminOnly).
+
+export type Role = 'admin' | 'viewer';
+export type Identity = { email: string | null; serviceToken: string | null };
+
+type AuthEnv = { CAMPSITES: KVNamespace; BOOTSTRAP_ADMIN?: string };
+
+export const ROLE_PREFIX = 'role:';
+
+// Decode (not verify) the Access JWT payload — Access already verified the signature at
+// the edge before the request reached us. Verifying against the team JWKS is a
+// defense-in-depth follow-up.
+function decodeJwtPayload(token: string): any | null {
+  const part = token.split('.')[1];
+  if (!part) return null;
+  try {
+    const b64 = part.replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    return JSON.parse(atob(padded));
+  } catch {
+    return null;
+  }
+}
+
+export function identify(req: Request): Identity {
+  const jwt = req.headers.get('Cf-Access-Jwt-Assertion');
+  const claims = jwt ? decodeJwtPayload(jwt) : null;
+  const email = typeof claims?.email === 'string' ? claims.email.toLowerCase() : null;
+  // Service-token (non_identity) logins carry `common_name` and no email.
+  const serviceToken = !email && typeof claims?.common_name === 'string' ? claims.common_name : null;
+  return { email, serviceToken };
+}
+
+export async function roleFor(env: AuthEnv, id: Identity): Promise<Role> {
+  if (id.serviceToken) return 'admin'; // owner's vended dev token
+  if (!id.email) return 'viewer';
+  if (env.BOOTSTRAP_ADMIN && id.email === env.BOOTSTRAP_ADMIN.toLowerCase()) return 'admin';
+  return (await env.CAMPSITES.get(`${ROLE_PREFIX}${id.email}`)) === 'admin' ? 'admin' : 'viewer';
+}
+
+export async function whoami(env: AuthEnv, req: Request) {
+  const id = identify(req);
+  const role = await roleFor(env, id);
+  return { email: id.email, serviceToken: id.serviceToken, role, isAdmin: role === 'admin' };
+}
+
+// Hono middleware: 403 unless the caller is an admin.
+export function adminOnly() {
+  return async (c: Context, next: Next) => {
+    const role = await roleFor(c.env, identify(c.req.raw));
+    if (role !== 'admin') return c.json({ error: 'admin role required' }, 403);
+    await next();
+  };
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,6 +3,7 @@ import { cors } from 'hono/cors';
 import campsites from './campsites-index.json';
 import { collectSite, HEARTBEAT_KEY, DLQ_PREFIX, listDlqIds, type WfEnv, type DlqEntry } from './workflows';
 import { readApi } from './read-api';
+import { whoami, adminOnly, ROLE_PREFIX } from './auth';
 
 // Cloudflare Workflows must be exported from the entry module by class name.
 export { CollectorLoop, HotDateWatchWorkflow } from './workflows';
@@ -10,6 +11,7 @@ export { CollectorLoop, HotDateWatchWorkflow } from './workflows';
 type Bindings = WfEnv & {
   CAMPSITES: KVNamespace;
   WATCH_WF: Workflow;
+  BOOTSTRAP_ADMIN?: string; // email that is always admin (RBAC bootstrap)
 };
 
 // If no heartbeat younger than this, the loop is considered dead → (re)start it.
@@ -30,6 +32,36 @@ app.get('/', (c) => c.text('Robot Geographical Society Backend API'));
 // Read-only availability + collector-health endpoints (the two-view webapp).
 app.route('/', readApi);
 
+// --- Identity & RBAC ---------------------------------------------------------
+// Who the caller is (from the Access identity) and their role. The frontend uses this
+// to show/hide admin actions; the backend enforces regardless (adminOnly below).
+app.get('/me', async (c) => c.json(await whoami(c.env, c.req.raw)));
+
+// Admin-only role management. BOOTSTRAP_ADMIN is always admin (not stored); these grant
+// or revoke admin for other emails.
+app.get('/admin/users', adminOnly(), async (c) => {
+  const list = await c.env.CAMPSITES.list({ prefix: ROLE_PREFIX });
+  const users = list.keys.map((k) => ({ email: k.name.slice(ROLE_PREFIX.length), role: 'admin' }));
+  return c.json({ bootstrapAdmin: c.env.BOOTSTRAP_ADMIN ?? null, users });
+});
+
+app.post('/admin/elevate', adminOnly(), async (c) => {
+  const email = (c.req.query('email') ?? '').toLowerCase();
+  if (!email) return c.json({ error: 'need ?email=' }, 400);
+  await c.env.CAMPSITES.put(`${ROLE_PREFIX}${email}`, 'admin');
+  return c.json({ email, role: 'admin' });
+});
+
+app.post('/admin/demote', adminOnly(), async (c) => {
+  const email = (c.req.query('email') ?? '').toLowerCase();
+  if (!email) return c.json({ error: 'need ?email=' }, 400);
+  if (c.env.BOOTSTRAP_ADMIN && email === c.env.BOOTSTRAP_ADMIN.toLowerCase()) {
+    return c.json({ error: 'cannot demote the bootstrap admin' }, 400);
+  }
+  await c.env.CAMPSITES.delete(`${ROLE_PREFIX}${email}`);
+  return c.json({ email, role: 'viewer' });
+});
+
 // GET /campsite/:id - Fetch individual campsite details (agency-prefixed slash ids).
 app.get('/campsite/:id{.+}', async (c) => {
   const id = c.req.param('id');
@@ -39,7 +71,7 @@ app.get('/campsite/:id{.+}', async (c) => {
 });
 
 // POST /seed - Seed the KV store with data (dev only).
-app.post('/seed', async (c) => {
+app.post('/seed', adminOnly(), async (c) => {
   try {
     const data = await c.req.json();
     for (const item of data) await c.env.CAMPSITES.put(item.key, item.value);
@@ -57,7 +89,7 @@ app.get('/campsites', async (c) => {
 // Start the deadline-driven collector loop. No-op if a fresh heartbeat shows one
 // already alive, unless ?force=1 (use after a crash/terminate, e.g. in response to
 // a staleness alert — the heartbeat can read "alive" even when no instance runs).
-app.post('/collect/start', async (c) => {
+app.post('/collect/start', adminOnly(), async (c) => {
   const force = c.req.query('force') === '1';
   const { alive, hb } = await loopAlive(c.env);
   if (alive && !force) return c.json({ status: 'already-running', lastWakeISO: hb?.lastWakeISO });
@@ -96,7 +128,7 @@ app.get('/collect/dlq', async (c) => {
 // Reactivate a quarantined site: drop its DLQ entry. The CollectorLoop reconciles
 // against the DLQ each wake, so the site is re-armed for collection on the next
 // wake (or sooner via the daily probe). No-op-safe if the id isn't quarantined.
-app.post('/collect/reactivate', async (c) => {
+app.post('/collect/reactivate', adminOnly(), async (c) => {
   const id = c.req.query('id');
   if (!id) return c.json({ error: 'need ?id=<campsite id>' }, 400);
   const key = `${DLQ_PREFIX}${id}.json`;
@@ -107,7 +139,7 @@ app.post('/collect/reactivate', async (c) => {
 
 // Ad-hoc one-shot collection of a single campsite (backfill/debug) — independent
 // of the loop's schedule.
-app.post('/collect/site', async (c) => {
+app.post('/collect/site', adminOnly(), async (c) => {
   const id = c.req.query('id');
   const site = (campsites as any[]).find((s) => s.id === id);
   if (!site) return c.json({ error: 'need ?id=<campsite id>' }, 400);
@@ -121,7 +153,7 @@ app.post('/collect/site', async (c) => {
 });
 
 // Watch a single (campsite, target_date) with adaptive cadence until sold out.
-app.post('/watch', async (c) => {
+app.post('/watch', adminOnly(), async (c) => {
   const id = c.req.query('id');
   const date = c.req.query('date');
   const every = c.req.query('every') || undefined;

--- a/backend/src/rbac.test.ts
+++ b/backend/src/rbac.test.ts
@@ -1,0 +1,100 @@
+import { expect, test, describe } from 'vitest';
+import { app } from './index';
+import { identify, roleFor } from './auth';
+import { makeR2 } from '../test/stubs/r2';
+
+const ADMIN = 'tommy.b.doerr@gmail.com';
+
+// Fake Access JWT (header.payload.sig) — only the payload is decoded.
+function jwt(claims: Record<string, unknown>): string {
+  const b64url = btoa(JSON.stringify(claims)).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+  return `h.${b64url}.s`;
+}
+const hdr = (claims: Record<string, unknown>) => ({ 'Cf-Access-Jwt-Assertion': jwt(claims) });
+
+function makeKV(initial: Record<string, string> = {}) {
+  const m = new Map(Object.entries(initial));
+  return {
+    get: async (k: string) => (m.has(k) ? m.get(k)! : null),
+    put: async (k: string, v: string) => { m.set(k, v); },
+    delete: async (k: string) => { m.delete(k); },
+    list: async ({ prefix = '' }: { prefix?: string } = {}) => ({
+      keys: [...m.keys()].filter((k) => k.startsWith(prefix)).map((name) => ({ name })),
+    }),
+    _map: m,
+  };
+}
+const env = (over: Record<string, unknown> = {}) =>
+  ({ CAMPSITES: makeKV(), RAW: makeR2({}), BOOTSTRAP_ADMIN: ADMIN, ...over }) as any;
+
+describe('identify — Access JWT → identity', () => {
+  test('email login', () => {
+    expect(identify(new Request('http://x', { headers: hdr({ email: 'A@B.com' }) })))
+      .toEqual({ email: 'a@b.com', serviceToken: null });
+  });
+  test('service token (common_name, no email)', () => {
+    expect(identify(new Request('http://x', { headers: hdr({ common_name: 'rgs-local-dev' }) })))
+      .toEqual({ email: null, serviceToken: 'rgs-local-dev' });
+  });
+  test('no Access header → anonymous', () => {
+    expect(identify(new Request('http://x'))).toEqual({ email: null, serviceToken: null });
+  });
+});
+
+describe('roleFor — identity → role', () => {
+  test('service token → admin (owner dev token)', async () => {
+    expect(await roleFor(env(), { email: null, serviceToken: 'rgs-local-dev' })).toBe('admin');
+  });
+  test('bootstrap email → admin', async () => {
+    expect(await roleFor(env(), { email: ADMIN, serviceToken: null })).toBe('admin');
+  });
+  test('email with a role:<email>=admin KV entry → admin', async () => {
+    const e = env({ CAMPSITES: makeKV({ 'role:bob@x.com': 'admin' }) });
+    expect(await roleFor(e, { email: 'bob@x.com', serviceToken: null })).toBe('admin');
+  });
+  test('unknown authenticated email → viewer', async () => {
+    expect(await roleFor(env(), { email: 'rando@x.com', serviceToken: null })).toBe('viewer');
+  });
+  test('anonymous → viewer', async () => {
+    expect(await roleFor(env(), { email: null, serviceToken: null })).toBe('viewer');
+  });
+});
+
+describe('/me', () => {
+  test('reports admin for the bootstrap email', async () => {
+    const res = await app.request('/me', { headers: hdr({ email: ADMIN }) }, env());
+    expect(await res.json()).toMatchObject({ email: ADMIN, role: 'admin', isAdmin: true });
+  });
+  test('reports viewer for an unknown email', async () => {
+    const res = await app.request('/me', { headers: hdr({ email: 'rando@x.com' }) }, env());
+    expect(await res.json()).toMatchObject({ role: 'viewer', isAdmin: false });
+  });
+});
+
+describe('mutation guard (adminOnly)', () => {
+  test('viewer → 403 on /collect/reactivate', async () => {
+    const res = await app.request('/collect/reactivate?id=234501', { method: 'POST', headers: hdr({ email: 'rando@x.com' }) }, env());
+    expect(res.status).toBe(403);
+  });
+  test('admin (bootstrap) → 200', async () => {
+    const res = await app.request('/collect/reactivate?id=234501', { method: 'POST', headers: hdr({ email: ADMIN }) }, env());
+    expect(res.status).toBe(200);
+  });
+  test('service token → 200 (owner dev path)', async () => {
+    const res = await app.request('/collect/reactivate?id=234501', { method: 'POST', headers: hdr({ common_name: 'rgs-local-dev' }) }, env());
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('/admin/elevate', () => {
+  test('viewer cannot elevate (403)', async () => {
+    const res = await app.request('/admin/elevate?email=bob@x.com', { method: 'POST', headers: hdr({ email: 'rando@x.com' }) }, env());
+    expect(res.status).toBe(403);
+  });
+  test('admin elevates another email → that email becomes admin', async () => {
+    const e = env();
+    const res = await app.request('/admin/elevate?email=Bob@X.com', { method: 'POST', headers: hdr({ email: ADMIN }) }, e);
+    expect(res.status).toBe(200);
+    expect(await roleFor(e, { email: 'bob@x.com', serviceToken: null })).toBe('admin');
+  });
+});

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -66,6 +66,11 @@ MAX_STALENESS_DAYS = "2"
 # /collect/reactivate?id=) can revive it.
 INACTIVE_AFTER_FAILURES = "5"
 
+# RBAC bootstrap: this Access email is always admin (gates the /collect/* mutations and
+# the reactivate UI). Other admins are granted via POST /admin/elevate. Not a secret —
+# it's an allowlisted identity, not a credential.
+BOOTSTRAP_ADMIN = "tommy.b.doerr@gmail.com"
+
 # No cron. The CollectorLoop self-perpetuates via continue-as-new; a hard crash
 # is surfaced by Grafana → Discord staleness alerting (observability repo), and a
 # human restarts it with POST /collect/start?force=1.

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -12,6 +12,12 @@ async function getJSON(path) {
   return res.json();
 }
 
+// The caller's identity + role from Cloudflare Access: { email, role, isAdmin }.
+// Drives which admin-only actions the UI shows (the backend enforces regardless).
+export function getMe() {
+  return getJSON('/me');
+}
+
 // Fleet health: one row per inventory site (156), already carrying lat/lng so the
 // map can render straight from this. Shape:
 //   { guid, name, agency, lat, lng, collect, state, lastCollectedDate, ageDays, dueMs, fails }

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -551,6 +551,11 @@ body {
 .cal-cell.cal-reserved, .cal-cell.cal-other { color: rgba(255, 255, 255, 0.7); }
 
 /* Collectors fleet panel */
+.fleet-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
+.role-badge { font-size: 10px; text-transform: uppercase; letter-spacing: 0.05em; padding: 2px 8px; border-radius: 20px; }
+.role-admin { background: rgba(166, 226, 46, 0.15); color: var(--green); }
+.role-viewer { background: rgba(255, 255, 255, 0.06); color: var(--text-muted); }
+
 .fleet-panel {
   position: absolute;
   top: 56px;

--- a/web/src/views/CollectorsView.jsx
+++ b/web/src/views/CollectorsView.jsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMap } from '../map/MapContext';
 import { useCircleLayer, rowsToFC, HOVER_PAINT } from '../map/useCircleLayer';
-import { getCollectors, getDlq, reactivate } from '../api';
+import { getCollectors, getDlq, reactivate, getMe } from '../api';
 import { STATE_STYLE } from '../constants';
 
 const COLLECTOR_PAINT = {
@@ -23,6 +23,14 @@ export default function CollectorsView() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null);
+  const [isAdmin, setIsAdmin] = useState(false); // gates the reactivate action (backend enforces too)
+
+  // Resolve the caller's role; a /me failure just leaves the UI as viewer.
+  useEffect(() => {
+    let live = true;
+    getMe().then((me) => { if (live) setIsAdmin(!!me?.isAdmin); }).catch(() => {});
+    return () => { live = false; };
+  }, []);
 
   const load = useCallback(() => {
     setLoading(true);
@@ -66,7 +74,7 @@ export default function CollectorsView() {
       </div>
 
       <FleetStatsPanel counts={counts} dlq={dlq} loading={loading} error={error}
-        onReactivate={onReactivate} />
+        onReactivate={onReactivate} isAdmin={isAdmin} />
 
       {selected && <CollectorPopup collector={selected} onClose={() => setSelected(null)} />}
     </>
@@ -89,10 +97,15 @@ function fmtDue(dueMs) {
   return `${Math.round(h / 24)} d`;
 }
 
-function FleetStatsPanel({ counts, dlq, loading, error, onReactivate }) {
+function FleetStatsPanel({ counts, dlq, loading, error, onReactivate, isAdmin }) {
   return (
     <div className="fleet-panel" aria-label="Fleet health">
-      <h2 className="panel-name">Fleet health</h2>
+      <div className="fleet-head">
+        <h2 className="panel-name">Fleet health</h2>
+        <span className={`role-badge ${isAdmin ? 'role-admin' : 'role-viewer'}`}>
+          {isAdmin ? 'admin' : 'viewer'}
+        </span>
+      </div>
       {loading && <div className="muted">loading…</div>}
       {error && <div className="error-text" role="alert">{error}</div>}
 
@@ -106,14 +119,16 @@ function FleetStatsPanel({ counts, dlq, loading, error, onReactivate }) {
 
       {dlq.length > 0 && (
         <div className="quarantine-list">
-          <h3>Quarantined ({dlq.length})</h3>
+          <h3>Quarantined ({dlq.length}){!isAdmin && <span className="muted small"> · reactivate is admin-only</span>}</h3>
           {dlq.map((s) => (
             <div key={s.id} className="quarantine-item">
               <div className="q-head">
                 <span className="q-name">{s.name}</span>
-                <button className="btn-reactivate" onClick={() => onReactivate(s.id)}>
-                  Reactivate
-                </button>
+                {isAdmin && (
+                  <button className="btn-reactivate" onClick={() => onReactivate(s.id)}>
+                    Reactivate
+                  </button>
+                )}
               </div>
               <div className="muted small">
                 {s.failures} fails · since {s.sinceISO?.slice(0, 10)}

--- a/web/src/views/CollectorsView.test.jsx
+++ b/web/src/views/CollectorsView.test.jsx
@@ -15,11 +15,14 @@ const DLQ = {
 };
 
 let reactivateCalls;
+let me; // /me response — set per test
 
 beforeEach(() => {
   reactivateCalls = [];
+  me = { email: 't@x', role: 'admin', isAdmin: true };
   vi.spyOn(global, 'fetch').mockImplementation((url) => {
     const u = String(url);
+    if (u.endsWith('/me')) return jsonOk(me);
     if (u.includes('/collect/reactivate')) { reactivateCalls.push(u); return jsonOk({ status: 'reactivated' }); }
     if (u.includes('/collect/dlq')) return jsonOk(DLQ);
     if (u.includes('/collectors')) return jsonOk(COLLECTORS);
@@ -45,7 +48,6 @@ describe('CollectorsView fleet panel', () => {
   it('summarizes fleet state counts', async () => {
     renderView();
     await waitFor(() => expect(screen.getByText('Fleet health')).toBeInTheDocument());
-    // Scope to the stat grid — state names like "Healthy" also appear in the legend.
     const grid = within(document.querySelector('.stat-grid'));
     const stat = (label) => grid.getByText(label).previousSibling.textContent;
     expect(stat('Total')).toBe('4');
@@ -54,13 +56,24 @@ describe('CollectorsView fleet panel', () => {
     expect(stat('Disabled')).toBe('1');
   });
 
-  it('lists quarantined collectors and reactivates by provider id', async () => {
+  it('admin: shows the role badge, lists quarantined collectors, reactivates by id', async () => {
     const user = userEvent.setup();
     renderView();
     await waitFor(() => expect(screen.getByText("Heart O' the Hills")).toBeInTheDocument());
+    expect(screen.getByText('admin')).toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: /Reactivate/i }));
+    await user.click(await screen.findByRole('button', { name: /Reactivate/i }));
     await waitFor(() => expect(reactivateCalls.length).toBe(1));
     expect(reactivateCalls[0]).toMatch(/\/collect\/reactivate\?id=247585$/);
+  });
+
+  it('viewer: no reactivate button, shows the admin-only note + viewer badge', async () => {
+    me = { email: 'rando@x', role: 'viewer', isAdmin: false };
+    renderView();
+    await waitFor(() => expect(screen.getByText("Heart O' the Hills")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('viewer')).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /Reactivate/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/reactivate is admin-only/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
`BACKEND` · `WEB` — **RBAC**

# Roles on top of the gate: admins act, everyone else watches

> _Cloudflare Access decides **who gets in**; it didn't decide **what they can do** — every authenticated user could reactivate collectors or re-seed. This adds app-level roles read from the Access identity: admins keep the mutations, everyone else is read-only._

> [!NOTE]
> **backend + web** · feat · risk: low · works with the current login (email-PIN / GitHub) · bootstrap admin = owner email

Every request already carries a verified identity — Access stamps `Cf-Access-Jwt-Assertion` (the Pages Function forwards it to the backend over the service binding). The backend reads the email from it and maps it to a role.

## Roles

| Caller | Role |
|---|---|
| The vended service token (local dev / Tailscale) | **admin** (it's the owner's) |
| `BOOTSTRAP_ADMIN` email (`tommy.b.doerr@gmail.com`) | **admin** — deterministic first admin |
| An email with a `role:<email>=admin` KV entry | **admin** |
| Any other authenticated user | **viewer** |

## What's gated

- **Admin-only mutations:** `/seed`, `/collect/start`, `/collect/reactivate`, `/collect/site`, `/watch` → 403 for viewers.
- **Open to any authenticated user:** availability, collectors, dlq, scheduler status, campsite reads.
- **`/me`** → `{ email, role, isAdmin }`; **`/admin/{users,elevate,demote}`** (admin-only) grant/revoke admin for other emails.
- **Frontend:** the Collectors view shows the Reactivate action + an `admin`/`viewer` badge only for admins; viewers see an "admin-only" note. The backend enforces regardless.

```mermaid
flowchart TD
  REQ["request (Cf-Access-Jwt-Assertion)"] --> ID["identify() → email / service-token"]
  ID --> ROLE["roleFor() → admin | viewer"]
  ROLE -->|admin| MUT["/collect/* · /seed · /watch ✓"]
  ROLE -->|viewer| R403["mutations → 403"]
  ROLE --> READS["reads → always allowed"]
```

## Verification

- **52 backend tests** (role resolution, `/me`, mutation 403/200 by role, elevate) + **34 web tests**; typecheck, lint, build clean.

## Risk & follow-ups

- JWT is **decoded, not signature-verified** — Access already verifies at the edge and the backend is only reachable through Access-gated paths; verifying against the team JWKS is a defense-in-depth follow-up.
- Bootstrap admin is config (`BOOTSTRAP_ADMIN`), so you're admin on first login — no chicken-and-egg. Needs a backend deploy to go live.
