### PR TITLE
feat(infra): Terraform IaC for the RGS data-plane (KV + R2 + Pages, imported)

### DIFF
--- a/infra/cloudflare/.gitignore
+++ b/infra/cloudflare/.gitignore
@@ -1,0 +1,8 @@
+# Local Terraform state holds resource metadata (and, for some roots, secrets) — never
+# commit it. Only *.tf + the provider lock file are tracked.
+.terraform/
+.terraform.lock.hcl.bak
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log

--- a/infra/cloudflare/.terraform.lock.hcl
+++ b/infra/cloudflare/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:TJQJrskWa1FJ8gk6BAhj4X6fa5TFqI255T6Y6ZKrFkU=",
+    "zh:2d3dc17f27dcf308f52bdede3b7bb00e6cda6c1a9fbdafd1bfe4a915e75fdc44",
+    "zh:413e3569ad0cc89f8ac425d8a197d9e892ff356ac24dedde386820cf5880a48e",
+    "zh:59f262b9af9a8845afeb2734a6bd83b260aa2c521e5c318850745823ef62b38d",
+    "zh:7d42963a47ff6dda8aada0cb73a26eb6807c7ff6bb4419cb91b32ce2412c8362",
+    "zh:89cad3906c9affa0f2947607d316d70c38541c399d0519ebee1f1ccc8aaf5675",
+    "zh:d5c7ff6c39d895e5746fed74ecc3f284c91c8c1f502da2e93f5c581f41f87f25",
+    "zh:dc425b5f40e94165e563dc55bd6e49cedfe879a03e668168610459ef071b1a87",
+    "zh:f0665907dd24ae93f9511216052d653bba0823c933e888cf02a4abf95f73dfe0",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/cloudflare/Makefile
+++ b/infra/cloudflare/Makefile
@@ -1,0 +1,39 @@
+# Manage the durable RGS data-plane resources (KV namespace, R2 bucket, Pages project).
+#
+# Auth is the *vended* rgs-infra token, read from the cloudflare-tfvend repo's Terraform
+# output (offline — no bootstrap token needed). Override its path with TFVEND=/path if
+# the repo lives elsewhere.
+
+TFVEND ?= /Volumes/dev/cloudflare-tfvend
+ACCOUNT_ID ?= d7adee58513c1b2f770ccaac90cf114f
+KV_ID  ?= aad9f04d90e945ffb8d278d7b8e70976
+R2_BUCKET ?= campsite-raw
+PAGES_PROJECT ?= robot-geographical-society-web
+export CLOUDFLARE_API_TOKEN := $(shell terraform -chdir=$(TFVEND) output -raw rgs_infra_token 2>/dev/null)
+
+.PHONY: help check plan apply import destroy
+
+help:
+	@echo "make import   # one-time: adopt the existing KV/R2/Pages into state (never recreate)"
+	@echo "make plan     # terraform plan (gate: must show 0 to destroy)"
+	@echo "make apply    # terraform apply (auto-approve)"
+
+check:
+	@test -n "$(CLOUDFLARE_API_TOKEN)" || { \
+		echo "No vended token. Is $(TFVEND) applied? (terraform -chdir=$(TFVEND) output rgs_infra_token)"; exit 1; }
+
+# One-time adoption of the live resources. Safe to re-run: import only writes local
+# state, never mutates Cloudflare. Run after `terraform init`, then `make plan`.
+import: check
+	terraform import cloudflare_workers_kv_namespace.campsites $(ACCOUNT_ID)/$(KV_ID)
+	terraform import cloudflare_r2_bucket.campsite_raw $(ACCOUNT_ID)/$(R2_BUCKET)/default
+	terraform import cloudflare_pages_project.web $(ACCOUNT_ID)/$(PAGES_PROJECT)
+
+plan: check
+	terraform plan
+
+apply: check
+	terraform apply -auto-approve
+
+destroy: check
+	@echo "Refusing to destroy data-plane resources (KV + R2 hold live data). Remove from state with 'terraform state rm' instead if needed."; exit 1

--- a/infra/cloudflare/README.md
+++ b/infra/cloudflare/README.md
@@ -1,0 +1,55 @@
+# infra/cloudflare — RGS data-plane resources (Terraform)
+
+Terraform that owns the durable, previously click-ops'd Cloudflare **data-plane**
+resources behind the RGS backend + frontend:
+
+- `cloudflare_workers_kv_namespace.campsites` — the **CAMPSITES** KV namespace
+  (id `aad9f04d…`; authoritative inventory `_inventory` + per-campsite detail).
+- `cloudflare_r2_bucket.campsite_raw` — the **campsite-raw** R2 bucket (banked
+  availability snapshots: `raw/ · summary/ · sites/ · watch/ · dlq/ · scheduler/`).
+- `cloudflare_pages_project.web` — the **robot-geographical-society-web** Pages project.
+
+## What this does NOT manage (by design)
+
+- **Worker / Pages code** → `wrangler deploy` / `wrangler pages deploy` (OAuth). Terraform
+  owns the resource shells; wrangler deploys code into them.
+- **Worker + Pages custom-domain attachment** → wrangler OAuth (same split as the Worker
+  domain bind). The DNS *records* live in `../dns`.
+- **Access boundary** → `../access`. **Worker bindings / vars / AE datasets / Workflows**
+  → `backend/wrangler.toml` (the deploy manifest — single source for those).
+
+So `wrangler.toml` and this root must agree on **identity only** (the KV id and bucket
+name); the outputs here surface them to keep the two from drifting.
+
+## Auth
+
+Uses the **vended** `rgs-infra` token from `../../../cloudflare-tfvend` (KV Write + R2
+Storage Write + Pages Write, account-scoped — it cannot touch Access, DNS, or deploy
+code). The Makefile reads it from that repo's Terraform output; no bootstrap needed.
+
+## Import, never recreate
+
+The KV namespace and R2 bucket hold **live production data**. These resources were
+**imported**, not created — `terraform apply` must never recreate them.
+
+```sh
+terraform init
+make import        # one-time adopt (idempotent on the cloud side — import only writes state)
+make plan          # GATE: must report "No changes" / 0 to destroy
+```
+
+`make destroy` is intentionally disabled here; remove a resource from management with
+`terraform state rm` instead.
+
+## State (local) + re-adopting
+
+State is **local and gitignored** (same as `../access`, `../dns`). A fresh clone or a
+removed worktree therefore has no state — don't `apply` blind. Re-adopt with:
+
+```sh
+terraform init && make import && make plan   # plan must show "No changes"
+```
+
+Because the per-root local-state model is now repeated across several roots, migrating
+these to a shared **R2 (S3) backend** is the planned hardening step (tfvend already
+vends R2 S3 creds). Until then, re-import is the recovery path.

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -1,0 +1,30 @@
+# Durable RGS data-plane resources, brought under Terraform by IMPORT (never
+# recreated — they hold live production data: the KV inventory and months of R2
+# snapshots). wrangler.toml keeps referencing these by id/name; `wrangler deploy`
+# still deploys the code into them. See README.md for the import commands.
+
+# The CAMPSITES KV namespace — authoritative campsite inventory (`_inventory`) plus
+# per-campsite detail. wrangler.toml binds it by id (aad9f04d…); CI writes `_inventory`
+# via the rgs-kv-write token.
+resource "cloudflare_workers_kv_namespace" "campsites" {
+  account_id = var.account_id
+  title      = var.kv_namespace_title
+}
+
+# The campsite-raw R2 bucket — banked availability snapshots
+# (raw/ · summary/ · sites/ · watch/ · dlq/ · scheduler/). Read by the Worker's
+# read-api; written by the collector Workflows.
+resource "cloudflare_r2_bucket" "campsite_raw" {
+  account_id = var.account_id
+  name       = var.r2_bucket_name
+}
+
+# The RGS frontend Pages project. Terraform owns the project shell (name + production
+# branch); `wrangler pages deploy` / CI still pushes the built assets, and the
+# custom-domain attachments (campsites/collectors) stay on the wrangler OAuth flow,
+# matching the Worker custom-domain split.
+resource "cloudflare_pages_project" "web" {
+  account_id        = var.account_id
+  name              = var.pages_project_name
+  production_branch = var.pages_production_branch
+}

--- a/infra/cloudflare/outputs.tf
+++ b/infra/cloudflare/outputs.tf
@@ -1,0 +1,16 @@
+# The ids/names wrangler.toml references, surfaced so the deploy manifest and this
+# Terraform root never drift on identity.
+output "kv_namespace_id" {
+  description = "CAMPSITES KV namespace id (matches wrangler.toml [[kv_namespaces]].id)."
+  value       = cloudflare_workers_kv_namespace.campsites.id
+}
+
+output "r2_bucket_name" {
+  description = "campsite-raw R2 bucket name (matches wrangler.toml [[r2_buckets]].bucket_name)."
+  value       = cloudflare_r2_bucket.campsite_raw.name
+}
+
+output "pages_project_name" {
+  description = "RGS frontend Pages project name."
+  value       = cloudflare_pages_project.web.name
+}

--- a/infra/cloudflare/providers.tf
+++ b/infra/cloudflare/providers.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# Auth comes from CLOUDFLARE_API_TOKEN — the *vended* rgs-infra token (issued by
+# ../../../cloudflare-tfvend), loaded by the Makefile from that repo's Terraform
+# output. This root manages only the durable data-plane resources (KV namespace, R2
+# bucket, Pages project). Worker/Pages *code* deploy stays on wrangler (OAuth); Access
+# and DNS live in their own roots (infra/access, infra/dns).
+provider "cloudflare" {}

--- a/infra/cloudflare/variables.tf
+++ b/infra/cloudflare/variables.tf
@@ -1,0 +1,29 @@
+variable "account_id" {
+  description = "Cloudflare account (tommyroar-dev)."
+  type        = string
+  default     = "d7adee58513c1b2f770ccaac90cf114f"
+}
+
+variable "kv_namespace_title" {
+  description = "Title of the CAMPSITES Workers KV namespace (the authoritative inventory + per-campsite KV)."
+  type        = string
+  default     = "CAMPSITES"
+}
+
+variable "r2_bucket_name" {
+  description = "Name of the R2 bucket holding the banked availability snapshots."
+  type        = string
+  default     = "campsite-raw"
+}
+
+variable "pages_project_name" {
+  description = "Cloudflare Pages project for the RGS frontend."
+  type        = string
+  default     = "robot-geographical-society-web"
+}
+
+variable "pages_production_branch" {
+  description = "Production branch for the Pages project."
+  type        = string
+  default     = "main"
+}


### PR DESCRIPTION
`INFRA` — **TERRAFORM DISPATCH**

# The data plane stops being click-ops

> _The KV namespace, R2 bucket, and Pages project were the last RGS production resources living only in the dashboard. They're now imported into Terraform — declared, least-privilege, recreation-safe._

> [!NOTE]
> **infra** · feat · risk: low · imported (no resource changes)

You're already ~60% IaC: `infra/access` owns the Access boundary and `infra/dns` owns the frontend DNS, each consuming a least-privilege token vended by `cloudflare-tfvend`. This adds the third root — `infra/cloudflare` — for the durable **data-plane** resources that had no declared source of truth.

## What it manages
- `cloudflare_workers_kv_namespace.campsites` — the **CAMPSITES** KV (id `aad9f04d…`).
- `cloudflare_r2_bucket.campsite_raw` — the **campsite-raw** snapshot bucket.
- `cloudflare_pages_project.web` — the **robot-geographical-society-web** Pages project.

All three were **imported, never created** — KV + R2 hold live production data. The gate held: after `make import`, `terraform plan` reports **No changes** (0 add / 0 change / 0 destroy).

> _"Terraform owns the resource shells; wrangler deploys the code into them."_

## The boundary (deliberate)
```mermaid
flowchart TD
  T[cloudflare-tfvend] -->|vends rgs-infra token| C[infra/cloudflare]
  C -->|owns shells| K[KV namespace]
  C --> R[R2 bucket]
  C --> P[Pages project]
  W[wrangler · OAuth] -->|deploys code| K
  W -->|deploys code + custom-domain attach| P
  M[wrangler.toml] -->|bindings · vars · AE · Workflows| K
```
Worker/Pages **code** stays on wrangler; `wrangler.toml` stays the single source for bindings, vars, AE datasets, and Workflows; Access + DNS keep their own roots. This root surfaces the KV id / bucket name as outputs so the two never drift on identity.

## Auth
A new vended **`rgs-infra`** token (KV Write + R2 Storage Write + Pages Write, account-scoped — cannot touch Access, DNS, or deploy code). Added to `cloudflare-tfvend` in a companion PR.

## Verification
- `terraform init && make import` (KV, R2 `…/campsite-raw/default`, Pages) → all "Import successful".
- `make plan` → **"No changes. Your infrastructure matches the configuration."**
- KV id in `wrangler.toml` matches the imported namespace; no `wrangler.toml` change needed.

## Risk & rollout
- **No resource changes** — pure adoption; `wrangler deploy` is unchanged.
- **State is local + gitignored** (like the sibling roots). Post-merge, re-run `make import` in the primary checkout to establish persistent state there; a shared **R2 (S3) backend** is the planned hardening (tfvend already vends R2 S3 creds).
- `make destroy` is disabled here — KV + R2 hold data; use `terraform state rm` to unmanage.
