### PR TITLE
feat: points fan onto the map behind a progress bar that actually moves

### DIFF
--- a/web/src/app.css
+++ b/web/src/app.css
@@ -426,6 +426,36 @@ body {
   border: 1px solid rgba(255, 255, 255, 0.12);
 }
 
+/* A control chip carrying a progress bar + caption side by side. */
+.control-chip--progress { display: inline-flex; align-items: center; gap: 8px; }
+
+/* Slim loading bar: determinate (fills as points stream in) or indeterminate
+   (sliding sweep while the fetch is in flight). */
+.progress {
+  width: 120px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.14);
+  overflow: hidden;
+  flex: 0 0 auto;
+}
+.progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--cyan);
+  transition: width 120ms linear;
+}
+.progress-fill--indeterminate {
+  width: 40%;
+  animation: progress-slide 1.1s ease-in-out infinite;
+}
+@keyframes progress-slide {
+  0% { transform: translateX(-110%); }
+  100% { transform: translateX(310%); }
+}
+
+.fleet-loading { display: flex; align-items: center; gap: 8px; margin: 4px 0 8px; }
+
 .muted { color: var(--text-muted); font-size: 12px; }
 .small { font-size: 11px; }
 .error-text { color: var(--pink); font-size: 12px; }

--- a/web/src/components/ProgressBar.jsx
+++ b/web/src/components/ProgressBar.jsx
@@ -1,0 +1,22 @@
+// A slim loading bar for map data. Determinate when `value` (0..1) is given — it fills
+// as points stream onto the map; pass `indeterminate` while the total is still unknown
+// (the network fetch is in flight, before any point has been placed). Replaces the old
+// static "loading…" text.
+export default function ProgressBar({ value = 0, indeterminate = false, label = 'Loading' }) {
+  const pct = Math.round(Math.max(0, Math.min(1, value)) * 100);
+  return (
+    <div
+      className="progress"
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={indeterminate ? undefined : pct}
+    >
+      <div
+        className={`progress-fill${indeterminate ? ' progress-fill--indeterminate' : ''}`}
+        style={indeterminate ? undefined : { width: `${pct}%` }}
+      />
+    </div>
+  );
+}

--- a/web/src/components/ProgressBar.test.jsx
+++ b/web/src/components/ProgressBar.test.jsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import ProgressBar from './ProgressBar';
+
+describe('ProgressBar', () => {
+  it('determinate: fills to the clamped percentage and exposes aria-valuenow', () => {
+    render(<ProgressBar value={0.42} label="Placing" />);
+    const bar = screen.getByRole('progressbar', { name: 'Placing' });
+    expect(bar).toHaveAttribute('aria-valuenow', '42');
+    expect(bar.firstChild).toHaveStyle({ width: '42%' });
+    expect(bar.firstChild).not.toHaveClass('progress-fill--indeterminate');
+  });
+
+  it('clamps out-of-range values', () => {
+    const { rerender } = render(<ProgressBar value={2} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '100');
+    rerender(<ProgressBar value={-1} />);
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow', '0');
+  });
+
+  it('indeterminate: no aria-valuenow, sliding-sweep modifier applied', () => {
+    render(<ProgressBar indeterminate label="Loading" />);
+    const bar = screen.getByRole('progressbar', { name: 'Loading' });
+    expect(bar).not.toHaveAttribute('aria-valuenow');
+    expect(bar.firstChild).toHaveClass('progress-fill--indeterminate');
+  });
+});

--- a/web/src/map/useCampgroundPies.js
+++ b/web/src/map/useCampgroundPies.js
@@ -3,16 +3,28 @@ import mapboxgl from 'mapbox-gl';
 import { AGENCY_COLORS, agencyShort } from '../constants';
 import { pacmanMarkup } from './pie';
 
+// requestAnimationFrame where available (browser/jsdom), else a timeout shim (bare
+// Node) — so the batched placement below works in every environment.
+const schedule = typeof requestAnimationFrame === 'function' ? requestAnimationFrame : (cb) => setTimeout(cb, 0);
+const unschedule = typeof cancelAnimationFrame === 'function' ? cancelAnimationFrame : clearTimeout;
+
 // Renders each campground as a small agency-colored "pac-man" disc at its point: the
 // filled wedge spans its remaining availability for the rest of the year
 // (remaining / remainingTotal). Color = agency; only the cutout shows availability.
 // Clicking a disc selects the campground; clicking empty map deselects.
-export function useCampgroundPies({ map, ready, rows, onSelect, onEmpty }) {
+//
+// Markers are placed **progressively** — a batch per animation frame — so the points
+// fan onto the map instead of the main thread janking on ~156 DOM markers at once.
+// `onProgress(placed, total)` fires after each batch (and once with (0, total) up
+// front), driving the determinate loading bar; `batchSize` tunes the fan-in cadence.
+export function useCampgroundPies({ map, ready, rows, onSelect, onEmpty, onProgress, batchSize = 16 }) {
   const markersRef = useRef([]);
   const onSelectRef = useRef(onSelect);
   const onEmptyRef = useRef(onEmpty);
+  const onProgressRef = useRef(onProgress);
   onSelectRef.current = onSelect;
   onEmptyRef.current = onEmpty;
+  onProgressRef.current = onProgress;
 
   useEffect(() => {
     if (!map || !ready) return undefined;
@@ -20,32 +32,45 @@ export function useCampgroundPies({ map, ready, rows, onSelect, onEmpty }) {
     for (const m of markersRef.current) m.remove();
     markersRef.current = [];
 
-    for (const r of rows ?? []) {
-      if (!Number.isFinite(r.lat) || !Number.isFinite(r.lng)) continue;
-      const color = AGENCY_COLORS[agencyShort(r.agency)] || '#888888';
-      const fraction = r.remainingTotal > 0
-        ? r.remaining / r.remainingTotal
-        : (r.total > 0 ? (r.available ?? 0) / r.total : 0);
+    const points = (rows ?? []).filter((r) => Number.isFinite(r.lat) && Number.isFinite(r.lng));
+    const total = points.length;
+    onProgressRef.current?.(0, total);
 
-      const el = document.createElement('div');
-      el.className = 'cg-pie';
-      el.title = `${r.name}: ${Math.round(fraction * 100)}% open the rest of the year`;
-      el.innerHTML = pacmanMarkup(fraction, { radius: 8, color });
-      el.addEventListener('click', (e) => {
-        e.stopPropagation();
-        onSelectRef.current?.(r);
-      });
-      const marker = new mapboxgl.Marker({ element: el, anchor: 'center' })
-        .setLngLat([r.lng, r.lat])
-        .addTo(map);
-      markersRef.current.push(marker);
-    }
+    let frame = 0;
+    let i = 0;
+    const placeBatch = () => {
+      const end = Math.min(i + batchSize, total);
+      for (; i < end; i++) {
+        const r = points[i];
+        const color = AGENCY_COLORS[agencyShort(r.agency)] || '#888888';
+        const fraction = r.remainingTotal > 0
+          ? r.remaining / r.remainingTotal
+          : (r.total > 0 ? (r.available ?? 0) / r.total : 0);
+
+        const el = document.createElement('div');
+        el.className = 'cg-pie';
+        el.title = `${r.name}: ${Math.round(fraction * 100)}% open the rest of the year`;
+        el.innerHTML = pacmanMarkup(fraction, { radius: 8, color });
+        el.addEventListener('click', (e) => {
+          e.stopPropagation();
+          onSelectRef.current?.(r);
+        });
+        const marker = new mapboxgl.Marker({ element: el, anchor: 'center' })
+          .setLngLat([r.lng, r.lat])
+          .addTo(map);
+        markersRef.current.push(marker);
+      }
+      onProgressRef.current?.(i, total);
+      if (i < total) frame = schedule(placeBatch);
+    };
+    if (total > 0) frame = schedule(placeBatch);
 
     return () => {
+      if (frame) unschedule(frame);
       for (const m of markersRef.current) m.remove();
       markersRef.current = [];
     };
-  }, [map, ready, rows]);
+  }, [map, ready, rows, batchSize]);
 
   // Deselect when clicking empty map (disc clicks stopPropagation, so this is canvas-only).
   useEffect(() => {

--- a/web/src/map/useCampgroundPies.test.jsx
+++ b/web/src/map/useCampgroundPies.test.jsx
@@ -1,0 +1,35 @@
+import { render, waitFor } from '@testing-library/react';
+import { useMemo } from 'react';
+import mapboxgl from 'mapbox-gl';
+import { useCampgroundPies } from './useCampgroundPies';
+
+// Mount the hook against the mocked map (see setupTests) and capture every
+// onProgress(placed, total) tick.
+function Harness({ rows, onProgress, batchSize }) {
+  const map = useMemo(() => new mapboxgl.Map(), []);
+  useCampgroundPies({ map, ready: true, rows, onSelect: () => {}, onEmpty: () => {}, onProgress, batchSize });
+  return null;
+}
+
+const row = (guid, lat, lng) => ({ guid, name: guid, agency: 'usfs', lat, lng, remaining: 1, remainingTotal: 2 });
+
+describe('useCampgroundPies — progressive placement', () => {
+  it('reports progress from 0 up to total, in batches, and ends complete', async () => {
+    const ticks = [];
+    const rows = [row('a', 47, -121), row('b', 48, -122), row('c', 49, -123)];
+    render(<Harness rows={rows} onProgress={(p, t) => ticks.push([p, t])} batchSize={2} />);
+
+    await waitFor(() => expect(ticks.at(-1)).toEqual([3, 3]));
+    expect(ticks[0]).toEqual([0, 3]);              // primes the bar with the total up front
+    expect(ticks.some(([p]) => p === 2)).toBe(true); // a mid batch landed (batchSize 2)
+    expect(Math.max(...ticks.map(([p]) => p))).toBe(3);
+  });
+
+  it('skips rows without coordinates when counting the total', async () => {
+    const ticks = [];
+    const rows = [row('a', 47, -121), { guid: 'b', name: 'b', agency: 'nps' }]; // b has no lat/lng
+    render(<Harness rows={rows} onProgress={(p, t) => ticks.push([p, t])} />);
+
+    await waitFor(() => expect(ticks.at(-1)).toEqual([1, 1]));
+  });
+});

--- a/web/src/views/AvailabilityView.jsx
+++ b/web/src/views/AvailabilityView.jsx
@@ -6,6 +6,7 @@ import { AGENCY_COLORS, agencyShort } from '../constants';
 import AgencyLegend from '../components/AgencyLegend';
 import StalenessBanner from '../components/StalenessBanner';
 import SiteCalendar from '../components/SiteCalendar';
+import ProgressBar from '../components/ProgressBar';
 import LocationPanes from '../panes/LocationPanes';
 
 // "Today" — remaining availability is summed across nights on/after this (rest of year).
@@ -16,14 +17,16 @@ export default function AvailabilityView() {
   // Each campground is a small agency-colored disc; its pac-man fill = remaining
   // availability for the rest of the year.
   const [rows, setRows] = useState([]);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true); // always fetches on mount — open on the bar
   const [error, setError] = useState(null);
   const [selected, setSelected] = useState(null); // a campground row
+  const [placed, setPlaced] = useState(0);        // markers drawn so far (progressive)
 
   useEffect(() => {
     let live = true;
     setLoading(true);
     setError(null);
+    setPlaced(0);
     getAvailability(TODAY)
       .then((data) => { if (live) setRows(data); })
       .catch((e) => { if (live) setError(e.message); })
@@ -36,7 +39,18 @@ export default function AvailabilityView() {
     if (map) map.flyTo({ center: [row.lng, row.lat], zoom: Math.max(map.getZoom(), 9) });
   };
 
-  useCampgroundPies({ map, ready, rows, onSelect, onEmpty: () => setSelected(null) });
+  useCampgroundPies({
+    map, ready, rows, onSelect,
+    onEmpty: () => setSelected(null),
+    onProgress: (n) => setPlaced(n),
+  });
+
+  // How many rows are actually placeable (have coordinates) — the progress denominator.
+  const total = useMemo(
+    () => rows.filter((r) => Number.isFinite(r.lat) && Number.isFinite(r.lng)).length,
+    [rows],
+  );
+  const placing = !loading && !error && total > 0 && placed < total;
 
   const stalest = useMemo(
     () => rows.reduce((min, r) => (r.collected_date && (!min || r.collected_date < min) ? r.collected_date : min), null),
@@ -47,10 +61,21 @@ export default function AvailabilityView() {
     <>
       <div className="map-overlay-tl">
         <div className="control-row">
-          {loading && <span className="muted control-chip">loading…</span>}
           {error && <span className="error-text control-chip" role="alert">{error}</span>}
-          {!loading && !error && (
-            <span className="muted control-chip">{rows.length} campgrounds · fill = remaining availability</span>
+          {loading && (
+            <span className="control-chip control-chip--progress">
+              <ProgressBar indeterminate label="Loading campgrounds" />
+              <span className="muted">loading campgrounds…</span>
+            </span>
+          )}
+          {placing && (
+            <span className="control-chip control-chip--progress">
+              <ProgressBar value={placed / total} label="Placing campgrounds" />
+              <span className="muted">{placed}/{total} campgrounds</span>
+            </span>
+          )}
+          {!loading && !error && !placing && (
+            <span className="muted control-chip">{total} campgrounds · fill = remaining availability</span>
           )}
         </div>
         <StalenessBanner date={stalest} />

--- a/web/src/views/CollectorsView.jsx
+++ b/web/src/views/CollectorsView.jsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMap } from '../map/MapContext';
 import { useCircleLayer, rowsToFC, HOVER_PAINT } from '../map/useCircleLayer';
 import { getCollectors, getDlq, reactivate, getMe } from '../api';
+import ProgressBar from '../components/ProgressBar';
 import { STATE_STYLE } from '../constants';
 
 const COLLECTOR_PAINT = {
@@ -106,7 +107,12 @@ function FleetStatsPanel({ counts, dlq, loading, error, onReactivate, isAdmin })
           {isAdmin ? 'admin' : 'viewer'}
         </span>
       </div>
-      {loading && <div className="muted">loading…</div>}
+      {loading && (
+        <div className="fleet-loading">
+          <ProgressBar indeterminate label="Loading fleet" />
+          <span className="muted">loading fleet…</span>
+        </div>
+      )}
       {error && <div className="error-text" role="alert">{error}</div>}
 
       <div className="stat-grid">


### PR DESCRIPTION
`web` — **UX DISPATCH**

# Points fan onto the map behind a bar that actually moves

> _The map used to freeze on a static "loading…" caption, then drop all ~156 campground discs at once. Now they stream in a batch per frame, and the caption is a real progress bar — indeterminate while fetching, then filling as the points land._

> [!NOTE]
> **web** · feat · risk: low · client-only, no backend change

Placing every pac-man marker in one synchronous loop spiked the main thread and gave the user nothing to watch but an italic "loading…". Two fixes, one feel: the points come in **progressively**, and the indicator is a **progress bar** instead of static text.

## What changed

- **`useCampgroundPies` places markers progressively** — a batch per animation frame (`batchSize`, default 16), so discs fan onto the map instead of popping all at once and the placement no longer janks. It calls `onProgress(placed, total)` after each batch (and `(0, total)` up front). rAF-guarded with a `setTimeout` fallback; the pending frame is cancelled on cleanup/re-run.
- **New `<ProgressBar>`** — determinate (fills as points stream in) or indeterminate (a sliding sweep while the network fetch is in flight). Replaces the static caption.
- **`AvailabilityView` drives the phases** — indeterminate *loading campgrounds…* → determinate *N/total campgrounds* as they place → final *`<n>` campgrounds · fill = remaining availability*. Opens on the bar (loading starts `true`) so there's no 0-count flash.
- **`CollectorsView`** reuses the same bar for its fleet load (indeterminate), so both views lose the static "loading…".

> _"A batch per frame: the map fills in front of you instead of stalling, then blinking."_

## How it flows

```mermaid
flowchart TD
  A[mount] --> B[fetch /availability]
  B -->|in flight| C[indeterminate bar:\nloading campgrounds…]
  B -->|resolved| D[place batch of 16 markers]
  D --> E[onProgress placed/total]
  E --> F{placed < total?}
  F -->|yes, next frame| D
  F -->|done| G[caption: n campgrounds]
```

## Verification

- `npm test -- --run` — **39/39 pass**, incl. new coverage: `ProgressBar` (determinate width + `aria-valuenow`, clamping, indeterminate modifier) and `useCampgroundPies` progressive placement (ticks 0 → total in batches; rows without coordinates excluded from the total).
- `npm run lint` clean · `vite build` clean.

## Risk & rollout

- Low — presentation only: marker placement is the same set of markers, just scheduled across frames; no data, contract, or backend change.
- The rAF fallback keeps the hook working under non-browser test envs; cancelling the frame on re-run prevents stray markers when the date/rows change mid-placement.
- Stacks cleanly with the caching PRs (#98 localStorage, #99 edge) — independent files.
