### PR TITLE
feat: stop recomputing the whole map from R2 on every request

### DIFF
--- a/backend/src/read-api.test.ts
+++ b/backend/src/read-api.test.ts
@@ -177,3 +177,29 @@ describe('/collectors — fleet health (current state, no history)', () => {
     expect(body[0]).toMatchObject({ guid: 'guid-kv-only', name: 'KV-only Camp' });
   });
 });
+
+// The Cache-API edge layer is a no-op under Node tests (no `caches` global), but the
+// browser-facing Cache-Control directive is still stamped — that's what lets the
+// browser HTTP cache honor the same TTL as the localStorage layer. Errors stay
+// uncached so a bad request is never sticky.
+describe('read endpoints — browser cache directives', () => {
+  test('a 200 read carries a private, max-age Cache-Control', async () => {
+    const RAW = seedR2();
+    const avail = await app.request(`/availability?date=${DATE}`, {}, { RAW } as any);
+    expect(avail.headers.get('Cache-Control')).toBe('private, max-age=600');
+
+    const fleet = await app.request('/collectors', {}, { RAW } as any);
+    expect(fleet.headers.get('Cache-Control')).toBe('private, max-age=60');
+  });
+
+  test('errors are not stamped (no sticky 400/404)', async () => {
+    const RAW = seedR2();
+    const bad = await app.request('/availability', {}, { RAW } as any); // 400, missing ?date=
+    expect(bad.status).toBe(400);
+    expect(bad.headers.get('Cache-Control')).toBeNull();
+
+    const missing = await app.request(`/availability/not-a-guid?date=${DATE}`, {}, { RAW } as any); // 404
+    expect(missing.status).toBe(404);
+    expect(missing.headers.get('Cache-Control')).toBeNull();
+  });
+});

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -21,8 +21,58 @@
  * read; until then the bulk endpoints fan out (cheap for /collectors, the one place
  * the WEBAPP_PLAN flags for the Cache-API/rollup optimization is /availability?date=).
  */
-import { Hono } from 'hono';
+import { Hono, type MiddlewareHandler } from 'hono';
 import { loadInventory, type InventoryEntry } from './inventory';
+
+// Edge cache for the shared, identity-independent read endpoints. The colo caches the
+// computed JSON (keyed by request URL) via the Workers Cache API, so the first caller
+// per colo per TTL pays the R2 fan-out and every other request — other users, other
+// devices, reloads past the browser's localStorage window — is served in ~1ms with
+// zero R2 reads. Safe to share: these responses are identical for all users (only /me
+// and the admin/mutation routes are identity-specific, and none of those are wrapped),
+// and Cloudflare Access gates upstream of the Worker, so the cache is only ever reached
+// by an already-authenticated request.
+//
+// Two directives, deliberately different:
+//   - stored copy: `max-age` only — the Workers Cache API refuses to store `private`.
+//   - browser copy: `private, max-age` — so nothing between the Worker and the browser
+//     caches it across identities, while the browser still honors the TTL.
+// A no-op where the Cache API is absent (Node tests): it just stamps the browser
+// directive and passes through.
+function edgeCache(maxAge: number): MiddlewareHandler {
+  const browserCC = `private, max-age=${maxAge}`;
+  const edgeCC = `max-age=${maxAge}`;
+  const store = (): Cache | null =>
+    typeof caches !== 'undefined' ? (caches as unknown as { default: Cache }).default : null;
+
+  return async (c, next) => {
+    const cache = store();
+    if (cache) {
+      const hit = await cache.match(c.req.raw);
+      if (hit) {
+        const res = new Response(hit.body, hit);
+        res.headers.set('Cache-Control', browserCC); // never hand the edge directive to the browser
+        return res;
+      }
+    }
+
+    await next();
+    if (!c.res || !c.res.ok) return; // don't cache or stamp errors (400/404)
+
+    if (cache) {
+      const copy = new Response(c.res.clone().body, c.res);
+      copy.headers.set('Cache-Control', edgeCC);
+      try {
+        c.executionCtx.waitUntil(cache.put(c.req.raw, copy));
+      } catch {
+        // no executionCtx (direct app.request in tests) — skip the background store
+      }
+    }
+    const out = new Response(c.res.body, c.res);
+    out.headers.set('Cache-Control', browserCC);
+    c.res = out;
+  };
+}
 
 // CAMPSITES (KV) holds the authoritative inventory under `_inventory`; RAW (R2) holds
 // the collected snapshots. The inventory is read per request (loadInventory) so a
@@ -103,7 +153,7 @@ export const readApi = new Hono<{ Bindings: ReadEnv }>();
 // GET /availability?date=YYYY-MM-DD[&collected=YYYY-MM-DD]
 // Every campground's aggregate availability for the requested night, keyed by guid,
 // projected from each site's freshest summary snapshot.
-readApi.get('/availability', async (c) => {
+readApi.get('/availability', edgeCache(600), async (c) => {
   const date = c.req.query('date');
   if (!date || !DATE_RE.test(date)) return c.json({ error: 'need ?date=YYYY-MM-DD' }, 400);
   const pinned = c.req.query('collected');
@@ -152,7 +202,7 @@ readApi.get('/availability', async (c) => {
 
 // GET /availability/:guid/site/:siteId — one site's per-night status calendar.
 // :siteId is the internal R2 site id (e.g. 81835), NOT the human label ("24").
-readApi.get('/availability/:guid/site/:siteId', async (c) => {
+readApi.get('/availability/:guid/site/:siteId', edgeCache(300), async (c) => {
   const { byGuid } = await inventoryFor(c.env);
   const entry = byGuid.get(c.req.param('guid'));
   if (!entry) return c.json({ error: 'unknown guid' }, 404);
@@ -180,7 +230,7 @@ readApi.get('/availability/:guid/site/:siteId', async (c) => {
 // GET /availability/:guid?date= — the per-campground site list for one night.
 // The "individual site number" filter resolves the human `label` ("24") → siteId
 // against this list, so we surface both.
-readApi.get('/availability/:guid', async (c) => {
+readApi.get('/availability/:guid', edgeCache(300), async (c) => {
   const { byGuid } = await inventoryFor(c.env);
   const entry = byGuid.get(c.req.param('guid'));
   if (!entry) return c.json({ error: 'unknown guid' }, 404);
@@ -206,7 +256,7 @@ readApi.get('/availability/:guid', async (c) => {
 // GET /collectors[?now=ms] — fleet health, current state only (no run-history;
 // that's the InfluxDB-backed /collectors/:guid/history, deferred). One row per
 // inventory site, colored by state.
-readApi.get('/collectors', async (c) => {
+readApi.get('/collectors', edgeCache(60), async (c) => {
   const now = Number(c.req.query('now')) || Date.now();
   const hb = (await getJson<any>(c.env, 'scheduler/heartbeat.json')) ?? {};
   const due: Record<string, number> = hb.due ?? {};


### PR DESCRIPTION
`backend` — **PERF DISPATCH**

# Stop recomputing the whole map from R2 on every request

> _`/availability?date=` walks every R2 partition and reads ~156 objects — once per user, per reload. The bytes don't change minute to minute. Now the colo computes it once per TTL and serves everyone else from cache._

> [!NOTE]
> **backend** · feat · risk: low · Workers Cache API · no schema/contract change

The read endpoints rebuild from R2 on every authenticated hit. The worst is `/availability?date=`: it lists every date partition, lists all objects per partition to resolve newest-per-id, then does **one `R2.get` per inventory entry** — ~156 reads plus list ops, *per user, per reload.* Two loads a minute apart return identical bytes, so the whole round-trip is waste. PR #98 fixed the per-browser side (localStorage); this fixes the **shared** side.

## The lever: Workers Cache API, not zone Cache Rules

Because the app sits behind Cloudflare Access, the public CDN edge won't cache these (auth-gated, dynamic). The cache that *does* work is `caches.default` **inside the Worker**, reached only after Access — so an `edgeCache(ttl)` middleware caches the computed JSON keyed by request URL.

- **First caller per colo per TTL** pays the fan-out; every other request — other users, other devices, reloads past the localStorage window — is served from the colo in ~1ms with **zero R2 reads**.
- **TTLs by volatility** — `/availability` 600s, per-campground reads 300s, `/collectors` 60s.
- **Two directives, deliberately different** — the stored copy uses a storable `max-age` (the Cache API *refuses* `private`); the browser copy uses `private, max-age` so nothing between the Worker and the browser caches across identities, while the browser HTTP cache still honors the TTL.
- **Errors are never cached**; a no-op where the Cache API is absent (Node tests).

> _"Only `/me`, admin, and mutations carry identity — and none of those are wrapped. The cached reads are the same for everyone."_

## How it flows

```mermaid
flowchart TD
  A[Authenticated request] --> B{colo cache hit?}
  B -->|hit| C[~1ms, 0 R2 reads]
  B -->|miss| D[R2 fan-out: list + ~156 gets]
  D --> E[store colo copy: max-age]
  E --> F[return browser copy: private, max-age]
  C --> F
```

## Why it's safe to share

- Responses are **identity-independent** — `/availability`, `/availability/:guid`, `/collectors` are byte-identical for all users. `/me`, `/admin/*`, and the `reactivate` mutation are **not** wrapped.
- **Access gates upstream** of the Worker, so the colo cache is only ever populated and read by already-authenticated requests — it never bypasses the gate.

## Verification

- `npm run typecheck` clean · `npm test -- --run` — **54/54 pass**, incl. two new cases: a 200 read carries `private, max-age=…`; a 400/404 carries no `Cache-Control` (no sticky errors).
- Cache-API path is a no-op under Node tests (no `caches` global), so coverage asserts the browser directive directly.

## Risk & rollout

- Low — additive middleware, no schema/contract/data change; falls back to today's behavior wherever `caches` is undefined.
- Staleness is bounded by the TTLs (≤10 min availability, ≤1 min fleet) and self-heals; the collector writes on a separate Worker, so there's no cross-colo purge — short TTLs cover it. `reactivate` may show ≤60s-stale fleet at the edge (the browser busts its own copy immediately in #98).
- **Touches the gated Worker** — deploy needs explicit OK; not deployed in this PR.
- Follow-up: precompute `summary/<date>/_index.json` so the *cold* path is one read too.
