### PR TITLE
feat(collector): write per-night campsite demand to Analytics Engine

### DIFF
--- a/backend/src/workflows.test.ts
+++ b/backend/src/workflows.test.ts
@@ -1,0 +1,55 @@
+import { expect, test, describe, vi } from 'vitest';
+
+// Mock the availability fetch so collectSite() gets a deterministic aggregate
+// (the network + R2 paths are exercised elsewhere; here we assert the AE writes).
+vi.mock('./availability', () => ({
+  fetchAvailability: vi.fn(async () => ({
+    raw: { ok: true },
+    by: {
+      // intentionally out of order to prove the soonest-first sort
+      '2026-07-02': { available: 0, reserved: 4, total: 4 },
+      '2026-07-01': { available: 3, reserved: 1, total: 4 },
+    },
+    bySite: {},
+  })),
+}));
+
+import { collectSite, type WfEnv } from './workflows';
+
+function spyEnv() {
+  const demand: Array<{ indexes: string[]; blobs: string[]; doubles: number[] }> = [];
+  const env = {
+    RAW: { put: vi.fn(async () => undefined) },
+    COLLECTOR_AE: { writeDataPoint: vi.fn() },
+    AVAIL_AE: { writeDataPoint: vi.fn() },
+    DEMAND_AE: { writeDataPoint: vi.fn((p: { indexes: string[]; blobs: string[]; doubles: number[] }) => demand.push(p)) },
+  } as unknown as WfEnv;
+  return { env, demand };
+}
+
+const SITE = { id: '233864', name: 'Kalaloch', agency: 'nps', kind: 'rec', ref: '233864' } as never;
+
+describe('collectSite → campsite_demand', () => {
+  test('writes one demand row per target night, soonest-first, with the per-night schema', async () => {
+    const { env, demand } = spyEnv();
+    await collectSite(env, SITE, '2026-06-20');
+    expect(demand).toEqual([
+      { indexes: ['233864'], blobs: ['2026-07-01', 'nps', 'Kalaloch'], doubles: [3, 1, 4] },
+      { indexes: ['233864'], blobs: ['2026-07-02', 'nps', 'Kalaloch'], doubles: [0, 4, 4] },
+    ]);
+  });
+
+  test('caps at 240 nights so collectSite stays under the AE 250-writes/invocation limit', async () => {
+    const big: Record<string, { available: number; reserved: number; total: number }> = {};
+    for (let i = 1; i <= 300; i++) big[`2026-${String(i).padStart(4, '0')}`] = { available: 1, reserved: 0, total: 1 };
+    const mod = await import('./availability');
+    (mod.fetchAvailability as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ raw: {}, by: big, bySite: {} });
+
+    const { env, demand } = spyEnv();
+    await collectSite(env, SITE, '2026-06-20');
+
+    expect(demand.length).toBe(240); // 300 nights → capped at 240
+    expect(demand[0].blobs[0]).toBe('2026-0001'); // soonest-first
+    expect(demand[239].blobs[0]).toBe('2026-0240'); // farthest 60 dropped
+  });
+});

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -25,6 +25,7 @@ export interface WfEnv {
   RUNS_AE?: AnalyticsEngineDataset; // (kept for compatibility)
   AVAIL_AE?: AnalyticsEngineDataset; // per-site availability rollup
   WATCH_AE?: AnalyticsEngineDataset; // dense per-check watch points
+  DEMAND_AE?: AnalyticsEngineDataset; // per-campground per-night demand → Grafana
 }
 
 // `collect: false` marks map-only / disabled sites (no rec/WA provider, or a
@@ -112,6 +113,23 @@ export async function collectSite(env: WfEnv, site: Site, date: string) {
     blobs: [date, site.agency, site.name],
     doubles: [av, rs, tot, open],
   });
+  // Per-campground per-night demand → campsite_demand: one row per target night,
+  // feeding the Campsite Demand dashboard (booking heatmap, hottest nights,
+  // in-demand campgrounds) now that it reads Analytics Engine instead of the host
+  // InfluxDB ingest. AE caps writeDataPoint() at 250/invocation and we already
+  // spend 2 above, so write only the soonest 240 nights — the demand-relevant
+  // horizon (far-out nights aren't "in demand" yet) and a hard guard against the
+  // cap for long booking windows (WA goingtocamp opens ~9 months out).
+  const nights = Object.entries(a.by)
+    .sort(([d1], [d2]) => (d1 < d2 ? -1 : 1))
+    .slice(0, 240);
+  for (const [targetDate, c] of nights) {
+    env.DEMAND_AE?.writeDataPoint({
+      indexes: [site.id],
+      blobs: [targetDate, site.agency, site.name],
+      doubles: [c.available, c.reserved, c.total],
+    });
+  }
   return { id: site.id, dates: Object.keys(a.by).length };
 }
 

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -54,6 +54,16 @@ dataset = "campsite_availability"
 binding = "WATCH_AE"
 dataset = "campsite_watch"
 
+# Per-campground per-night demand (one row per campground per target night per
+# run, soonest 240 nights). Feeds the Campsite Demand dashboard (booking heatmap,
+# hottest nights, in-demand campgrounds) after the 2026-06 move off the host
+# InfluxDB ingest. Schema:
+#   index=site.id  blob1=targetDate blob2=agency blob3=name
+#   double1=available double2=reserved double3=total
+[[analytics_engine_datasets]]
+binding = "DEMAND_AE"
+dataset = "campsite_demand"
+
 [vars]
 # The one knob: every campsite is refreshed within this many days. No fixed schedule.
 MAX_STALENESS_DAYS = "2"


### PR DESCRIPTION
# 🏕️ Write per-night campsite demand to Analytics Engine

> **Emit the demand data Grafana needs from the edge.** `collectSite()` already holds per-night availability for each campground at collect time — this writes it to a new `campsite_demand` AE dataset so the **Campsite Demand** dashboard can read from Analytics Engine instead of the host InfluxDB ingest that's being retired.

> [!NOTE]
> **area** collector/AE · **type** feat · **risk** low (additive, optional binding) · 3 files · part of campsite → native-Cloudflare migration

---

## Why

The campsite monitoring migration (`observability-config` `Cloudflare-migration-plan.md`, PR #107) is moving Grafana off the Mac's `campsite-ingest` job. The **Demand** dashboard's panels (booking heatmap, hottest nights, in-demand campgrounds) need **per-campground per-night** counts — which only existed in InfluxDB. This makes the collector Worker emit them to AE, the same way it already emits `campsite_collector` / `campsite_availability`.

## What

```mermaid
flowchart TD
  CS["collectSite() — a.by already has<br/>{targetDate: available/reserved/total}"] --> W["DEMAND_AE.writeDataPoint()<br/>soonest 240 nights"]
  W --> DS["AE dataset: campsite_demand"]
  DS --> G["Grafana: Campsite Demand<br/>(heatmap · hottest nights · in-demand)"]
```

- New AE binding `DEMAND_AE` → dataset `campsite_demand` (`wrangler.toml`).
- In `collectSite()`, after the existing `AVAIL_AE` write, loop `a.by` and write one row per target night.

| field | holds |
| --- | --- |
| index | `site.id` (consistent with the other AE datasets) |
| blobs | `targetDate`, `agency`, `name` |
| doubles | `available`, `reserved`, `total` |

**Why the 240-night cap:** AE allows **250 `writeDataPoint()` per invocation** and `collectSite` already spends 2 (`COLLECTOR_AE` + `AVAIL_AE`). We write only the **soonest 240 nights** — the demand-relevant horizon (far-out nights aren't "in demand" yet) and a hard guard for long booking windows (WA goingtocamp opens ~9 months out).

## Verification

- `npm run typecheck` clean; **57/57 tests pass** (`npx vitest run`).
- New `workflows.test.ts` asserts the per-night schema, **soonest-first** ordering, and the **240-cap** (300 nights → 240 written, farthest 60 dropped).
- `DEMAND_AE` is **optional** (`?:`) and no-ops if the binding is absent — same graceful pattern as the existing AE writes.

## Deferred — readiness is a separate problem

`campsite_readiness` is **not** in this PR. Unlike demand, readiness can't be computed on the collect path: it needs a **60-day R2 history scan** (cells/events/median-depth, formula in `predict/readiness.py`). Options for a follow-up: a scheduled history-scanning Workflow that ports the formula to TS, **or** keep a thin host job for readiness only. Until then, the **Predictions** dashboard stays on InfluxDB.

## Risk

**Low / additive.** No existing write changes; the new dataset is independent. Write volume rises (~1 → ≤240 rows per site per run) but stays under the AE per-invocation cap by construction, and AE samples high-cardinality writes. Reversible by removing the binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
