### PR TITLE
feat: reloads stop re-downloading the whole map

### DIFF
--- a/web/src/api.js
+++ b/web/src/api.js
@@ -12,6 +12,67 @@ async function getJSON(path) {
   return res.json();
 }
 
+// Persistent browser cache (localStorage), so a *page reload* doesn't re-fetch the
+// bulk datasets — the full campground availability and the collector fleet. The
+// in-memory Maps below dedupe within one page load; this layer carries the data
+// across reloads. Each entry is { t: epochMs, v: body }; anything older than its TTL
+// is ignored (and refetched). All access is best-effort: a missing/blocked/quota'd
+// localStorage just falls through to the network.
+const CACHE_PREFIX = 'rgs:cache:';
+
+// Snapshots are daily and the availability key is date-specific, so it's safe to
+// hold for hours; fleet health drifts (age/next-due/state), so keep that short.
+const AVAILABILITY_TTL = 3 * 60 * 60 * 1000; // 3 h
+const FLEET_TTL = 10 * 60 * 1000;            // 10 min
+
+// The DOM Storage (browser + jsdom). Reached via `window` on purpose — a bare
+// `localStorage` would resolve to Node's experimental global, which throws.
+function store() {
+  try {
+    return globalThis.window?.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function cacheGet(path, ttlMs) {
+  try {
+    const raw = store()?.getItem(CACHE_PREFIX + path);
+    if (!raw) return undefined;
+    const { t, v } = JSON.parse(raw);
+    if (!t || Date.now() - t > ttlMs) return undefined;
+    return v;
+  } catch {
+    return undefined;
+  }
+}
+
+function cacheSet(path, body) {
+  try {
+    store()?.setItem(CACHE_PREFIX + path, JSON.stringify({ t: Date.now(), v: body }));
+  } catch {
+    // localStorage unavailable or over quota — caching is best-effort.
+  }
+}
+
+function cacheDelete(path) {
+  try {
+    store()?.removeItem(CACHE_PREFIX + path);
+  } catch {
+    // ignore
+  }
+}
+
+// Like getJSON, but served from the persistent cache within `ttlMs`. On a miss it
+// fetches and persists the fresh body; failures are never cached.
+async function getCachedJSON(path, ttlMs) {
+  const hit = cacheGet(path, ttlMs);
+  if (hit !== undefined) return hit;
+  const body = await getJSON(path);
+  cacheSet(path, body);
+  return body;
+}
+
 // The caller's identity + role from Cloudflare Access: { email, role, isAdmin }.
 // Drives which admin-only actions the UI shows (the backend enforces regardless).
 export function getMe() {
@@ -23,7 +84,7 @@ export function getMe() {
 //   { guid, name, agency, lat, lng, collect, state, lastCollectedDate, ageDays, dueMs, fails }
 // state ∈ "healthy" | "overdue" | "quarantined" | "disabled".
 export function getCollectors() {
-  return getJSON('/collectors');
+  return getCachedJSON('/collectors', FLEET_TTL);
 }
 
 // Availability for a single night across every collected campground. Cached per
@@ -32,7 +93,7 @@ export function getCollectors() {
 const availabilityCache = new Map();
 export function getAvailability(date) {
   if (availabilityCache.has(date)) return availabilityCache.get(date);
-  const p = getJSON(`/availability?date=${date}`).catch((err) => {
+  const p = getCachedJSON(`/availability?date=${date}`, AVAILABILITY_TTL).catch((err) => {
     availabilityCache.delete(date); // don't cache failures
     throw err;
   });
@@ -56,6 +117,16 @@ export function getSiteCalendar(guid, siteId) {
 export function _resetCaches() {
   availabilityCache.clear();
   seriesCache.clear();
+  try {
+    const ls = store();
+    if (ls) {
+      for (const k of Object.keys(ls)) {
+        if (k.startsWith(CACHE_PREFIX)) ls.removeItem(k);
+      }
+    }
+  } catch {
+    // no localStorage — nothing to clear
+  }
 }
 
 // Run `fn` over `items` with at most `limit` in flight; preserves order.
@@ -101,7 +172,7 @@ export function getCampgroundSeries(guid, date) {
 // so the fleet panel's quarantine list reads from here.
 //   { count, sites: [{ id, name, agency, kind, since, sinceISO, failures, lastError }] }
 export function getDlq() {
-  return getJSON('/collect/dlq');
+  return getCachedJSON('/collect/dlq', FLEET_TTL);
 }
 
 // Reactivate a quarantined collector (mutation — leaves the read path). Keys on the
@@ -111,5 +182,9 @@ export async function reactivate(id) {
     method: 'POST',
   });
   if (!res.ok) throw new Error(`reactivate ${id} → HTTP ${res.status}`);
+  // The fleet just changed — drop the cached fleet/DLQ so the view's follow-up
+  // load() re-fetches instead of serving the pre-reactivation snapshot.
+  cacheDelete('/collectors');
+  cacheDelete('/collect/dlq');
   return res.json().catch(() => ({}));
 }

--- a/web/src/api.test.js
+++ b/web/src/api.test.js
@@ -1,5 +1,6 @@
-import { getAvailability, getCollectors, reactivate } from './api';
+import { getAvailability, getCollectors, reactivate, _resetCaches } from './api';
 
+beforeEach(() => _resetCaches()); // drop the persistent (localStorage) cache between cases
 afterEach(() => vi.restoreAllMocks());
 
 function jsonOk(body) {
@@ -22,6 +23,29 @@ describe('api data layer', () => {
     const dates = spy.mock.calls.map(([u]) => String(u));
     expect(dates.filter((u) => u.includes('2026-07-01'))).toHaveLength(1);
     expect(dates.filter((u) => u.includes('2026-07-02'))).toHaveLength(1);
+  });
+
+  it('getCollectors serves from the persistent cache — a reload-style repeat does not refetch', async () => {
+    const spy = vi.spyOn(global, 'fetch').mockReturnValue(jsonOk([{ guid: 'a' }]));
+    await getCollectors();
+    // getCollectors holds nothing in memory, so this second call only avoids the
+    // network if it read the body back out of localStorage — i.e. survives a reload.
+    const rows = await getCollectors();
+    expect(rows).toEqual([{ guid: 'a' }]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('reactivate busts the fleet cache so the next read refetches', async () => {
+    const spy = vi
+      .spyOn(global, 'fetch')
+      .mockReturnValueOnce(jsonOk([{ guid: 'a', state: 'quarantined' }])) // getCollectors (cold)
+      .mockReturnValueOnce(jsonOk({ status: 'reactivated' }))             // reactivate POST
+      .mockReturnValueOnce(jsonOk([{ guid: 'a', state: 'healthy' }]));    // getCollectors (refetch)
+    await getCollectors();
+    await reactivate('247585');
+    const rows = await getCollectors();
+    expect(rows).toEqual([{ guid: 'a', state: 'healthy' }]);
+    expect(spy).toHaveBeenCalledTimes(3); // the cache was invalidated, so the reread went to network
   });
 
   it('reactivate POSTs /collect/reactivate keyed on provider id', async () => {

--- a/web/src/setupTests.js
+++ b/web/src/setupTests.js
@@ -1,5 +1,19 @@
 import '@testing-library/jest-dom';
 
+// This vitest jsdom env ships without Web Storage, so provide a tiny in-memory
+// localStorage (data keys are own-enumerable; the Storage methods live on the
+// prototype, so Object.keys(localStorage) returns just the keys, as in a browser).
+// The persistent api.js cache relies on it; real browsers have it natively.
+if (typeof window.localStorage === 'undefined') {
+  const storage = Object.create({
+    getItem(k) { return Object.prototype.hasOwnProperty.call(this, k) ? this[k] : null; },
+    setItem(k, v) { this[k] = String(v); },
+    removeItem(k) { delete this[k]; },
+    clear() { for (const k of Object.keys(this)) delete this[k]; },
+  });
+  Object.defineProperty(window, 'localStorage', { value: storage, configurable: true });
+}
+
 // Mock mapbox-gl for tests (it requires a browser canvas)
 vi.mock('mapbox-gl', () => {
   const makeMap = () => {


### PR DESCRIPTION
`web` — **PERF DISPATCH**

# Reloads stop re-downloading the whole map

> _Every page load re-fetched all 156 sites from the gated Worker. Now a reload reads them back out of the browser, and the network stays quiet until the data actually goes stale._

> [!NOTE]
> **web** · feat · risk: low · client-only, no backend change

The data layer already had per-session `Map` caches — but they live in memory, so every reload (and the app is reached behind a Cloudflare Access login, so reloads are common) threw them away and re-hit the Worker for the full fleet: `/availability` (every campground for the day), `/collectors`, and `/collect/dlq`. The bytes don't change between two reloads a minute apart; the round-trip is pure waste.

## The fix: a persistent layer under the in-memory caches

- **`getCachedJSON(path, ttl)`** — serves the body from `localStorage` within its TTL, otherwise fetches and persists it. Failures are **never** cached.
- **TTLs match how fast each dataset moves** — availability **3 h** (snapshots are daily and the key is date-specific), fleet + DLQ **10 min** (health drifts: age / next-due / state).
- **`reactivate()` busts the fleet keys** so the view's follow-up `load()` shows the post-reactivation state, never a stale snapshot.
- **Best-effort and guarded** — no storage, or over quota, just falls through to the network. Reads go through `window.localStorage` on purpose: a bare `localStorage` resolves to Node's experimental global.

> _"In-memory caches dedupe within one load; this layer is what survives the reload."_

## How it flows

```mermaid
flowchart TD
  A[view asks for data] --> B{in-memory Map?}
  B -->|hit| Z[return]
  B -->|miss| C{localStorage fresh?}
  C -->|within TTL| Z
  C -->|stale / absent| D[fetch gated Worker]
  D --> E[persist body + TTL]
  E --> Z
  F[reactivate] -->|bust fleet keys| C
```

## Verification

- `npm test -- --run` — **36/36 pass**, incl. two new cases: a `getCollectors` repeat is a cache hit (no second `fetch`), and `reactivate` busts the fleet cache so the next read refetches.
- Added an in-memory `localStorage` polyfill to `setupTests.js` (this vitest jsdom env ships without Web Storage; real browsers have it natively).
- `npm run lint` clean · `vite build` clean.

## Risk & rollout

- Low — client-only, no backend/contract change. Worst case is a user seeing up-to-3-h-old availability or up-to-10-min-old fleet health on a reload; a hard refresh past the TTL re-fetches, and `reactivate` already invalidates eagerly.
- Follow-up (separate): push caching to the edge — `Cache-Control` on the Worker / Pages Function + the Workers Cache API — so the first load is fast too, not just reloads.
