### PR TITLE
fix(collector): stop hot-path demand writes (AE write-limit outage)

### DIFF
--- a/backend/src/workflows.test.ts
+++ b/backend/src/workflows.test.ts
@@ -1,14 +1,12 @@
 import { expect, test, describe, vi } from 'vitest';
 
-// Mock the availability fetch so collectSite() gets a deterministic aggregate
-// (the network + R2 paths are exercised elsewhere; here we assert the AE writes).
+// Mock the availability fetch so collectSite() gets a deterministic aggregate.
 vi.mock('./availability', () => ({
   fetchAvailability: vi.fn(async () => ({
     raw: { ok: true },
     by: {
-      // intentionally out of order to prove the soonest-first sort
-      '2026-07-02': { available: 0, reserved: 4, total: 4 },
       '2026-07-01': { available: 3, reserved: 1, total: 4 },
+      '2026-07-02': { available: 0, reserved: 4, total: 4 },
     },
     bySite: {},
   })),
@@ -17,39 +15,28 @@ vi.mock('./availability', () => ({
 import { collectSite, type WfEnv } from './workflows';
 
 function spyEnv() {
-  const demand: Array<{ indexes: string[]; blobs: string[]; doubles: number[] }> = [];
+  const calls = { collector: 0, avail: 0, demand: 0 };
   const env = {
     RAW: { put: vi.fn(async () => undefined) },
-    COLLECTOR_AE: { writeDataPoint: vi.fn() },
-    AVAIL_AE: { writeDataPoint: vi.fn() },
-    DEMAND_AE: { writeDataPoint: vi.fn((p: { indexes: string[]; blobs: string[]; doubles: number[] }) => demand.push(p)) },
+    COLLECTOR_AE: { writeDataPoint: vi.fn(() => { calls.collector++; }) },
+    AVAIL_AE: { writeDataPoint: vi.fn(() => { calls.avail++; }) },
+    DEMAND_AE: { writeDataPoint: vi.fn(() => { calls.demand++; }) },
   } as unknown as WfEnv;
-  return { env, demand };
+  return { env, calls };
 }
 
 const SITE = { id: '233864', name: 'Kalaloch', agency: 'nps', kind: 'rec', ref: '233864' } as never;
 
-describe('collectSite → campsite_demand', () => {
-  test('writes one demand row per target night, soonest-first, with the per-night schema', async () => {
-    const { env, demand } = spyEnv();
+describe('collectSite AE writes — bounded per invocation', () => {
+  // Regression guard for the AE "write limit exceeded" outage (#103): the loop
+  // collects many sites per workflow invocation, so collectSite must write a SMALL,
+  // fixed number of AE rows. Per-night demand (~240/site) is re-homed in a separate
+  // Workflow; here collectSite must spend exactly 2 writes (collector + availability).
+  test('writes exactly collector + availability, and NO per-night demand', async () => {
+    const { env, calls } = spyEnv();
     await collectSite(env, SITE, '2026-06-20');
-    expect(demand).toEqual([
-      { indexes: ['233864'], blobs: ['2026-07-01', 'nps', 'Kalaloch'], doubles: [3, 1, 4] },
-      { indexes: ['233864'], blobs: ['2026-07-02', 'nps', 'Kalaloch'], doubles: [0, 4, 4] },
-    ]);
-  });
-
-  test('caps at 240 nights so collectSite stays under the AE 250-writes/invocation limit', async () => {
-    const big: Record<string, { available: number; reserved: number; total: number }> = {};
-    for (let i = 1; i <= 300; i++) big[`2026-${String(i).padStart(4, '0')}`] = { available: 1, reserved: 0, total: 1 };
-    const mod = await import('./availability');
-    (mod.fetchAvailability as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ raw: {}, by: big, bySite: {} });
-
-    const { env, demand } = spyEnv();
-    await collectSite(env, SITE, '2026-06-20');
-
-    expect(demand.length).toBe(240); // 300 nights → capped at 240
-    expect(demand[0].blobs[0]).toBe('2026-0001'); // soonest-first
-    expect(demand[239].blobs[0]).toBe('2026-0240'); // farthest 60 dropped
+    expect(calls.collector).toBe(1);
+    expect(calls.avail).toBe(1);
+    expect(calls.demand).toBe(0); // must NOT spam DEMAND_AE from the hot path
   });
 });

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -115,23 +115,13 @@ export async function collectSite(env: WfEnv, site: Site, date: string) {
     blobs: [date, site.agency, site.name],
     doubles: [av, rs, tot, open],
   });
-  // Per-campground per-night demand → campsite_demand: one row per target night,
-  // feeding the Campsite Demand dashboard (booking heatmap, hottest nights,
-  // in-demand campgrounds) now that it reads Analytics Engine instead of the host
-  // InfluxDB ingest. AE caps writeDataPoint() at 250/invocation and we already
-  // spend 2 above, so write only the soonest 240 nights — the demand-relevant
-  // horizon (far-out nights aren't "in demand" yet) and a hard guard against the
-  // cap for long booking windows (WA goingtocamp opens ~9 months out).
-  const nights = Object.entries(a.by)
-    .sort(([d1], [d2]) => (d1 < d2 ? -1 : 1))
-    .slice(0, 240);
-  for (const [targetDate, c] of nights) {
-    env.DEMAND_AE?.writeDataPoint({
-      indexes: [site.id],
-      blobs: [targetDate, site.agency, site.name],
-      doubles: [c.available, c.reserved, c.total],
-    });
-  }
+  // NOTE: per-campground per-night demand (campsite_demand) is NOT written here.
+  // The loop collects multiple sites per workflow invocation, and writing one AE row
+  // per target night (~240/site) blew the Analytics Engine cap of 250 writeDataPoint()
+  // calls *per invocation* once a wake collected more than one site → the whole
+  // CollectorLoop errored out. Demand is re-homed in a separate daily Workflow that
+  // writes one campground per step (≤240 writes/step, under the cap). The DEMAND_AE
+  // binding stays for that Workflow. (Regression from #103; reverted here.)
   return { id: site.id, dates: Object.keys(a.by).length };
 }
 


### PR DESCRIPTION
# 🚑 Fix collector AE write-limit outage

> **The CollectorLoop is down** — it errored with *"Analytics Engine write limit exceeded"* and stopped (0 running instances). Regression from #103: `collectSite()` wrote ~240 `campsite_demand` rows per site, but the loop collects **multiple sites per workflow invocation**, so writes blew AE's **250 writeDataPoint()/invocation** cap. This reverts the hot-path demand write to restore collection.

> [!NOTE]
> **area** collector · **type** fix (incident) · **risk** low (removes writes) · 2 files · restores a down collector

## What
- Remove the per-night `campsite_demand` write from `collectSite()` (keep the `DEMAND_AE` binding).
- `collectSite` now spends exactly **2** AE writes (collector + availability) — bounded regardless of how many sites a wake collects.
- Test flipped to a **regression guard**: asserts `collectSite` writes collector + availability and **no** demand.

## Why per-night demand can't live here
The loop collects many sites per invocation; ~240 demand writes/site × N sites ≫ 250. Demand gets **re-homed in a separate daily Workflow** that writes **one campground per step** (≤240 writes/step, under the cap) — same shape as the readiness Workflow.

## Verification
`tsc --noEmit` clean; regression-guard test passes. After merge: deploy + `wrangler workflows trigger campsite-collector` to restart the (currently dead) loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
