### PR TITLE
feat: Watch a date fill up — re-plumbing the hot-date signal off Analytics Engine

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -26,7 +26,7 @@ flowchart LR
     watch["HotDateWatchWorkflow<br/>adaptive step.sleep loop"]
     wf & watch -->|plain fetch, 6 mo| src[recreation.gov / WA goingtocamp]
     wf -->|"PUT raw/ + summary/<date>/<id>"| r2[("R2 campsite-raw")]
-    watch -->|"PUT watch/<date>/<id>/<ts>"| r2
+    watch -->|"PUT watch/<id>/<targetDate> (fill-curve)"| r2
   end
   subgraph MAC["🖥️ Home Mac — observability repo (ingest)"]
     ingest["launchd 07:30<br/>campsites/ingest.py"] --> influx[("InfluxDB campsites")] --> graf["Grafana<br/>Campsite Availability"]
@@ -39,7 +39,7 @@ flowchart LR
 | `scheduled()` | cron trigger | create the daily collector workflow |
 | `CampsiteCollectorWorkflow` | Workflow `COLLECTOR_WF` | one `step.do` per site (per-step retry/resume) → R2 |
 | `HotDateWatchWorkflow` | Workflow `WATCH_WF` | adaptive `step.sleep` watch of one (site, date) → R2 `watch/` |
-| `RAW` | R2 `campsite-raw` | `raw/`, `summary/<date>/<id>.json`, `sites/<date>/<id>.json`, `watch/<date>/<id>/<ts>.json`, `dlq/<id>.json` |
+| `RAW` | R2 `campsite-raw` | `raw/`, `summary/<date>/<id>.json`, `sites/<date>/<id>.json`, `watch/<id>/<targetDate>.json`, `dlq/<id>.json` |
 | `CAMPSITES` | KV | the campsite API |
 
 ## R2 object layout
@@ -53,7 +53,7 @@ goingtocamp resourceLocation id (negative, e.g. `-2147483476`) — **not** the
 | `raw/<date>/<agency>/<id>.json` | untouched upstream payload | audit trail; two un-normalized schemas (rec.gov vs goingtocamp) |
 | `summary/<date>/<id>.json` | `{id,name,agency,kind, by_date: {date → {available,reserved,total}}}` | campground rollup; consumed by the Mac ingest |
 | `sites/<date>/<id>.json` | `{id,name,agency,kind,collected_date, sites: {siteId → {label,loop,type,use, by_date}}}` | **per individual site**; `by_date[date]` ∈ `available\|reserved\|other` |
-| `watch/<date>/<id>/<ts>.json` | dense adaptive watch point | hot-date burn-down |
+| `watch/<id>/<targetDate>.json` | `{id,name,agency,kind,target_date,lat,lng,started_at,updated_at,done,sold_out, points: [{ts,available,reserved,total}]}` | hot-date **fill-curve** (one object per (campground, target night); read-modify-write append). Read by the webapp's `GET /watch` (was the `campsite_watch` Analytics Engine dataset — re-plumbed AE → R2, #107). |
 | `dlq/<id>.json` | quarantine marker | presence == site skipped until reactivated |
 
 `summary/` and `sites/` are normalized **identically across both providers** —
@@ -101,7 +101,8 @@ sequenceDiagram
   U->>W: create({ site, targetDate })
   loop until sold out or date passes
     W->>S: fetch availability for targetDate
-    W->>R2: PUT watch/<date>/<id>/<ts>.json  (dense point)
+    W->>R2: GET watch/<id>/<targetDate>.json  (prev curve)
+    W->>R2: PUT watch/<id>/<targetDate>.json  (append point)
     Note over W: cadence = hourly if near/filling, else daily
     W->>W: step.sleep(interval)
   end
@@ -109,7 +110,10 @@ sequenceDiagram
 
 This emits *dense, adaptive* burn-down data for the specific high-demand dates
 you care about — what uniform daily snapshots can't — for materially better
-sell-out projections. Durable: survives eviction and resumes mid-loop.
+sell-out projections. Durable: survives eviction and resumes mid-loop. The series
+is banked as one read-modify-write **fill-curve** object per (campground, target
+night) so the webapp reads it back in a single `GET /watch/:guid/:date` — re-plumbed
+off the `campsite_watch` Analytics Engine dataset (now droppable; #107, work item 2).
 
 ## Dev
 

--- a/backend/src/read-api.test.ts
+++ b/backend/src/read-api.test.ts
@@ -252,6 +252,76 @@ describe('/demand — cross-campground demand aggregation', () => {
   });
 });
 
+describe('/watch — hot-date fill-curves (AE → R2 re-plumb, #107 item 2)', () => {
+  const TARGET = '2026-07-04';
+  // A second campground (Colonial Creek North, rec.gov 246855) so /watch lists more
+  // than one curve and the hottest-first sort is exercised.
+  const CC_ID = '246855';
+  const CC_GUID = '526a9c1d-814b-5019-991b-1abb73c7340d';
+
+  function seedWatch() {
+    return makeR2({
+      // MF: filling but not sold out (60% booked at the latest point).
+      [`watch/${MF_ID}/${TARGET}.json`]: {
+        id: MF_ID, name: 'Middle Fork', agency: 'usfs', kind: 'rec', target_date: TARGET,
+        started_at: '2026-06-20T10:00:00.000Z', updated_at: '2026-06-21T10:00:00.000Z',
+        done: false, sold_out: false,
+        points: [
+          { ts: '2026-06-20T10:00:00.000Z', available: 8, reserved: 2, total: 10 },
+          { ts: '2026-06-21T10:00:00.000Z', available: 4, reserved: 6, total: 10 },
+        ],
+      },
+      // CC: sold out (100% booked) — must sort ahead of MF.
+      [`watch/${CC_ID}/${TARGET}.json`]: {
+        id: CC_ID, name: 'Colonial Creek North', agency: 'nps', kind: 'rec', target_date: TARGET,
+        started_at: '2026-06-20T10:00:00.000Z', updated_at: '2026-06-21T11:00:00.000Z',
+        done: true, sold_out: true,
+        points: [{ ts: '2026-06-21T11:00:00.000Z', available: 0, reserved: 5, total: 5 }],
+      },
+    });
+  }
+
+  test('lists every curve keyed by guid, hottest first, with the latest-point summary', async () => {
+    const RAW = seedWatch();
+    const res = await app.request('/watch', {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    expect(body.watches.map((w: any) => w.guid)).toEqual([CC_GUID, MF_GUID]); // sold-out CC first
+    const mf = body.watches.find((w: any) => w.guid === MF_GUID);
+    expect(mf).toMatchObject({
+      name: 'Middle Fork', target_date: TARGET, done: false, sold_out: false,
+      observations: 2, available: 4, reserved: 6, total: 10, fill: 0.6,
+    });
+    expect(Number.isFinite(mf.lat) && Number.isFinite(mf.lng)).toBe(true); // coords for the map
+  });
+
+  test('GET /watch/:guid/:date returns the full fill-curve series', async () => {
+    const RAW = seedWatch();
+    const res = await app.request(`/watch/${MF_GUID}/${TARGET}`, {}, { RAW } as any);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.guid).toBe(MF_GUID);
+    expect(body.points.map((p: any) => p.reserved)).toEqual([2, 6]);
+    expect(body.started_at).toBe('2026-06-20T10:00:00.000Z');
+  });
+
+  test('unknown guid → 404; bad date → 400; missing curve → 404', async () => {
+    const RAW = seedWatch();
+    expect((await app.request(`/watch/not-a-guid/${TARGET}`, {}, { RAW } as any)).status).toBe(404);
+    expect((await app.request(`/watch/${MF_GUID}/nope`, {}, { RAW } as any)).status).toBe(400);
+    expect((await app.request(`/watch/${MF_GUID}/2099-01-01`, {}, { RAW } as any)).status).toBe(404);
+  });
+
+  test('carries the 120s browser cache directive', async () => {
+    const RAW = seedWatch();
+    const list = await app.request('/watch', {}, { RAW } as any);
+    expect(list.headers.get('Cache-Control')).toBe('private, max-age=120');
+    const one = await app.request(`/watch/${MF_GUID}/${TARGET}`, {}, { RAW } as any);
+    expect(one.headers.get('Cache-Control')).toBe('private, max-age=120');
+  });
+});
+
 // The Cache-API edge layer is a no-op under Node tests (no `caches` global), but the
 // browser-facing Cache-Control directive is still stamped — that's what lets the
 // browser HTTP cache honor the same TTL as the localStorage layer. Errors stay

--- a/backend/src/read-api.ts
+++ b/backend/src/read-api.ts
@@ -266,6 +266,98 @@ readApi.get('/demand', edgeCache(600), async (c) => {
   return c.json({ from, collected: { earliest, latest: collLatest }, nights: nightRows, campgrounds });
 });
 
+// --- hot-date Watch fill-curves -------------------------------------------------
+// The HotDateWatchWorkflow banks an adaptive series of observations for one
+// (campground, target night) to a single R2 object `watch/<id>/<targetDate>.json`
+// (was the campsite_watch Analytics Engine dataset — re-plumbed AE → R2 so the webapp
+// reads the curve directly; robot-geographical-society#107, work item 2). Shape:
+//   { id, name, agency, kind, target_date, lat, lng, started_at, updated_at,
+//     done, sold_out, points: [{ ts, available, reserved, total }] }
+// keyed by provider id; we translate id ↔ guid here so the browser only ever sees guid.
+
+const WATCH_PREFIX = 'watch/';
+
+type WatchPoint = { ts: string; available: number; reserved: number; total: number };
+type WatchCurve = {
+  id: string; name?: string; agency?: string; kind?: string; target_date: string;
+  lat?: number | null; lng?: number | null; started_at?: string; updated_at?: string;
+  done?: boolean; sold_out?: boolean; points?: WatchPoint[];
+};
+
+// Latest point of a curve, for the list summary (current fill / booked counts).
+function watchSummary(curve: WatchCurve) {
+  const points = curve.points ?? [];
+  const last = points[points.length - 1] ?? { available: 0, reserved: 0, total: 0, ts: curve.updated_at };
+  const fill = last.total > 0 ? last.reserved / last.total : 0;
+  return { last, fill, observations: points.length };
+}
+
+// GET /watch — every active/completed fill-curve, keyed by guid, one row per
+// (campground, target night). The list summary carries the latest point so the
+// webapp can rank by current fill without fetching each full curve.
+readApi.get('/watch', edgeCache(120), async (c) => {
+  const { inventory } = await inventoryFor(c.env);
+  const byId = new Map(inventory.map((e) => [e.id, e]));
+
+  const { objects } = await listAll(c.env, { prefix: WATCH_PREFIX });
+  const rows: any[] = [];
+  for (const o of objects) {
+    if (!o.key.endsWith('.json')) continue;
+    const curve = await getJson<WatchCurve>(c.env, o.key);
+    if (!curve) continue;
+    const entry = byId.get(curve.id);
+    const { last, fill, observations } = watchSummary(curve);
+    rows.push({
+      guid: entry?.guid ?? null,
+      id: curve.id,
+      name: entry?.name ?? curve.name ?? null,
+      agency: entry?.agency_full ?? entry?.agency ?? curve.agency ?? null,
+      lat: entry?.lat ?? curve.lat ?? null,
+      lng: entry?.lng ?? curve.lng ?? null,
+      target_date: curve.target_date,
+      started_at: curve.started_at ?? null,
+      updated_at: curve.updated_at ?? null,
+      done: curve.done ?? false,
+      sold_out: curve.sold_out ?? false,
+      observations,
+      available: last.available,
+      reserved: last.reserved,
+      total: last.total,
+      fill,
+    });
+  }
+  // Hottest (most booked) first, then soonest target night.
+  rows.sort((a, b) => b.fill - a.fill || (a.target_date < b.target_date ? -1 : a.target_date > b.target_date ? 1 : 0));
+  return c.json({ watches: rows });
+});
+
+// GET /watch/:guid/:date — one campground/target-night fill-curve (the full series of
+// observations over the life of the watch). :date is the target night, YYYY-MM-DD.
+readApi.get('/watch/:guid/:date', edgeCache(120), async (c) => {
+  const { byGuid } = await inventoryFor(c.env);
+  const entry = byGuid.get(c.req.param('guid'));
+  if (!entry) return c.json({ error: 'unknown guid' }, 404);
+  const date = c.req.param('date');
+  if (!DATE_RE.test(date)) return c.json({ error: 'need a YYYY-MM-DD target date' }, 400);
+
+  const curve = await getJson<WatchCurve>(c.env, `${WATCH_PREFIX}${entry.id}/${date}.json`);
+  if (!curve) return c.json({ error: 'no watch for that campground/date' }, 404);
+
+  return c.json({
+    guid: entry.guid,
+    name: entry.name ?? curve.name ?? null,
+    agency: entry.agency_full ?? entry.agency ?? curve.agency ?? null,
+    lat: entry.lat ?? curve.lat ?? null,
+    lng: entry.lng ?? curve.lng ?? null,
+    target_date: curve.target_date,
+    started_at: curve.started_at ?? null,
+    updated_at: curve.updated_at ?? null,
+    done: curve.done ?? false,
+    sold_out: curve.sold_out ?? false,
+    points: curve.points ?? [],
+  });
+});
+
 // GET /availability/:guid/site/:siteId — one site's per-night status calendar.
 // :siteId is the internal R2 site id (e.g. 81835), NOT the human label ("24").
 readApi.get('/availability/:guid/site/:siteId', edgeCache(300), async (c) => {

--- a/backend/src/workflows.test.ts
+++ b/backend/src/workflows.test.ts
@@ -12,7 +12,8 @@ vi.mock('./availability', () => ({
   })),
 }));
 
-import { collectSite, type WfEnv } from './workflows';
+import { collectSite, appendWatchPoint, watchKey, type WfEnv, type WatchCurve } from './workflows';
+import { makeR2 } from '../test/stubs/r2';
 
 function spyEnv() {
   const calls = { collector: 0, avail: 0, demand: 0 };
@@ -38,5 +39,52 @@ describe('collectSite AE writes — bounded per invocation', () => {
     expect(calls.collector).toBe(1);
     expect(calls.avail).toBe(1);
     expect(calls.demand).toBe(0); // must NOT spam DEMAND_AE from the hot path
+  });
+});
+
+const WATCH_SITE = {
+  id: '233864', name: 'Kalaloch', agency: 'nps', kind: 'rec', ref: '233864',
+  targetDate: '2026-07-04', lat: 47.6, lng: -124.4,
+} as never;
+
+describe('appendWatchPoint — fill-curve banked to R2 (AE → R2 re-plumb, #107 item 2)', () => {
+  // The hot-date watcher no longer writes the campsite_watch Analytics Engine dataset;
+  // it appends each observation to ONE R2 object (watch/<id>/<targetDate>.json) so the
+  // webapp can read the whole fill-curve in a single get. There is no AE binding in the
+  // env here — if the workflow still tried to write AE, it would throw.
+  test('seeds the curve object on the first observation', async () => {
+    const RAW = makeR2();
+    const env = { RAW } as unknown as WfEnv;
+    const curve = await appendWatchPoint(
+      env, WATCH_SITE,
+      { ts: '2026-06-21T10:00:00.000Z', available: 8, reserved: 2, total: 10 },
+      false, false,
+    );
+    expect(curve).toMatchObject({
+      id: '233864', name: 'Kalaloch', agency: 'nps', kind: 'rec',
+      target_date: '2026-07-04', lat: 47.6, lng: -124.4, done: false, sold_out: false,
+    });
+    expect(curve.started_at).toBe('2026-06-21T10:00:00.000Z');
+    expect(curve.points).toEqual([{ ts: '2026-06-21T10:00:00.000Z', available: 8, reserved: 2, total: 10 }]);
+
+    // It really landed in R2 at the documented key.
+    const stored = (await (await RAW.get(watchKey('233864', '2026-07-04')))!.json()) as WatchCurve;
+    expect(stored.points).toHaveLength(1);
+  });
+
+  test('read-modify-writes: appends to the existing series and keeps started_at', async () => {
+    const RAW = makeR2();
+    const env = { RAW } as unknown as WfEnv;
+    await appendWatchPoint(env, WATCH_SITE, { ts: '2026-06-21T10:00:00.000Z', available: 8, reserved: 2, total: 10 }, false, false);
+    const curve = await appendWatchPoint(
+      env, WATCH_SITE,
+      { ts: '2026-06-21T16:00:00.000Z', available: 0, reserved: 10, total: 10 },
+      true, true,
+    );
+    expect(curve.started_at).toBe('2026-06-21T10:00:00.000Z'); // preserved from the first point
+    expect(curve.updated_at).toBe('2026-06-21T16:00:00.000Z');
+    expect(curve.done).toBe(true);
+    expect(curve.sold_out).toBe(true);
+    expect(curve.points.map((p) => p.reserved)).toEqual([2, 10]);
   });
 });

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -24,7 +24,8 @@ export interface WfEnv {
   COLLECTOR_AE?: AnalyticsEngineDataset; // per-site coverage → Grafana
   RUNS_AE?: AnalyticsEngineDataset; // (kept for compatibility)
   AVAIL_AE?: AnalyticsEngineDataset; // per-site availability rollup
-  WATCH_AE?: AnalyticsEngineDataset; // dense per-check watch points
+  // (Removed) WATCH_AE — the hot-date watcher now banks its fill-curve to R2
+  // (watch/<id>/<date>.json) for the webapp, not Analytics Engine (#107, item 2).
   DEMAND_AE?: AnalyticsEngineDataset; // per-campground per-night demand → Grafana
   READINESS_AE?: AnalyticsEngineDataset; // daily prediction-readiness gauge → Grafana
   READINESS_WF: Workflow; // daily readiness Workflow (self-reference for continue-as-new)
@@ -310,7 +311,67 @@ export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
 
 // --- 2. Adaptive hot-date watcher ----------------------------------------------
 
-type WatchParams = Site & { targetDate: string; every?: string; maxChecks?: number };
+type WatchParams = Site & {
+  targetDate: string;
+  every?: string;
+  maxChecks?: number;
+  lat?: number | null;
+  lng?: number | null;
+};
+
+// One fill-curve observation: the campground-night counts at a point in time.
+export type WatchPoint = { ts: string; available: number; reserved: number; total: number };
+
+// The fill-curve object the watcher banks to R2 at `watch/<id>/<targetDate>.json`.
+// One object per (campground, target night), growing a `points` series over the life
+// of the watch — read straight back by the webapp's GET /watch endpoints.
+export type WatchCurve = {
+  id: string;
+  name: string;
+  agency: string;
+  kind: "rec" | "wa";
+  target_date: string;
+  lat?: number | null;
+  lng?: number | null;
+  started_at: string;
+  updated_at: string;
+  done: boolean;
+  sold_out: boolean;
+  points: WatchPoint[];
+};
+
+export const watchKey = (id: string, targetDate: string) => `watch/${id}/${targetDate}.json`;
+
+// Append one observation to the (read-modify-write) fill-curve object in R2. The whole
+// series lives in a single object so the read API can serve a curve in one R2 get; the
+// watch cadence is slow (hours, capped at ~500 checks) so the rewrite cost is trivial.
+export async function appendWatchPoint(
+  env: WfEnv,
+  p: WatchParams,
+  point: WatchPoint,
+  done: boolean,
+  soldOut: boolean,
+): Promise<WatchCurve> {
+  const key = watchKey(p.id, p.targetDate);
+  const existing = await env.RAW.get(key);
+  const prev = existing ? ((await existing.json()) as WatchCurve) : null;
+  const curve: WatchCurve = {
+    id: p.id,
+    name: p.name,
+    agency: p.agency,
+    kind: p.kind,
+    target_date: p.targetDate,
+    lat: p.lat ?? prev?.lat ?? null,
+    lng: p.lng ?? prev?.lng ?? null,
+    started_at: prev?.started_at ?? point.ts,
+    updated_at: point.ts,
+    done,
+    sold_out: soldOut,
+    points: [...(prev?.points ?? []), point],
+  };
+  await env.RAW.put(key, JSON.stringify(curve));
+  return curve;
+}
 
 export class HotDateWatchWorkflow extends WorkflowEntrypoint<WfEnv, WatchParams> {
   async run(event: WorkflowEvent<WatchParams>, step: WorkflowStep) {
@@ -329,20 +390,23 @@ export class HotDateWatchWorkflow extends WorkflowEntrypoint<WfEnv, WatchParams>
           const monthStart = new Date(Date.UTC(target.getUTCFullYear(), target.getUTCMonth(), 1));
           const a = await fetchAvailability(p.kind, p.ref, 1, monthStart);
           const c: Counts = a.by[p.targetDate] ?? { available: 0, reserved: 0, total: 0 };
-          const observedAt = new Date().toISOString();
-          await this.env.RAW.put(
-            `watch/${p.targetDate}/${p.id}/${observedAt}.json`,
-            JSON.stringify({ id: p.id, name: p.name, agency: p.agency, target_date: p.targetDate, observedAt, ...c }),
-          );
-          this.env.WATCH_AE?.writeDataPoint({
-            indexes: [p.id],
-            blobs: [p.targetDate, p.agency, p.name],
-            doubles: [c.available, c.reserved, c.total],
-          });
+          const ts = new Date().toISOString();
           const now = Date.now();
           const daysOut = (Date.parse(p.targetDate) - now) / 86_400_000;
           const fill = c.total ? 1 - c.available / c.total : 0;
           const done = c.available === 0 || daysOut <= 0;
+          // Bank the fill-curve to R2 (was the campsite_watch Analytics Engine dataset):
+          // AE → R2 re-plumb so the webapp reads the curve directly with no AE round-trip
+          // (robot-geographical-society#107, work item 2). Adaptive cadence is unchanged;
+          // only the sink moved. The campsite_watch AE dataset is now unused and can be
+          // dropped — its binding/IaC live in observability-config (follow-up there).
+          await appendWatchPoint(
+            this.env,
+            p,
+            { ts, available: c.available, reserved: c.reserved, total: c.total },
+            done,
+            c.available === 0,
+          );
           const interval =
             p.every ?? (daysOut < 7 || fill > 0.8 ? "1 hour" : daysOut < 30 ? "6 hours" : "24 hours");
           return { c, done, interval, daysOut: Math.round(daysOut), fill: Math.round(fill * 100) };

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -47,12 +47,10 @@ dataset = "campsite_collector_runs"
 binding = "AVAIL_AE"
 dataset = "campsite_availability"
 
-# Dense per-check hot-date watch points. Schema:
-#   index=site.id  blob1=targetDate blob2=agency blob3=name
-#   double1=available double2=reserved double3=total
-[[analytics_engine_datasets]]
-binding = "WATCH_AE"
-dataset = "campsite_watch"
+# (Removed) WATCH_AE / campsite_watch — the hot-date watcher now banks its fill-curve
+# to R2 (watch/<id>/<targetDate>.json) so the webapp reads it directly with no AE
+# round-trip (robot-geographical-society#107, work item 2). The campsite_watch dataset
+# is unused; drop it in observability-config (follow-up).
 
 # Per-campground per-night demand (one row per campground per target night per
 # run, soonest 240 nights). Feeds the Campsite Demand dashboard (booking heatmap,

--- a/web/e2e/campsite.test.js
+++ b/web/e2e/campsite.test.js
@@ -40,12 +40,18 @@ test.describe('Robot Geographical Society - Integration', () => {
     await page.goto(`${BASE_URL}/availability`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('link', { name: /Availability/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /Demand/i })).toBeVisible();
+    await expect(page.getByRole('link', { name: /Watch/i })).toBeVisible();
     await expect(page.getByRole('link', { name: /Collectors/i })).toBeVisible();
   });
 
   test('demand view renders the demand panel', async ({ page }) => {
     await page.goto(`${BASE_URL}/demand`, { waitUntil: 'domcontentloaded' });
     await expect(page.getByRole('heading', { name: 'Demand' })).toBeVisible();
+  });
+
+  test('watch view renders the watch panel', async ({ page }) => {
+    await page.goto(`${BASE_URL}/watch`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: 'Watch' })).toBeVisible();
   });
 
   test('availability view renders the map controls and agency legend', async ({ page }) => {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -5,6 +5,7 @@ import { MapContext } from './map/MapContext';
 import { MAP_STYLE, WA_BOUNDS } from './constants';
 import AvailabilityView from './views/AvailabilityView';
 import DemandView from './views/DemandView';
+import WatchView from './views/WatchView';
 import CollectorsView from './views/CollectorsView';
 
 // The app is served at two gated subdomains; each lands on its own view (the nav tabs
@@ -73,6 +74,7 @@ export default function App() {
           <nav className="nav-tabs">
             <NavLink to="/availability" className="nav-tab">Availability</NavLink>
             <NavLink to="/demand" className="nav-tab">Demand</NavLink>
+            <NavLink to="/watch" className="nav-tab">Watch</NavLink>
             <NavLink to="/collectors" className="nav-tab">Collectors</NavLink>
           </nav>
         </header>
@@ -89,6 +91,7 @@ export default function App() {
             <Route path="/" element={<Navigate to={defaultPath()} replace />} />
             <Route path="/availability" element={<AvailabilityView />} />
             <Route path="/demand" element={<DemandView />} />
+            <Route path="/watch" element={<WatchView />} />
             <Route path="/collectors" element={<CollectorsView />} />
             <Route path="*" element={<Navigate to={defaultPath()} replace />} />
           </Routes>

--- a/web/src/api.js
+++ b/web/src/api.js
@@ -111,6 +111,23 @@ export function getDemand() {
   return getCachedJSON('/demand', AVAILABILITY_TTL);
 }
 
+// Hot-date Watch fill-curves: the adaptive series the watcher banks to R2 for one
+// (campground, target night), re-plumbed off Analytics Engine so the webapp reads it
+// directly (#107, work item 2). The list summary carries each watch's latest point:
+//   { watches: [{ guid, name, agency, lat, lng, target_date, started_at, updated_at,
+//                 done, sold_out, observations, available, reserved, total, fill }] }
+// Short TTL (the watcher updates a curve every few hours).
+export function getWatches() {
+  return getCachedJSON('/watch', FLEET_TTL);
+}
+
+// One campground/target-night fill-curve — the full observation series:
+//   { guid, name, agency, target_date, started_at, updated_at, done, sold_out,
+//     points: [{ ts, available, reserved, total }] }
+export function getWatchCurve(guid, date) {
+  return getJSON(`/watch/${guid}/${date}`);
+}
+
 // Per-site rows for one campground on a date:
 //   { sites: [{ siteId, label, loop, type, use, status }] }
 // status ∈ "available" | "reserved" | "other".

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -649,6 +649,22 @@ button.demand-row:hover .demand-row-name { color: var(--text); }
 .demand-bar-fill { display: block; height: 100%; border-radius: 4px; }
 .demand-bar-label { white-space: nowrap; font-variant-numeric: tabular-nums; }
 
+/* Watch view — one card per watched (campground, target night) with its fill-curve.
+   Reuses the .fleet-panel shell on the right. */
+.watch-section { margin-top: 8px; display: flex; flex-direction: column; gap: 10px; }
+.watch-row {
+  display: block; width: 100%; text-align: left; padding: 8px;
+  background: var(--bg-surface, rgba(255, 255, 255, 0.03));
+  border: 1px solid var(--border); border-radius: 6px;
+  color: inherit; font-family: inherit; cursor: pointer;
+}
+.watch-row:hover { border-color: var(--text-muted); }
+.watch-row-head { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.watch-row-name { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.watch-row-fill { font-size: 12px; font-variant-numeric: tabular-nums; font-weight: 600; }
+.watch-row-date { margin: 1px 0 4px; }
+.watch-curve { display: block; width: 100%; }
+
 .state-badge {
   display: inline-block;
   padding: 3px 10px;

--- a/web/src/panes/watch.js
+++ b/web/src/panes/watch.js
@@ -1,0 +1,67 @@
+// Pure derivations over the /watch payload (the hot-date fill-curves). The Worker
+// returns each watch as a series of observed points ({ ts, available, reserved, total });
+// the view's chart + ranking are computed from them here so the math is unit-testable
+// independent of React.
+
+// Share of a campground-night that's booked at one observation: reserved / total.
+// `total` includes "other" (not-yet-released / not-reservable), so this is the true
+// fraction of the night's inventory already spoken for. 0 when nothing was captured.
+export function bookedPct({ reserved = 0, total = 0 } = {}) {
+  return total > 0 ? reserved / total : 0;
+}
+
+// The latest observation's booked fraction — how full the night is *right now*. Used to
+// rank watches (hottest first) and color the pin/badge.
+export function latestFill(curve) {
+  const points = curve?.points ?? [];
+  const last = points[points.length - 1];
+  return last ? bookedPct(last) : (Number.isFinite(curve?.fill) ? curve.fill : 0);
+}
+
+// Normalize a fill-curve for plotting: each point gets `pct` (booked fraction 0..1) and
+// an `x` in [0,1] spread evenly across the observation count (the watch cadence is
+// adaptive, so even spacing reads cleaner than true-time spacing for a thumbnail). The
+// series is returned in observation order. Empty series → [].
+export function curvePoints(points = []) {
+  const n = points.length;
+  return points.map((p, i) => ({
+    ts: p.ts,
+    pct: bookedPct(p),
+    reserved: p.reserved ?? 0,
+    available: p.available ?? 0,
+    total: p.total ?? 0,
+    x: n <= 1 ? 0 : i / (n - 1),
+  }));
+}
+
+// Build an SVG points string (in a width×height box, padded) for a fill-curve so the
+// chart component stays declarative. y is inverted (0% booked at the bottom). Returns
+// { line, area } point strings, or null for an empty series.
+export function curveGeometry(points = [], { width = 200, height = 60, pad = 2 } = {}) {
+  const pts = curvePoints(points);
+  if (pts.length === 0) return null;
+  const w = width - pad * 2;
+  const h = height - pad * 2;
+  const x = (v) => pad + v * w;
+  const y = (pct) => pad + h - pct * h;
+  const line = pts.map((p) => `${x(p.x).toFixed(1)},${y(p.pct).toFixed(1)}`).join(' ');
+  const area = `${x(0).toFixed(1)},${(pad + h).toFixed(1)} ${line} ${x(1).toFixed(1)},${(pad + h).toFixed(1)}`;
+  return { line, area };
+}
+
+// Watches ranked by current fill, hottest first; ties broken by the soonest target
+// night. Does not mutate the input.
+export function rankWatches(watches = []) {
+  return [...watches].sort(
+    (a, b) => latestFill(b) - latestFill(a) ||
+      (a.target_date < b.target_date ? -1 : a.target_date > b.target_date ? 1 : 0),
+  );
+}
+
+// Fill ramp: hot (mostly booked) = red, cold (mostly open) = green — "full" is the
+// signal a watch is tracking, so it mirrors the Demand ramp.
+export function fillColor(pct) {
+  if (pct >= 0.66) return '#F85149';
+  if (pct >= 0.33) return '#D29922';
+  return '#3FB950';
+}

--- a/web/src/panes/watch.test.js
+++ b/web/src/panes/watch.test.js
@@ -1,0 +1,80 @@
+import { describe, test, expect } from 'vitest';
+import { bookedPct, latestFill, curvePoints, curveGeometry, rankWatches, fillColor } from './watch';
+
+describe('bookedPct', () => {
+  test('reserved / total, including "other" in the denominator', () => {
+    expect(bookedPct({ reserved: 6, total: 10 })).toBe(0.6);
+  });
+  test('0 when nothing captured', () => {
+    expect(bookedPct({ reserved: 0, total: 0 })).toBe(0);
+    expect(bookedPct()).toBe(0);
+  });
+});
+
+describe('latestFill', () => {
+  test('uses the last observed point', () => {
+    const curve = { points: [{ reserved: 2, total: 10 }, { reserved: 9, total: 10 }] };
+    expect(latestFill(curve)).toBe(0.9);
+  });
+  test('falls back to a summary `fill` when there are no points', () => {
+    expect(latestFill({ points: [], fill: 0.4 })).toBe(0.4);
+    expect(latestFill({})).toBe(0);
+  });
+});
+
+describe('curvePoints', () => {
+  const points = [
+    { ts: 't0', available: 8, reserved: 2, total: 10 },
+    { ts: 't1', available: 4, reserved: 6, total: 10 },
+    { ts: 't2', available: 0, reserved: 10, total: 10 },
+  ];
+  test('attaches booked pct and an even x in [0,1]', () => {
+    const out = curvePoints(points);
+    expect(out.map((p) => p.pct)).toEqual([0.2, 0.6, 1]);
+    expect(out.map((p) => p.x)).toEqual([0, 0.5, 1]);
+  });
+  test('single point sits at x=0; empty → []', () => {
+    expect(curvePoints([{ reserved: 1, total: 2 }])[0].x).toBe(0);
+    expect(curvePoints([])).toEqual([]);
+  });
+});
+
+describe('curveGeometry', () => {
+  test('builds line + area point strings in the padded box', () => {
+    const g = curveGeometry(
+      [{ reserved: 0, total: 10 }, { reserved: 10, total: 10 }],
+      { width: 100, height: 50, pad: 0 },
+    );
+    // 0% booked at the bottom (y=50), 100% at the top (y=0), x spans full width.
+    expect(g.line).toBe('0.0,50.0 100.0,0.0');
+    // Area closes down to the baseline at both ends.
+    expect(g.area).toBe('0.0,50.0 0.0,50.0 100.0,0.0 100.0,50.0');
+  });
+  test('empty series → null', () => {
+    expect(curveGeometry([])).toBeNull();
+  });
+});
+
+describe('rankWatches', () => {
+  const watches = [
+    { guid: 'a', target_date: '2026-07-04', points: [{ reserved: 2, total: 10 }] }, // 20%
+    { guid: 'b', target_date: '2026-07-04', points: [{ reserved: 10, total: 10 }] }, // 100%
+    { guid: 'c', target_date: '2026-06-01', points: [{ reserved: 5, total: 10 }] }, // 50%
+  ];
+  test('hottest first, ties by soonest target night', () => {
+    expect(rankWatches(watches).map((w) => w.guid)).toEqual(['b', 'c', 'a']);
+  });
+  test('does not mutate the input', () => {
+    const copy = [...watches];
+    rankWatches(watches);
+    expect(watches).toEqual(copy);
+  });
+});
+
+describe('fillColor', () => {
+  test('hot → red, mid → amber, cold → green', () => {
+    expect(fillColor(0.9)).toBe('#F85149');
+    expect(fillColor(0.5)).toBe('#D29922');
+    expect(fillColor(0.1)).toBe('#3FB950');
+  });
+});

--- a/web/src/views/WatchView.jsx
+++ b/web/src/views/WatchView.jsx
@@ -1,0 +1,223 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useMap } from '../map/MapContext';
+import { useCircleLayer, rowsToFC, HOVER_PAINT } from '../map/useCircleLayer';
+import { getWatches, getWatchCurve } from '../api';
+import { AGENCY_COLORS, agencyShort } from '../constants';
+import StalenessBanner from '../components/StalenessBanner';
+import ProgressBar from '../components/ProgressBar';
+import { latestFill, curveGeometry, rankWatches, fillColor } from '../panes/watch';
+
+// Hot-date Watch — "watch this date fill up". The collector's HotDateWatchWorkflow
+// densely re-checks one (campground, target night) on an adaptive cadence and banks the
+// fill-curve to R2 (GET /watch); this view plots % booked over the life of each watch.
+// Pins are colored by how full each watched night is right now; the panel ranks the
+// hottest watches and draws each one's fill-curve.
+
+// Map pins colored by the watch's current fill (latest reserved / total), carried on
+// each feature as `fill`.
+const WATCH_PAINT = {
+  ...HOVER_PAINT,
+  'circle-color': [
+    'step', ['get', 'fill'],
+    '#3FB950',       // cold (mostly open)
+    0.33, '#D29922', // warming
+    0.66, '#F85149', // hot (mostly booked)
+  ],
+};
+
+const pct = (x) => `${Math.round(x * 100)}%`;
+const weekday = (night) =>
+  new Date(`${night}T00:00:00`).toLocaleDateString(undefined, { weekday: 'short', month: 'short', day: 'numeric' });
+
+export default function WatchView() {
+  const { map, ready } = useMap();
+  const [watches, setWatches] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selected, setSelected] = useState(null); // a watch row
+
+  useEffect(() => {
+    let live = true;
+    setLoading(true);
+    setError(null);
+    getWatches()
+      .then((d) => { if (live) setWatches(d?.watches ?? []); })
+      .catch((e) => { if (live) setError(e.message); })
+      .finally(() => { if (live) setLoading(false); });
+    return () => { live = false; };
+  }, []);
+
+  const rows = useMemo(() => watches ?? [], [watches]);
+  const latestUpdate = useMemo(
+    () => rows.map((w) => w.updated_at).filter(Boolean).sort().slice(-1)[0]?.slice(0, 10) ?? null,
+    [rows],
+  );
+
+  // Pins carry the current fill so the paint can color them without recomputing.
+  const fc = useMemo(() => rowsToFC(rows, (w) => ({ fill: latestFill(w) })), [rows]);
+
+  const onSelect = (props) => {
+    setSelected(props);
+    if (map && Number.isFinite(props.lat) && Number.isFinite(props.lng)) {
+      map.flyTo({ center: [props.lng, props.lat], zoom: Math.max(map.getZoom(), 9) });
+    }
+  };
+
+  useCircleLayer({
+    map, ready, id: 'watch', features: fc, paint: WATCH_PAINT,
+    onSelect,
+    onEmptyClick: () => setSelected(null),
+  });
+
+  return (
+    <>
+      <div className="map-overlay-tl">
+        <div className="control-row">
+          {error && <span className="error-text control-chip" role="alert">{error}</span>}
+          {loading && (
+            <span className="control-chip control-chip--progress">
+              <ProgressBar indeterminate label="Loading watches" />
+              <span className="muted">loading watches…</span>
+            </span>
+          )}
+          {!loading && !error && (
+            <span className="muted control-chip">{rows.length} watched dates · pin fill = how booked</span>
+          )}
+        </div>
+        <StalenessBanner date={latestUpdate} />
+      </div>
+
+      <WatchLegend />
+
+      {!loading && !error && <WatchPanel watches={rows} onSelect={onSelect} />}
+
+      {selected && <WatchDetail watch={selected} onClose={() => setSelected(null)} />}
+    </>
+  );
+}
+
+function WatchLegend() {
+  const items = [
+    ['#3FB950', 'Mostly open'],
+    ['#D29922', 'Filling'],
+    ['#F85149', 'Mostly booked'],
+  ];
+  return (
+    <div className="legend legend-states" aria-label="Watch legend">
+      {items.map(([color, label]) => (
+        <span key={label} className="legend-item">
+          <span className="legend-dot" style={{ backgroundColor: color }} />
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function WatchPanel({ watches, onSelect }) {
+  const ranked = useMemo(() => rankWatches(watches), [watches]);
+
+  if (!watches.length) {
+    return (
+      <div className="fleet-panel" aria-label="Hot-date watches">
+        <h2 className="panel-name">Watch</h2>
+        <div className="muted">No dates are being watched yet.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="fleet-panel" aria-label="Hot-date watches">
+      <h2 className="panel-name">Watch</h2>
+      <div className="muted small">Watched nights, filling up — hottest first.</div>
+
+      <section className="watch-section">
+        {ranked.map((w) => {
+          const fill = latestFill(w);
+          return (
+            <button
+              key={`${w.guid}-${w.target_date}`}
+              className="watch-row"
+              onClick={() => onSelect(w)}
+            >
+              <div className="watch-row-head">
+                <span className="watch-row-name">{w.name}</span>
+                <span className="watch-row-fill" style={{ color: fillColor(fill) }}>
+                  {w.sold_out ? 'SOLD OUT' : pct(fill)}
+                </span>
+              </div>
+              <div className="watch-row-date muted small">{weekday(w.target_date)}</div>
+              <FillCurve points={w.points} fill={fill} />
+            </button>
+          );
+        })}
+      </section>
+    </div>
+  );
+}
+
+// A small SVG fill-curve: x = observation order across the watch, y = % booked
+// (0% at the bottom). `points` may be absent on the list rows (the summary only
+// carries the latest point) — then we render a flat line at the current fill.
+function FillCurve({ points, fill, width = 200, height = 48 }) {
+  const series = points && points.length
+    ? points
+    : [{ reserved: 0, total: 1 }, { reserved: fill, total: 1 }];
+  const g = curveGeometry(series, { width, height, pad: 2 });
+  const color = fillColor(fill);
+  if (!g) return null;
+  return (
+    <svg
+      className="watch-curve" viewBox={`0 0 ${width} ${height}`} width="100%" height={height}
+      preserveAspectRatio="none" role="img" aria-label={`${pct(fill)} booked`}
+    >
+      <polygon points={g.area} fill={color} fillOpacity="0.12" />
+      <polyline points={g.line} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+    </svg>
+  );
+}
+
+// Clicking a watch loads its full fill-curve (the list only carries the latest point)
+// and shows the series detail.
+function WatchDetail({ watch, onClose }) {
+  const [curve, setCurve] = useState(null);
+  const [err, setErr] = useState(null);
+
+  useEffect(() => {
+    let live = true;
+    setCurve(null);
+    setErr(null);
+    getWatchCurve(watch.guid, watch.target_date)
+      .then((d) => { if (live) setCurve(d); })
+      .catch((e) => { if (live) setErr(e.message); });
+    return () => { live = false; };
+  }, [watch.guid, watch.target_date]);
+
+  const points = curve?.points ?? watch.points ?? [];
+  const fill = points.length ? latestFill({ points }) : latestFill(watch);
+
+  return (
+    <div className="detail-panel" role="dialog" aria-label="Hot-date watch">
+      <button className="panel-close" onClick={onClose} aria-label="Close panel">✕</button>
+      <div className="panel-agency" style={{ color: AGENCY_COLORS[agencyShort(watch.agency)] }}>
+        {watch.agency}
+      </div>
+      <h2 className="panel-name">{watch.name}</h2>
+      <div className="muted small">Target night · {weekday(watch.target_date)}</div>
+      <div className="state-badge" style={{ background: fillColor(fill) }}>
+        {watch.sold_out ? 'Sold out' : `${pct(fill)} booked`}
+      </div>
+
+      {err && <div className="error-text" role="alert">{err}</div>}
+      <FillCurve points={points} fill={fill} width={260} height={96} />
+
+      <dl className="kv">
+        <dt>Observations</dt><dd>{points.length || watch.observations || 0}</dd>
+        <dt>Reserved</dt><dd>{points.length ? points[points.length - 1].reserved : watch.reserved}</dd>
+        <dt>Open</dt><dd>{points.length ? points[points.length - 1].available : watch.available}</dd>
+        <dt>Started</dt><dd>{(curve?.started_at ?? watch.started_at)?.slice(0, 10) ?? '—'}</dd>
+      </dl>
+      <div className="muted small">% booked over the life of the watch.</div>
+    </div>
+  );
+}

--- a/web/src/views/WatchView.test.jsx
+++ b/web/src/views/WatchView.test.jsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MapContext } from '../map/MapContext';
+import WatchView from './WatchView';
+import { _resetCaches } from '../api';
+
+// Two watched nights. Colonial Creek is sold out (100% booked); Middle Fork is filling
+// (60%). The list rows carry the latest-point summary; the detail fetch returns the
+// full curve.
+const WATCHES = {
+  watches: [
+    {
+      guid: 'cc', name: 'Colonial Creek North', agency: 'National Park Service',
+      lat: 48, lng: -121, target_date: '2026-07-04', updated_at: '2026-06-21T11:00:00.000Z',
+      done: true, sold_out: true, observations: 1, available: 0, reserved: 5, total: 5, fill: 1,
+    },
+    {
+      guid: 'mf', name: 'Middle Fork', agency: 'US Forest Service',
+      lat: 47, lng: -121, target_date: '2026-07-04', updated_at: '2026-06-21T10:00:00.000Z',
+      done: false, sold_out: false, observations: 2, available: 4, reserved: 6, total: 10, fill: 0.6,
+    },
+  ],
+};
+
+const MF_CURVE = {
+  guid: 'mf', name: 'Middle Fork', agency: 'US Forest Service', target_date: '2026-07-04',
+  started_at: '2026-06-20T10:00:00.000Z', updated_at: '2026-06-21T10:00:00.000Z',
+  done: false, sold_out: false,
+  points: [
+    { ts: '2026-06-20T10:00:00.000Z', available: 8, reserved: 2, total: 10 },
+    { ts: '2026-06-21T10:00:00.000Z', available: 4, reserved: 6, total: 10 },
+  ],
+};
+
+beforeEach(() => {
+  _resetCaches();
+  vi.spyOn(global, 'fetch').mockImplementation((url) => {
+    const u = String(url);
+    if (u.includes('/watch/mf/')) return jsonOk(MF_CURVE);
+    if (u.includes('/watch')) return jsonOk(WATCHES);
+    return jsonOk({});
+  });
+});
+afterEach(() => vi.restoreAllMocks());
+
+function jsonOk(body) {
+  return Promise.resolve({ ok: true, json: () => Promise.resolve(body) });
+}
+
+function renderView() {
+  return render(
+    <MapContext.Provider value={{ map: null, ready: false }}>
+      <WatchView />
+    </MapContext.Provider>,
+  );
+}
+
+describe('WatchView', () => {
+  it('ranks watched nights hottest first and shows the sold-out marker', async () => {
+    renderView();
+    await waitFor(() => expect(screen.getByText('Watch')).toBeInTheDocument());
+
+    const names = screen.getAllByText(/Colonial Creek North|Middle Fork/).map((n) => n.textContent);
+    expect(names[0]).toBe('Colonial Creek North'); // sold out → top
+    expect(screen.getByText('SOLD OUT')).toBeInTheDocument();
+    expect(screen.getByText('60%')).toBeInTheDocument(); // Middle Fork's current fill
+  });
+
+  it('opens a watch detail with the full fill-curve on click', async () => {
+    const user = userEvent.setup();
+    renderView();
+    await waitFor(() => expect(screen.getByText('Watch')).toBeInTheDocument());
+
+    await user.click(screen.getByText('Middle Fork'));
+
+    const dialog = await screen.findByRole('dialog', { name: /Hot-date watch/i });
+    // The detail fetched the 2-point curve.
+    await waitFor(() => expect(within(dialog).getByText('2')).toBeInTheDocument()); // observations
+    expect(within(dialog).getByText('60% booked')).toBeInTheDocument();
+  });
+
+  it('shows an empty state when nothing is watched', async () => {
+    global.fetch.mockImplementation(() => jsonOk({ watches: [] }));
+    renderView();
+    await waitFor(() => expect(screen.getByText(/No dates are being watched yet/)).toBeInTheDocument());
+  });
+});


### PR DESCRIPTION
`WEBAPP · COLLECTOR` — **PRODUCT DISPATCH**

# Watch a date fill up — re-plumbing the hot-date signal off Analytics Engine

> _The watcher already knew which nights were burning down. It just had nowhere to say so. This pipes the fill-curve into R2 and draws it in the webapp._

> [!NOTE]
> **webapp + collector** · feat · risk: low · part of #107 (work item 2)

The collector's `HotDateWatchWorkflow` densely re-checks one (campground, target night) on an adaptive cadence and was writing every observation to the `campsite_watch` Analytics Engine dataset. In the native-Cloudflare migration the Grafana panel that read it was removed (it was already empty) — so the "watch this date fill up" signal landed **nowhere user-facing**. This re-plumbs the sink **Analytics Engine → R2** and builds the product view, the sibling of the cross-campground Demand view (#108).

## The move: same watcher, new sink

- **Workflow → R2.** The watcher now appends each observation to **one** read-modify-write object, `watch/<id>/<targetDate>.json`, holding a `points` series of `{ ts, available, reserved, total }`. The adaptive cadence (hourly when near/filling, else daily) is untouched — only the sink changed. The `WATCH_AE` binding and `campsite_watch` dataset are gone from `wrangler.toml`.
- **Two read endpoints.** `GET /watch` lists every curve keyed by `guid` (hottest first, latest-point summary); `GET /watch/:guid/:date` returns one full curve. Both edge-cached 120s, with the same `guid ↔ providerId` translation as `/availability`.
- **Webapp view.** A new **Watch** tab: map pins colored by current fill, a panel ranking watched nights, each with an SVG fill-curve of % booked over the life of the watch, and a detail popup that loads the full series. The math lives in pure, unit-tested `panes/watch.js`.

> _"One object per watched night, appended in place — so the webapp reads a whole burn-down curve in a single GET."_

## How it flows

```mermaid
flowchart TD
  W["HotDateWatchWorkflow<br/>adaptive step.sleep loop"] -->|"GET+PUT watch/&lt;id&gt;/&lt;date&gt;.json<br/>(append fill-curve point)"| R2[("R2 campsite-raw")]
  W -.->|"removed: writeDataPoint()"| AE["campsite_watch AE<br/>(now droppable)"]
  R2 --> RA["read-api: GET /watch<br/>GET /watch/:guid/:date"]
  RA -->|"guid-keyed JSON, edge-cached 120s"| API["web api.js<br/>getWatches / getWatchCurve"]
  API --> V["WatchView<br/>pins + fill-curve panel"]
  style AE stroke-dasharray: 4 4
```

## Checkpoints

- [x] Workflow banks the fill-curve to R2; AE write + binding removed.
- [x] `GET /watch` + `GET /watch/:guid/:date` read endpoints (guid translation, edge cache).
- [x] Watch nav tab + `/watch` route + `panes/watch.js` derivations + WatchView.
- [ ] Follow-up: drop the unused `campsite_watch` AE dataset in `observability-config`.

## Screens & wireframes

No static mock — the view is interactive (map pins + per-watch SVG fill-curves). The flow diagram above is the canonical reference; the `flowchart TD` in `backend/README.md` is updated to match the new R2 key.

## Verification

- **Backend:** `npm test -- --run` → **70 passed** (was 64; +2 workflow R2-sink, +4 read-api `/watch`). `tsc --noEmit` clean.
- **Web:** `npm test -- --run` → **55 passed** (+11 `panes/watch` derivations, +3 WatchView). `npm run lint` clean; `vite build` clean. e2e adds a Watch-tab + panel check (green once the Worker is deployed, like the other live-Worker e2e).
- **Not deployed.** Code + tests + PR only — deployment is gated and stays the user's call.

## Risk & rollout

- **Low.** Read-only new endpoints; the workflow change swaps one sink for another with the cadence intact. No schema migration — `watch/` was previously dense per-observation objects; the new single-object curve is a fresh key shape the read API expects (old keys, if any, are simply ignored).
- **Follow-up:** `campsite_watch` AE is now unused and can be deleted in `observability-config` (its binding/IaC live there — not touched here).
