### PR TITLE
feat: the frontend's custom domains, as code

### DIFF
--- a/infra/dns/.gitignore
+++ b/infra/dns/.gitignore
@@ -1,0 +1,9 @@
+# Terraform state can reference token-derived values — never commit it.
+*.tfstate
+*.tfstate.*
+.terraform/
+*.tfvars
+crash.log
+crash.*.log
+
+# Keep .terraform.lock.hcl committed for reproducible inits.

--- a/infra/dns/.terraform.lock.hcl
+++ b/infra/dns/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:TJQJrskWa1FJ8gk6BAhj4X6fa5TFqI255T6Y6ZKrFkU=",
+    "zh:2d3dc17f27dcf308f52bdede3b7bb00e6cda6c1a9fbdafd1bfe4a915e75fdc44",
+    "zh:413e3569ad0cc89f8ac425d8a197d9e892ff356ac24dedde386820cf5880a48e",
+    "zh:59f262b9af9a8845afeb2734a6bd83b260aa2c521e5c318850745823ef62b38d",
+    "zh:7d42963a47ff6dda8aada0cb73a26eb6807c7ff6bb4419cb91b32ce2412c8362",
+    "zh:89cad3906c9affa0f2947607d316d70c38541c399d0519ebee1f1ccc8aaf5675",
+    "zh:d5c7ff6c39d895e5746fed74ecc3f284c91c8c1f502da2e93f5c581f41f87f25",
+    "zh:dc425b5f40e94165e563dc55bd6e49cedfe879a03e668168610459ef071b1a87",
+    "zh:f0665907dd24ae93f9511216052d653bba0823c933e888cf02a4abf95f73dfe0",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/dns/Makefile
+++ b/infra/dns/Makefile
@@ -1,0 +1,28 @@
+# Manage DNS for the rgs frontend custom domains (campsites/collectors → the Pages
+# alias, proxied + gated by Access).
+#
+# Auth is the *vended* rgs-frontend-dns token, read from the cloudflare-tfvend repo's
+# Terraform output (offline — no bootstrap token needed). Override its path with
+# TFVEND=/path if the repo lives elsewhere.
+
+TFVEND ?= /Volumes/dev/cloudflare-tfvend
+export CLOUDFLARE_API_TOKEN := $(shell terraform -chdir=$(TFVEND) output -raw rgs_frontend_dns_token 2>/dev/null)
+
+.PHONY: help check plan apply destroy
+
+help:
+	@echo "make plan      # terraform plan"
+	@echo "make apply     # terraform apply (auto-approve) — creates the proxied CNAMEs"
+
+check:
+	@test -n "$(CLOUDFLARE_API_TOKEN)" || { \
+		echo "No vended token. Is $(TFVEND) applied? (terraform -chdir=$(TFVEND) output rgs_frontend_dns_token)"; exit 1; }
+
+plan: check
+	terraform plan
+
+apply: check
+	terraform apply -auto-approve
+
+destroy: check
+	terraform destroy

--- a/infra/dns/README.md
+++ b/infra/dns/README.md
@@ -1,0 +1,43 @@
+# infra/dns — DNS for the rgs frontend custom domains
+
+Terraform that manages the **DNS records** for the deployed frontend custom domains:
+
+| Hostname | Record |
+| --- | --- |
+| `campsites.robogeosociety.xyz` | proxied `CNAME` → `robot-geographical-society-web.pages.dev` |
+| `collectors.robogeosociety.xyz` | proxied `CNAME` → `robot-geographical-society-web.pages.dev` |
+
+Both are **gated by Cloudflare Access** (`../access/frontend.tf`). This is a private
+project — every hostname must require an Owner SSO login. **Apply the Access gate
+first**, so a record never resolves to an unauthenticated app.
+
+## Division of labour (why DNS is the only thing here)
+
+- **Access boundary** → `../access` (Terraform, vended `rgs-access-admin` token).
+- **Pages custom-domain attachment** → done on the **wrangler OAuth flow** (like the
+  Worker custom-domain bind), because OAuth carries Pages Write.
+- **DNS record** → here. OAuth has zone *read* but not DNS *write*, so the record is
+  managed with the least-privilege vended **`rgs-frontend-dns`** token (zone DNS Write,
+  `robogeosociety.xyz` only — nothing else).
+
+## Auth
+
+Uses the **vended** `rgs-frontend-dns` token from `../../../cloudflare-tfvend` (read
+from its Terraform output — offline, no bootstrap token needed). State is local and
+gitignored.
+
+## Use
+
+```sh
+terraform init
+make plan
+make apply        # creates the two proxied CNAMEs
+```
+
+## Adding a frontend domain
+
+1. Add the hostname to `frontend_hostnames` here **and** to `frontend_hostnames` in
+   `../access/frontend.tf` (the gate) — keep them in lockstep.
+2. Attach it to the Pages project on the OAuth flow (Cloudflare API
+   `POST /accounts/{acc}/pages/projects/{project}/domains`).
+3. `make apply` here for the record.

--- a/infra/dns/dns.tf
+++ b/infra/dns/dns.tf
@@ -1,0 +1,22 @@
+# DNS for the deployed frontend custom domains. Each hostname is a **proxied** CNAME
+# (orange cloud) to the Pages alias, so Cloudflare routes it to the Pages app — which
+# is gated by the matching Access application in infra/access/frontend.tf. The Access
+# app is applied first (the gate), so these records never expose an unauthenticated
+# path. This is a PRIVATE project.
+#
+# Why DNS lives here and not on the wrangler OAuth flow (where the Pages custom-domain
+# *attachment* is done, like the Worker custom-domain bind): wrangler's OAuth token
+# carries Pages Write + zone *read*, but not DNS *write*. So the record itself is
+# managed here with the least-privilege vended rgs-frontend-dns token (zone DNS Write,
+# this zone only).
+resource "cloudflare_dns_record" "frontend" {
+  for_each = toset(var.frontend_hostnames)
+
+  zone_id = var.zone_id
+  name    = each.value
+  type    = "CNAME"
+  content = var.pages_alias
+  proxied = true
+  ttl     = 1 # required; 1 = automatic (and forced to automatic while proxied)
+  comment = "RGS Pages frontend (gated by Cloudflare Access)"
+}

--- a/infra/dns/outputs.tf
+++ b/infra/dns/outputs.tf
@@ -1,0 +1,4 @@
+output "frontend_records" {
+  description = "The managed frontend CNAMEs (hostname → target)."
+  value       = { for h, r in cloudflare_dns_record.frontend : h => "${r.type} → ${r.content} (proxied=${r.proxied})" }
+}

--- a/infra/dns/providers.tf
+++ b/infra/dns/providers.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Auth comes from CLOUDFLARE_API_TOKEN — the *vended* rgs-frontend-dns token (issued by
+# ../../../cloudflare-tfvend), loaded by the Makefile from that repo's Terraform output.
+# That token is DNS Write scoped to the single robogeosociety.xyz zone — nothing else.
+provider "cloudflare" {}

--- a/infra/dns/variables.tf
+++ b/infra/dns/variables.tf
@@ -1,0 +1,24 @@
+variable "zone_id" {
+  description = "Cloudflare zone id for robogeosociety.xyz."
+  type        = string
+  default     = "56bcf25e94954aee543e4a344b0cf8f7"
+}
+
+variable "pages_alias" {
+  description = "The Pages project alias the frontend custom domains CNAME to."
+  type        = string
+  default     = "robot-geographical-society-web.pages.dev"
+}
+
+variable "frontend_hostnames" {
+  description = <<-EOT
+    The frontend custom domains served by the Pages app. Each is a proxied CNAME to the
+    Pages alias and is gated by a Cloudflare Access app (see infra/access/frontend.tf) —
+    keep these two lists in lockstep, or a domain resolves without an auth boundary.
+  EOT
+  type        = list(string)
+  default = [
+    "campsites.robogeosociety.xyz",
+    "collectors.robogeosociety.xyz",
+  ]
+}


### PR DESCRIPTION
`infra` — **PLATFORM DISPATCH**

# The frontend's custom domains, as code

> _`campsites.` and `collectors.robogeosociety.xyz` now resolve to the gated Pages app — and the DNS that makes them resolve is a reviewable Terraform root, not a click in the dashboard._

> [!NOTE]
> **infra** · feat · risk: low · 2 DNS records · private project (Access-gated)

The deployed frontend answers on two custom subdomains. Two of the three pieces already existed: the **Access gate** (`infra/access/frontend.tf`) and the **Pages custom-domain attachment** (done on the wrangler OAuth flow, like the Worker bind). The missing piece was the **DNS records** — and wrangler's OAuth token carries zone *read* but not DNS *write*, so it couldn't create them.

## What this adds

A small Terraform root, `infra/dns/`, that owns the two records:

| Hostname | Record |
|---|---|
| `campsites.robogeosociety.xyz` | proxied `CNAME` → `robot-geographical-society-web.pages.dev` |
| `collectors.robogeosociety.xyz` | proxied `CNAME` → `robot-geographical-society-web.pages.dev` |

- **Least-privilege auth** — a vended `rgs-frontend-dns` token (zone **DNS Write**, `robogeosociety.xyz` only; defined in `cloudflare-tfvend`). It can't touch Access, KV, R2, Workers, or any other zone.
- **Mirrors `infra/access`** — Makefile reads the token from the tfvend output; state gitignored; lock file committed.
- **Division of labour is documented** in the README: Access boundary → `infra/access`; Pages attachment → wrangler OAuth; DNS record → here (the one step OAuth can't do).

> _"Gate first, then DNS — a record never resolves to an unauthenticated app."_

## How it fits

```mermaid
flowchart TD
  A[campsites/collectors.robogeosociety.xyz] --> B[proxied CNAME this PR]
  B --> C[Pages alias *.pages.dev]
  C --> D{Cloudflare Access\ninfra/access/frontend.tf}
  D -->|Owner SSO| E[Pages app + /api]
  D -->|no session| F[SSO login]
```

## Verification

- `terraform plan` → 2 to add; `make apply` created both records.
- Live: both hostnames return 302 → Access; **both load the app end-to-end** through SSO (campsites: map + nav; collectors: Fleet-health panel, admin badge). The boundary held — the gate was applied before DNS, so no unauthenticated window.

## Risk & rollout

- Low — two DNS records for an already-gated app; no app/data change. Already applied and verified; this PR is the version-controlled record.
- Adding a domain later: append to `frontend_hostnames` here **and** to `infra/access/frontend.tf` (keep them in lockstep), attach on the OAuth flow, `make apply`.
