### PR TITLE
fix: edge-cache /collect/dlq for parity with /collectors

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -56,4 +56,12 @@ describe('Hono API Tests', () => {
     const body = await res.json();
     expect(body).toEqual(mockCampsite);
   });
+
+  test('GET /collect/dlq carries the cache directive (edge parity with /collectors)', async () => {
+    const RAW = { list: async () => ({ objects: [] }) };
+    const res = await app.request('/collect/dlq', {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Cache-Control')).toBe('private, max-age=60');
+    expect(await res.json()).toEqual({ count: 0, sites: [] });
+  });
 });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import campsites from './campsites-index.json';
 import { collectSite, HEARTBEAT_KEY, DLQ_PREFIX, listDlqIds, type WfEnv, type DlqEntry } from './workflows';
-import { readApi } from './read-api';
+import { readApi, edgeCache } from './read-api';
 import { whoami, adminOnly, ROLE_PREFIX } from './auth';
 
 // Cloudflare Workflows must be exported from the entry module by class name.
@@ -115,8 +115,11 @@ app.get('/scheduler/status', async (c) => {
 });
 
 // The dead-letter queue: sites quarantined after too many consecutive failures.
-// Each entry is dlq/<id>.json in R2 (the source of truth for "inactive").
-app.get('/collect/dlq', async (c) => {
+// Each entry is dlq/<id>.json in R2 (the source of truth for "inactive"). Edge-cached
+// for 60s to match /collectors — the fleet view loads the two together, and this is
+// shared, identity-independent data. reactivate() busts the browser copy; the edge
+// self-heals within the short TTL.
+app.get('/collect/dlq', edgeCache(60), async (c) => {
   const list = await c.env.RAW.list({ prefix: DLQ_PREFIX });
   const entries = await Promise.all(
     list.objects.map(async (o) => (await c.env.RAW.get(o.key))?.json<DlqEntry>()),

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -39,7 +39,7 @@ import { loadInventory, type InventoryEntry } from './inventory';
 //     caches it across identities, while the browser still honors the TTL.
 // A no-op where the Cache API is absent (Node tests): it just stamps the browser
 // directive and passes through.
-function edgeCache(maxAge: number): MiddlewareHandler {
+export function edgeCache(maxAge: number): MiddlewareHandler {
   const browserCC = `private, max-age=${maxAge}`;
   const edgeCC = `max-age=${maxAge}`;
   const store = (): Cache | null =>


### PR DESCRIPTION
`backend` — **PERF DISPATCH**

# The one collector read that missed the edge cache

> _`/collectors` is edge-cached; its sibling `/collect/dlq` wasn't — it lived in a different file and quietly re-listed R2 on every authenticated request. This closes the gap._

> [!NOTE]
> **backend** · fix · risk: low · one route + one test · no contract change

When #99 added the `edgeCache` middleware, it wrapped the read endpoints in `read-api.ts`. But `/collect/dlq` is defined in `index.ts`, *outside* that router — so it never picked up an edge layer: no `Cache-Control`, and a fresh R2 `list` + per-entry `get` on every hit. The fleet view loads it right next to `/collectors`, and it's the same shared, identity-independent data, so it should cache the same way.

## The fix

- **Export `edgeCache`** from `read-api.ts` and wrap the dlq route: `app.get('/collect/dlq', edgeCache(60), …)` — same 60s TTL as `/collectors`.
- **Invalidation unchanged** — `reactivate()` already busts the browser copy of `/collect/dlq`; the edge entry self-heals within the 60s TTL (no cross-colo purge, same trade-off as `/collectors`).

| Endpoint | Browser (#98) | Edge (#99 / here) |
|---|---|---|
| `/collectors` | 10 min | 60 s |
| `/collect/dlq` | 10 min | **60 s (new)** |

## Verification

- New test: `/collect/dlq` carries `Cache-Control: private, max-age=60`.
- `npm run typecheck` clean · `npm test -- --run` — **55/55 pass**.

## Risk & rollout

- Low — one additive middleware on one route; no schema/contract change, and a no-op where the Cache API is absent (Node tests). Worst case is ≤60s-stale quarantine detail at the edge after a reactivate, which the browser busts immediately.
- Touches the gated Worker → deploy needs explicit OK; not deployed in this PR.
