### PR TITLE
fix(web): detail-pane tab overflow + survival-row stats clipping

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -612,15 +612,20 @@ body {
 /* ---- Per-location panes (swipeable views) ---- */
 .location-panes { margin-top: 4px; }
 
-.pane-tabs { display: flex; gap: 4px; margin-bottom: 10px; }
+/* All four tabs (Survival/Availability/Layout/Status) must fit the ~312px pane; tighter
+   pills keep them on one line, with overflow-x:auto as a safety net on very narrow panes. */
+.pane-tabs { display: flex; gap: 4px; margin-bottom: 10px; overflow-x: auto; scrollbar-width: none; }
+.pane-tabs::-webkit-scrollbar { display: none; }
 .pane-tab {
-  padding: 4px 12px;
+  padding: 4px 9px;
   border-radius: 20px;
   border: 1px solid var(--border);
   background: transparent;
   color: var(--text-muted);
   font-family: inherit;
-  font-size: 12px;
+  font-size: 11px;
+  white-space: nowrap;
+  flex: 0 0 auto;
   cursor: pointer;
 }
 .pane-tab-on { color: var(--text); border-color: var(--cyan); background: rgba(102, 217, 239, 0.1); }
@@ -647,9 +652,11 @@ body {
 .survival-list { list-style: none; display: flex; flex-direction: column; gap: 2px; }
 .survival-row {
   display: grid;
-  grid-template-columns: 64px 1fr auto;
+  /* minmax(0,1fr) lets the sparkline column shrink (grid items default to min-width:auto),
+     so the fixed 96px stats column always fits "runs out MM-DD" without clipping. */
+  grid-template-columns: 56px minmax(0, 1fr) 96px;
   align-items: center;
-  gap: 10px;
+  gap: 8px;
   width: 100%;
   padding: 6px 6px;
   background: transparent;
@@ -665,7 +672,9 @@ body {
 .survival-label { font-size: 13px; font-weight: 700; }
 .survival-loop { max-width: 60px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .survival-stats { display: flex; flex-direction: column; align-items: flex-end; line-height: 1.2; }
+.survival-stats > span { white-space: nowrap; }
 .sparkline, .bars { display: block; }
+.sparkline { width: 100%; }
 
 /* Availability bars view (day/week/month/season) */
 .bars-view { display: flex; flex-direction: column; }

--- a/web/src/components/SurvivalSparkline.jsx
+++ b/web/src/components/SurvivalSparkline.jsx
@@ -7,10 +7,14 @@ import { computeRunway } from '../panes/runway';
 export default function SurvivalSparkline({ byDate, from, width = 168, height = 38 }) {
   const { remaining, n, exhaustionIndex, availableNights } = computeRunway(byDate, { from });
 
+  // viewBox + width:100% so the sparkline flexes to its grid column (the `width`/`height`
+  // props define the coordinate system, not a fixed pixel size); non-scaling strokes keep
+  // line weights crisp under the non-uniform horizontal scale.
   if (n === 0 || availableNights === 0) {
-    return <svg className="sparkline" width={width} height={height} role="img"
-      aria-label="no availability"><line x1="0" y1={height - 1} x2={width} y2={height - 1}
-        stroke="#6E7681" strokeWidth="1" /></svg>;
+    return <svg className="sparkline" viewBox={`0 0 ${width} ${height}`} width="100%" height={height}
+      preserveAspectRatio="none" role="img" aria-label="no availability">
+      <line x1="0" y1={height - 1} x2={width} y2={height - 1}
+        stroke="#6E7681" strokeWidth="1" vectorEffect="non-scaling-stroke" /></svg>;
   }
 
   const pad = 2;
@@ -24,13 +28,14 @@ export default function SurvivalSparkline({ byDate, from, width = 168, height = 
   const area = `${pad},${pad + h} ${line} ${x(n - 1).toFixed(1)},${pad + h}`;
 
   return (
-    <svg className="sparkline" width={width} height={height} role="img"
+    <svg className="sparkline" viewBox={`0 0 ${width} ${height}`} width="100%" height={height}
+      preserveAspectRatio="none" role="img"
       aria-label={`${availableNights} available nights, runs out at horizon ${exhaustionIndex + 1} of ${n}`}>
       <polygon points={area} fill="rgba(166,226,46,0.12)" />
-      <polyline points={line} fill="none" stroke="#A6E22E" strokeWidth="1.5" />
+      <polyline points={line} fill="none" stroke="#A6E22E" strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
       {exhaustionIndex >= 0 && (
         <line x1={x(exhaustionIndex).toFixed(1)} y1={pad} x2={x(exhaustionIndex).toFixed(1)} y2={pad + h}
-          stroke="#F85149" strokeWidth="1" strokeDasharray="2 2" />
+          stroke="#F85149" strokeWidth="1" strokeDasharray="2 2" vectorEffect="non-scaling-stroke" />
       )}
     </svg>
   );


### PR DESCRIPTION
`web` · campground detail pane

# Two clipped panels in the detail pane, both fixed

> _Opening a campground showed the bug: the fourth tab `Status` was sliced off the panel edge, and every row's `17 nights / runs out 09-10` was either wrapping mid-token or chopped to `17 n`. Both are squeeze-to-fit layout faults — now they fit._

> [!NOTE]
> **web** · fix · risk: low · CSS + one responsive SVG · verified live across all four sub-views · lint + 34 tests green

## Why

Caught on the live deployed app (Middle Fork, Playwright). The per-campground detail pane is ~312px wide, and two pieces didn't budget for it:

- **Tab row** — `Survival · Availability · Layout · Status` needed 347px in a 312px row (`overflow-x: visible`), so `Status` was clipped ~35px.
- **Survival/bars rows** — the right-hand `N nights / runs out MM-DD` stats sat in an `auto` grid column that the fixed-width (168px) `SurvivalSparkline` starved: the grid's `1fr` couldn't shrink (grid items default to `min-width: auto`), so the columns summed to 336px and pushed the stats off-panel — first wrapping (`09-` / `10`), then clipping (`17 n`).

## What

```text
 BEFORE  [#16][ sparkline 168px fixed ][17 n…]   ← 336px > 312, stats clipped
 AFTER   [#16][ sparkline flexes 132px ][17 nights]   ← 300px, fits
                                        [runs out 09-10]
```

- **Tabs** — tighter pills (`padding 4px 9px`, `font 11px`, `nowrap`); all four fit one line. `overflow-x: auto` (scrollbar hidden) is a safety net for narrower panes.
- **`SurvivalSparkline`** — responsive: `viewBox` + `width="100%"` + `preserveAspectRatio="none"`, with `vector-effect: non-scaling-stroke` so line weights stay crisp under horizontal scale.
- **`.survival-row` grid** — `56px minmax(0, 1fr) 96px`: `minmax(0,1fr)` lets the sparkline shrink, the fixed 96px column always holds `runs out MM-DD`, and `.survival-stats > span` is `nowrap`. The Availability bars view shares these classes, so it's fixed too.

## Verification

- **Playwright on the live app**, all four sub-views: tabs fit (`312=312`, `Status` fully visible); stats column 48px→96px, longest token `runs out 09-10` (93px) fits with no wrap/clip; sparkline flexes to 132px. Layout + Status grids and the Collectors fleet panel were already clean.
- `npm run lint` clean · `vite build` ok · **34/34** unit tests pass.

## Risk

- Low. Pure presentation: CSS + SVG sizing attributes, no data or behavior change. `preserveAspectRatio="none"` scales the sparkline horizontally only (fixed height), and non-scaling strokes keep it sharp.
