### PR TITLE
fix(access): allow the owner's GitHub email (isillness@gmail.com) through SSO

### DIFF
--- a/infra/access/access.tf
+++ b/infra/access/access.tf
@@ -33,7 +33,7 @@ resource "cloudflare_zero_trust_access_application" "backend" {
       name       = "Owner SSO"
       decision   = "allow"
       precedence = 1
-      include    = [{ email = { email = var.allow_email } }]
+      include    = [for e in var.allow_emails : { email = { email = e } }]
     },
     {
       name       = "Local dev service token"

--- a/infra/access/frontend.tf
+++ b/infra/access/frontend.tf
@@ -32,7 +32,7 @@ resource "cloudflare_zero_trust_access_application" "frontend" {
       name       = "Owner SSO"
       decision   = "allow"
       precedence = 1
-      include    = [{ email = { email = var.allow_email } }]
+      include    = [for e in var.allow_emails : { email = { email = e } }]
     },
   ]
 }

--- a/infra/access/variables.tf
+++ b/infra/access/variables.tf
@@ -10,10 +10,13 @@ variable "hostname" {
   default     = "api.robogeosociety.xyz"
 }
 
-variable "allow_email" {
-  description = "Email allowed to reach the backend via Access SSO."
-  type        = string
-  default     = "tommy.b.doerr@gmail.com"
+variable "allow_emails" {
+  description = "Emails allowed through Access SSO (the owner's identities across IdPs)."
+  type        = list(string)
+  # tommy.b.doerr@gmail.com — email one-time-PIN / primary owner identity.
+  # isillness@gmail.com     — the email the owner's GitHub account presents (verified via
+  #                           the Access audit log); without it, GitHub SSO is denied.
+  default = ["tommy.b.doerr@gmail.com", "isillness@gmail.com"]
 }
 
 # Social IdP client secrets — sensitive, never committed. Pass at apply via


### PR DESCRIPTION
`infra/access` · Cloudflare Access

# The owner's GitHub login was bouncing — one missing email

> _Access authenticated the GitHub SSO fine, then denied it: the policy allowed only `tommy.b.doerr@gmail.com`, but the owner's GitHub account presents a different email. The audit log named the culprit; this adds it._

> [!NOTE]
> **infra** · fix · risk: low · security-boundary change (widens allow-list by one owner identity) · applied live via targeted apply

## Why

The frontend went live behind Cloudflare Access, but signing in with **GitHub** returned "no access" — authenticated, not authorized. The `Access: Audit Logs Read`-scoped audit log was decisive:

| Time (UTC) | Result | Email |
|---|---|---|
| 22:11 | **denied** | `isillness@gmail.com` |
| 19:46 | allowed | `tommy.b.doerr@gmail.com` |
| 19:43 | **denied** | `isillness@gmail.com` |

The owner's GitHub account presents `isillness@gmail.com` (the same identity as the tailnet owner) — never in the single-email policy.

## What

- **`allow_email` (string) → `allow_emails` (list)** = `["tommy.b.doerr@gmail.com", "isillness@gmail.com"]` — the owner's identities across IdPs (email one-time-PIN + GitHub).
- Both **Owner-SSO policy `include` blocks** (backend app in `access.tf`, the four Pages apps in `frontend.tf`) now iterate the list: `[for e in var.allow_emails : { email = { email = e } }]`.

```mermaid
flowchart TD
  GH["GitHub SSO → isillness@gmail.com"] --> POL{"Owner SSO include"}
  PIN["Email PIN → tommy.b.doerr@gmail.com"] --> POL
  POL -->|both now listed| OK["allow → app loads"]
```

## Verification

- `terraform validate` + `fmt` clean. Plan: the 5 Access apps gain `isillness@gmail.com`.
- **Applied live** with a *targeted* apply of the 5 Access applications only (`0 added, 5 changed`) — deliberately **not** the IdP resources, whose secrets are passed at apply time and default empty (a blanket apply would have wiped the GitHub secret and created the parked Google IdP).
- RBAC: `role:isillness@gmail.com = admin` written to the live KV (out of band; not in this repo) so the GitHub login lands as admin.
- Final check: owner re-runs GitHub SSO; the audit log should flip `isillness@gmail.com` to `allowed=true`.

## Risk

- Low, but it **widens the auth boundary** — by exactly one identity, the owner's own GitHub email, verified from the audit log. Still a single-owner private gate; no domains or wildcards. The `allow_emails` list makes adding/removing identities a one-line review in future.
