### PR TITLE
feat(infra): R2 remote-state backend for the Cloudflare Terraform roots

### DIFF
--- a/infra/access/Makefile
+++ b/infra/access/Makefile
@@ -7,8 +7,18 @@
 TFVEND ?= /Volumes/dev/cloudflare-tfvend
 ENVFILE ?= ../../web/.env.local
 export CLOUDFLARE_API_TOKEN := $(shell terraform -chdir=$(TFVEND) output -raw rgs_access_admin_token 2>/dev/null)
+# Remote-state (R2 S3 backend) credentials — the vended tfstate-r2 token.
+export AWS_ACCESS_KEY_ID := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_access_key_id 2>/dev/null)
+export AWS_SECRET_ACCESS_KEY := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_secret_access_key 2>/dev/null)
 
-.PHONY: help check plan apply envfile destroy
+.PHONY: help check init migrate plan apply envfile destroy
+
+init: check
+	terraform init
+
+# One-time migration of existing local state into the R2 backend.
+migrate: check
+	terraform init -migrate-state
 
 help:
 	@echo "make plan      # terraform plan"

--- a/infra/access/backend.tf
+++ b/infra/access/backend.tf
@@ -1,0 +1,18 @@
+# Remote state on R2 (S3-compatible). Credentials come from AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY, exported by the Makefile from the vended `tfstate-r2` token
+# (cloudflare-tfvend outputs). State holds the Access service-token secret — R2 is private.
+terraform {
+  backend "s3" {
+    bucket    = "tommyroar-tfstate"
+    key       = "rgs/access.tfstate"
+    region    = "auto"
+    endpoints = { s3 = "https://d7adee58513c1b2f770ccaac90cf114f.r2.cloudflarestorage.com" }
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    use_path_style              = true
+    skip_s3_checksum            = true
+  }
+}

--- a/infra/cloudflare/Makefile
+++ b/infra/cloudflare/Makefile
@@ -10,10 +10,15 @@ KV_ID  ?= aad9f04d90e945ffb8d278d7b8e70976
 R2_BUCKET ?= campsite-raw
 PAGES_PROJECT ?= robot-geographical-society-web
 export CLOUDFLARE_API_TOKEN := $(shell terraform -chdir=$(TFVEND) output -raw rgs_infra_token 2>/dev/null)
+# Remote-state (R2 S3 backend) credentials — the vended tfstate-r2 token.
+export AWS_ACCESS_KEY_ID := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_access_key_id 2>/dev/null)
+export AWS_SECRET_ACCESS_KEY := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_secret_access_key 2>/dev/null)
 
-.PHONY: help check plan apply import destroy
+.PHONY: help check init migrate plan apply import destroy
 
 help:
+	@echo "make init     # terraform init (R2 remote-state backend)"
+	@echo "make migrate  # one-time: terraform init -migrate-state (local -> R2)"
 	@echo "make import   # one-time: adopt the existing KV/R2/Pages into state (never recreate)"
 	@echo "make plan     # terraform plan (gate: must show 0 to destroy)"
 	@echo "make apply    # terraform apply (auto-approve)"
@@ -21,6 +26,13 @@ help:
 check:
 	@test -n "$(CLOUDFLARE_API_TOKEN)" || { \
 		echo "No vended token. Is $(TFVEND) applied? (terraform -chdir=$(TFVEND) output rgs_infra_token)"; exit 1; }
+
+init: check
+	terraform init
+
+# One-time migration of existing local state into the R2 backend.
+migrate: check
+	terraform init -migrate-state
 
 # One-time adoption of the live resources. Safe to re-run: import only writes local
 # state, never mutates Cloudflare. Run after `terraform init`, then `make plan`.

--- a/infra/cloudflare/backend.tf
+++ b/infra/cloudflare/backend.tf
@@ -1,0 +1,19 @@
+# Remote state on R2 (S3-compatible). Credentials come from AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY, exported by the Makefile from the vended `tfstate-r2` token
+# (cloudflare-tfvend outputs). The skip_* / use_path_style / skip_s3_checksum flags are
+# what make the AWS s3 backend talk to R2 instead of real S3.
+terraform {
+  backend "s3" {
+    bucket    = "tommyroar-tfstate"
+    key       = "rgs/cloudflare.tfstate"
+    region    = "auto"
+    endpoints = { s3 = "https://d7adee58513c1b2f770ccaac90cf114f.r2.cloudflarestorage.com" }
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    use_path_style              = true
+    skip_s3_checksum            = true
+  }
+}

--- a/infra/cloudflare/main.tf
+++ b/infra/cloudflare/main.tf
@@ -28,3 +28,12 @@ resource "cloudflare_pages_project" "web" {
   name              = var.pages_project_name
   production_branch = var.pages_production_branch
 }
+
+# Shared Terraform remote-state bucket (S3-compatible R2). Created here because this root
+# holds the rgs-infra R2 Storage Write token; the consumer roots (this one, ../access,
+# ../dns, tommyroar/infra/mapbox) keep their state under distinct keys in it. tfvend stays
+# on local state (it vends the S3 creds for this bucket — see cloudflare-tfvend/state.tf).
+resource "cloudflare_r2_bucket" "tfstate" {
+  account_id = var.account_id
+  name       = "tommyroar-tfstate"
+}

--- a/infra/dns/Makefile
+++ b/infra/dns/Makefile
@@ -7,8 +7,18 @@
 
 TFVEND ?= /Volumes/dev/cloudflare-tfvend
 export CLOUDFLARE_API_TOKEN := $(shell terraform -chdir=$(TFVEND) output -raw rgs_frontend_dns_token 2>/dev/null)
+# Remote-state (R2 S3 backend) credentials — the vended tfstate-r2 token.
+export AWS_ACCESS_KEY_ID := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_access_key_id 2>/dev/null)
+export AWS_SECRET_ACCESS_KEY := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_secret_access_key 2>/dev/null)
 
-.PHONY: help check plan apply destroy
+.PHONY: help check init migrate plan apply destroy
+
+init: check
+	terraform init
+
+# One-time migration of existing local state into the R2 backend.
+migrate: check
+	terraform init -migrate-state
 
 help:
 	@echo "make plan      # terraform plan"

--- a/infra/dns/backend.tf
+++ b/infra/dns/backend.tf
@@ -1,0 +1,18 @@
+# Remote state on R2 (S3-compatible). Credentials come from AWS_ACCESS_KEY_ID /
+# AWS_SECRET_ACCESS_KEY, exported by the Makefile from the vended `tfstate-r2` token
+# (cloudflare-tfvend outputs).
+terraform {
+  backend "s3" {
+    bucket    = "tommyroar-tfstate"
+    key       = "rgs/dns.tfstate"
+    region    = "auto"
+    endpoints = { s3 = "https://d7adee58513c1b2f770ccaac90cf114f.r2.cloudflarestorage.com" }
+
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    use_path_style              = true
+    skip_s3_checksum            = true
+  }
+}


### PR DESCRIPTION
`INFRA` — **TERRAFORM DISPATCH**

# State leaves the laptop

> _Five Terraform roots were each keeping local, gitignored state with a documented "lose the file, re-import everything" recovery. They now share one R2 bucket — durable, private, recoverable._

> [!NOTE]
> **infra** · feat · risk: low · state migrated (no resource changes)

After the data-plane IaC landed (#110), the RGS Cloudflare estate had **five** Terraform roots — `tfvend`, `infra/cloudflare`, `infra/access`, `infra/dns`, and `tommyroar/infra/mapbox` — all on **local** state. Each carried the same fragility: a removed worktree or fresh clone meant no state, and the only recovery was a careful re-import dance. This moves the consumer roots onto a shared **R2 (S3-compatible) backend**.

## What changed
- **`infra/cloudflare`** creates the shared bucket (`cloudflare_r2_bucket.tfstate` → `tommyroar-tfstate`) — it holds the `rgs-infra` R2 Storage Write token — and points its own backend at it.
- **`infra/cloudflare` · `infra/access` · `infra/dns`** each get a `backend "s3"` (distinct keys: `rgs/{cloudflare,access,dns}.tfstate`) with the `use_path_style` + `skip_*` + `skip_s3_checksum` flags R2 needs. Makefiles export the S3 creds from the vended `tfstate-r2` token and gain `init` / `migrate` targets.
- **`tfvend` stays on local state** — it vends the S3 creds for this bucket, so its own state can't live there (circular). Companion PR adds the `tfstate-r2` token.

> _"The bootstrap root stays local; everything it bootstraps goes remote."_

## How it fits
```mermaid
flowchart TD
  TF[tfvend · local state] -->|vends tfstate-r2 S3 creds| B[(r2://tommyroar-tfstate)]
  C[infra/cloudflare] -->|rgs/cloudflare.tfstate| B
  A[infra/access] -->|rgs/access.tfstate| B
  D[infra/dns] -->|rgs/dns.tfstate| B
  M[tommyroar/infra/mapbox] -->|infra/mapbox.tfstate| B
```

## Verification
- `terraform init -migrate-state` on each root → "Successfully configured the backend s3"; all resources copied (verified via `state list` + the four objects present in R2).
- Post-migration `plan`: **cloudflare + dns = "No changes."**
- **access** plans only the **pre-existing** Google-IdP-pending-secret drift (unrelated to the backend; would show with local state too).

## Risk & rollout
- **No resource changes** — pure state relocation; `wrangler deploy` untouched.
- Credentials are the least-privilege `tfstate-r2` token (R2 object r/w on the one bucket); state objects are private to R2.
- **Companion PRs:** `cloudflare-tfvend` (the token) and `tommyroar/infra` (mapbox migration — which surfaced a pre-existing "4 tokens in state without config" drift, flagged there; do not `apply` mapbox until reconciled).
- Follow-up: a shared `backend.tf` partial-config + `-backend-config` could DRY the four near-identical blocks.
