### PR TITLE
feat(backend): Discord alerts for new campsite availability

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -129,3 +129,20 @@ npx wrangler workflows instances describe campsite-collector <id>
 Workflows: `src/workflows.ts`. Plain-fetch clients: `src/availability.ts`.
 Campsite set: `src/campsites-index.json` (61 reservable: 39 rec.gov, 22 WA).
 Ingest side: `observability/campsites/`.
+
+## Discord availability alerts
+
+After each successful `collectSite()`, the `CollectorLoop` compares the new
+`summary/<date>/<id>.json` against the most recent prior snapshot (R2 lookback ≤7d)
+and posts a green Discord embed for any night that went **0 → available** (gains
+only — fill-ups are silent). Logic lives in `src/discord.ts`
+(`detectChanges` · `buildEmbed` · `notifyAvailabilityChanges`); it is **opt-in and
+non-blocking** — a no-op when the secret is unset, and a webhook failure never fails
+collection (it runs in its own replay-safe `step.do`, so a retry can't double-post).
+
+Enable it by setting the webhook URL as a Wrangler **secret** (never commit a real
+value):
+
+```sh
+npx wrangler secret put DISCORD_WEBHOOK_URL    # paste the channel's webhook URL
+```

--- a/backend/src/discord.test.ts
+++ b/backend/src/discord.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  detectChanges,
+  buildEmbed,
+  sendWebhook,
+  notifyAvailabilityChanges,
+  loadPreviousSummary,
+  type AvailabilityChange,
+  type SiteInfo,
+} from "./discord";
+import type { ByDate } from "./availability";
+
+// --- detectChanges -----------------------------------------------------------
+
+describe("detectChanges", () => {
+  const today = "2026-06-27";
+
+  it("returns empty when current has no availability", () => {
+    const prev: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
+    const curr: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
+    expect(detectChanges(prev, curr, today)).toEqual([]);
+  });
+
+  it("detects 0 → >0 transition", () => {
+    const prev: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
+    const curr: ByDate = { "2026-06-28": { available: 3, reserved: 7, total: 10 } };
+    const changes = detectChanges(prev, curr, today);
+    expect(changes).toHaveLength(1);
+    expect(changes[0]).toMatchObject({
+      date: "2026-06-28",
+      previousAvailable: 0,
+      currentAvailable: 3,
+      total: 10,
+    });
+  });
+
+  it("detects newly appeared date (absent in prev)", () => {
+    const prev: ByDate = {};
+    const curr: ByDate = { "2026-07-04": { available: 5, reserved: 15, total: 20 } };
+    const changes = detectChanges(prev, curr, today);
+    expect(changes).toHaveLength(1);
+    expect(changes[0].previousAvailable).toBe(0);
+    expect(changes[0].currentAvailable).toBe(5);
+  });
+
+  it("handles null prev (first collection)", () => {
+    const curr: ByDate = { "2026-07-04": { available: 2, reserved: 8, total: 10 } };
+    const changes = detectChanges(null, curr, today);
+    expect(changes).toHaveLength(1);
+  });
+
+  it("ignores dates before today", () => {
+    const curr: ByDate = { "2026-06-20": { available: 5, reserved: 5, total: 10 } };
+    expect(detectChanges(null, curr, today)).toEqual([]);
+  });
+
+  it("ignores dates that were already available", () => {
+    const prev: ByDate = { "2026-06-28": { available: 3, reserved: 7, total: 10 } };
+    const curr: ByDate = { "2026-06-28": { available: 5, reserved: 5, total: 10 } };
+    // Was already >0, so this is NOT a new appearance.
+    expect(detectChanges(prev, curr, today)).toEqual([]);
+  });
+
+  it("does NOT alert on availability loss (>0 → 0)", () => {
+    // Sites filling up is the opposite of what we notify on — silence, not noise.
+    const prev: ByDate = { "2026-06-28": { available: 4, reserved: 6, total: 10 } };
+    const curr: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
+    expect(detectChanges(prev, curr, today)).toEqual([]);
+  });
+
+  it("does NOT alert on a decrease that stays available (5 → 2)", () => {
+    // Still bookable, but it never went 0 → >0, so it's not a fresh opening.
+    const prev: ByDate = { "2026-06-28": { available: 5, reserved: 5, total: 10 } };
+    const curr: ByDate = { "2026-06-28": { available: 2, reserved: 8, total: 10 } };
+    expect(detectChanges(prev, curr, today)).toEqual([]);
+  });
+
+  it("returns multiple changes sorted by date", () => {
+    const prev: ByDate = {
+      "2026-07-10": { available: 0, reserved: 10, total: 10 },
+      "2026-07-05": { available: 0, reserved: 10, total: 10 },
+    };
+    const curr: ByDate = {
+      "2026-07-10": { available: 2, reserved: 8, total: 10 },
+      "2026-07-05": { available: 1, reserved: 9, total: 10 },
+    };
+    const changes = detectChanges(prev, curr, today);
+    expect(changes).toHaveLength(2);
+    expect(changes[0].date).toBe("2026-07-05");
+    expect(changes[1].date).toBe("2026-07-10");
+  });
+});
+
+// --- buildEmbed --------------------------------------------------------------
+
+describe("buildEmbed", () => {
+  const site: SiteInfo = {
+    id: "usfs/middle-fork",
+    name: "Middle Fork",
+    agency: "usfs",
+    kind: "rec",
+    lat: 47.55,
+    lng: -121.53,
+  };
+
+  it("builds a green embed with campsite info", () => {
+    const changes: AvailabilityChange[] = [
+      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 3, total: 20 },
+    ];
+    const embed = buildEmbed(site, changes);
+    expect(embed.color).toBe(0x2ecc71);
+    expect(embed.title).toContain("Middle Fork");
+    expect(embed.title).toContain("Available");
+    expect(embed.fields.find((f) => f.name === "Park / Agency")?.value).toBe("US Forest Service");
+  });
+
+  it("includes a book-now link for rec.gov sites", () => {
+    const changes: AvailabilityChange[] = [
+      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
+    ];
+    const embed = buildEmbed(site, changes);
+    const bookField = embed.fields.find((f) => f.name === "Book Now");
+    expect(bookField).toBeDefined();
+    expect(bookField!.value).toContain("recreation.gov");
+  });
+
+  it("uses the numeric provider ref (not the slug) in the rec.gov link", () => {
+    // rec.gov campground URLs are keyed by the numeric id; the slug would 404.
+    const refSite: SiteInfo = { ...site, ref: 233864 };
+    const changes: AvailabilityChange[] = [
+      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
+    ];
+    const embed = buildEmbed(refSite, changes);
+    const bookField = embed.fields.find((f) => f.name === "Book Now");
+    expect(bookField!.value).toContain("/campgrounds/233864");
+    expect(bookField!.value).not.toContain("usfs/middle-fork");
+  });
+
+  it("prefers an explicit reservation_url when provided", () => {
+    const urlSite: SiteInfo = { ...site, reservation_url: "https://example.org/book/here" };
+    const changes: AvailabilityChange[] = [
+      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
+    ];
+    const embed = buildEmbed(urlSite, changes);
+    const bookField = embed.fields.find((f) => f.name === "Book Now");
+    expect(bookField!.value).toContain("https://example.org/book/here");
+  });
+
+  it("handles WA state parks", () => {
+    const waSite: SiteInfo = { id: "wa/deception-pass", name: "Deception Pass", agency: "wa", kind: "wa" };
+    const changes: AvailabilityChange[] = [
+      { date: "2026-08-01", previousAvailable: 0, currentAvailable: 5, total: 30 },
+    ];
+    const embed = buildEmbed(waSite, changes);
+    expect(embed.fields.find((f) => f.name === "Park / Agency")?.value).toBe("Washington State Parks");
+  });
+
+  it("caps date lines at 15 with overflow indicator", () => {
+    const changes: AvailabilityChange[] = Array.from({ length: 20 }, (_, i) => ({
+      date: `2026-07-${String(i + 1).padStart(2, "0")}`,
+      previousAvailable: 0,
+      currentAvailable: 1,
+      total: 10,
+    }));
+    const embed = buildEmbed(site, changes);
+    const availField = embed.fields.find((f) => f.name === "Availability");
+    expect(availField!.value).toContain("…and 5 more dates");
+  });
+
+  it("pluralizes correctly for single change", () => {
+    const changes: AvailabilityChange[] = [
+      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
+    ];
+    const embed = buildEmbed(site, changes);
+    // The number is bold-wrapped (**1**), so check for the singular noun form.
+    expect(embed.description).toContain("campsite-night ");
+    expect(embed.description).not.toContain("campsite-nights");
+  });
+});
+
+// --- sendWebhook -------------------------------------------------------------
+
+describe("sendWebhook", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("returns true on 204", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+    const ok = await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] });
+    expect(ok).toBe(true);
+  });
+
+  it("returns false on 429 (rate limit)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 429 }));
+    const ok = await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] });
+    expect(ok).toBe(false);
+  });
+
+  it("returns false on network error", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
+    const ok = await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] });
+    expect(ok).toBe(false);
+  });
+});
+
+// --- loadPreviousSummary (R2 mock) -------------------------------------------
+
+function mockR2Bucket(data: Record<string, any>): R2Bucket {
+  return {
+    get: vi.fn(async (key: string) => {
+      if (key in data) {
+        return { json: async () => data[key] } as any;
+      }
+      return null;
+    }),
+  } as any;
+}
+
+describe("loadPreviousSummary", () => {
+  it("finds the most recent prior snapshot", async () => {
+    const raw = mockR2Bucket({
+      "summary/2026-06-25/usfs/middle-fork.json": {
+        by_date: { "2026-07-04": { available: 0, reserved: 10, total: 10 } },
+      },
+    });
+    const prev = await loadPreviousSummary(raw, "usfs/middle-fork", "2026-06-27");
+    expect(prev).toEqual({ "2026-07-04": { available: 0, reserved: 10, total: 10 } });
+    // Should have tried 2026-06-26 first, then 2026-06-25.
+    expect(raw.get).toHaveBeenCalledWith("summary/2026-06-26/usfs/middle-fork.json");
+    expect(raw.get).toHaveBeenCalledWith("summary/2026-06-25/usfs/middle-fork.json");
+  });
+
+  it("returns null when no prior snapshot exists", async () => {
+    const raw = mockR2Bucket({});
+    const prev = await loadPreviousSummary(raw, "usfs/middle-fork", "2026-06-27");
+    expect(prev).toBeNull();
+  });
+});
+
+// --- notifyAvailabilityChanges (integration) ---------------------------------
+
+describe("notifyAvailabilityChanges", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  const site: SiteInfo = {
+    id: "usfs/middle-fork",
+    name: "Middle Fork",
+    agency: "usfs",
+    kind: "rec",
+  };
+
+  it("skips when DISCORD_WEBHOOK_URL is not set", async () => {
+    const env = { RAW: mockR2Bucket({}), DISCORD_WEBHOOK_URL: undefined };
+    const result = await notifyAvailabilityChanges(env as any, site, "2026-06-27");
+    expect(result).toEqual({ notified: false, changes: 0 });
+  });
+
+  it("notifies on availability change", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+    const raw = mockR2Bucket({
+      // Previous day: fully booked
+      "summary/2026-06-26/usfs/middle-fork.json": {
+        by_date: { "2026-07-04": { available: 0, reserved: 20, total: 20 } },
+      },
+      // Current day: 3 opened up
+      "summary/2026-06-27/usfs/middle-fork.json": {
+        by_date: { "2026-07-04": { available: 3, reserved: 17, total: 20 } },
+      },
+    });
+    const env = { RAW: raw, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifyAvailabilityChanges(env as any, site, "2026-06-27");
+    expect(result).toEqual({ notified: true, changes: 1 });
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("skips when no changes detected", async () => {
+    // Install a spy so the not-called assertion has a real spy to inspect (and so a
+    // stray fetch can't escape to the network).
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+    const raw = mockR2Bucket({
+      "summary/2026-06-26/usfs/middle-fork.json": {
+        by_date: { "2026-07-04": { available: 3, reserved: 17, total: 20 } },
+      },
+      "summary/2026-06-27/usfs/middle-fork.json": {
+        by_date: { "2026-07-04": { available: 3, reserved: 17, total: 20 } },
+      },
+    });
+    const env = { RAW: raw, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifyAvailabilityChanges(env as any, site, "2026-06-27");
+    expect(result).toEqual({ notified: false, changes: 0 });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -1,0 +1,304 @@
+/**
+ * Discord webhook notifications for campsite availability changes.
+ *
+ * Detects state changes (unavailable → available) by comparing the current
+ * collection snapshot against the previous one in R2, then posts a rich embed
+ * to a Discord channel via webhook.
+ *
+ * Integration: called from the CollectorLoop after a successful collectSite().
+ * Requires the DISCORD_WEBHOOK_URL env var (a secret — add via `wrangler secret`).
+ *
+ * Design choices:
+ *   - Change detection compares summary/<prevDate>/<id>.json vs the just-written
+ *     summary/<date>/<id>.json. A date with 0 available yesterday and >0 today
+ *     (or absent yesterday) is a "newly available" event.
+ *   - Only fires on availability gains (not losses) to keep the channel useful.
+ *   - Embeds are green (#2ecc71) for availability, with campground/park info.
+ *   - Rate-limited: Discord webhooks allow 30 req/min; the collector does ≤1 site
+ *     per wake (MAX_BATCH=1) so we're well within limits.
+ */
+
+import type { ByDate } from "./availability";
+
+// --- Types -------------------------------------------------------------------
+
+export type AvailabilityChange = {
+  date: string;           // YYYY-MM-DD
+  previousAvailable: number;
+  currentAvailable: number;
+  total: number;
+};
+
+export type SiteInfo = {
+  id: string;
+  name: string;
+  agency: string;
+  kind: "rec" | "wa";
+  ref?: string | number | null; // provider id (numeric rec.gov campground id / WA resourceLocation id)
+  lat?: number | null;
+  lng?: number | null;
+  reservation_url?: string | null;
+};
+
+// Shape of the R2 `summary/<date>/<id>.json` object written by collectSite().
+type SummarySnapshot = { by_date?: ByDate };
+
+export type DiscordEmbed = {
+  title: string;
+  description: string;
+  color: number;
+  fields: { name: string; value: string; inline?: boolean }[];
+  footer?: { text: string };
+  timestamp?: string;
+  url?: string;
+};
+
+// --- Change detection --------------------------------------------------------
+
+/**
+ * Compare two by_date snapshots and return dates where availability appeared
+ * (was 0 or absent, now > 0). Only looks at dates from today onward.
+ */
+export function detectChanges(
+  prev: ByDate | null,
+  current: ByDate,
+  today?: string,
+): AvailabilityChange[] {
+  const cutoff = today ?? new Date().toISOString().slice(0, 10);
+  const changes: AvailabilityChange[] = [];
+
+  for (const [date, counts] of Object.entries(current)) {
+    if (date < cutoff) continue; // ignore past dates
+    if (counts.available <= 0) continue; // nothing opened up
+
+    const prevCounts = prev?.[date];
+    const prevAvail = prevCounts?.available ?? 0;
+
+    // Fire when availability appeared (was 0 or missing, now > 0).
+    if (prevAvail === 0 && counts.available > 0) {
+      changes.push({
+        date,
+        previousAvailable: prevAvail,
+        currentAvailable: counts.available,
+        total: counts.total,
+      });
+    }
+  }
+
+  return changes.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+}
+
+/**
+ * Load the previous summary snapshot from R2 for comparison. Walks the recent
+ * date-partitions (newest first, excluding `currentDate`) to find the most
+ * recent prior snapshot for this site.
+ */
+export async function loadPreviousSummary(
+  raw: R2Bucket,
+  siteId: string,
+  currentDate: string,
+  lookbackDays = 7,
+): Promise<ByDate | null> {
+  // Generate candidate dates (yesterday back to lookbackDays ago).
+  const candidates: string[] = [];
+  const base = new Date(`${currentDate}T00:00:00Z`);
+  for (let i = 1; i <= lookbackDays; i++) {
+    const d = new Date(base.getTime() - i * 86_400_000);
+    candidates.push(d.toISOString().slice(0, 10));
+  }
+
+  for (const d of candidates) {
+    const obj = await raw.get(`summary/${d}/${siteId}.json`);
+    if (obj) {
+      const snap = await obj.json<SummarySnapshot>();
+      return snap?.by_date ?? null;
+    }
+  }
+  return null;
+}
+
+// --- Discord embed formatting ------------------------------------------------
+
+const GREEN = 0x2ecc71;
+
+function formatDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  const day = dt.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" });
+  const month = dt.toLocaleDateString("en-US", { month: "short", timeZone: "UTC" });
+  return `${day}, ${month} ${d}`;
+}
+
+function reservationUrl(site: SiteInfo): string | null {
+  if (site.reservation_url) return site.reservation_url;
+  if (site.kind === "rec") {
+    // rec.gov campground URLs are keyed by the numeric provider id (the inventory
+    // `ref`, e.g. 233864) — NOT the agency slug id (e.g. "usfs/middle-fork"), which
+    // would 404. Fall back to the id only if no ref is available.
+    return `https://www.recreation.gov/camping/campgrounds/${site.ref ?? site.id}`;
+  }
+  if (site.kind === "wa") {
+    return `https://washington.goingtocamp.com/`;
+  }
+  return null;
+}
+
+function agencyLabel(site: SiteInfo): string {
+  const labels: Record<string, string> = {
+    usfs: "US Forest Service",
+    nps: "National Park Service",
+    wa: "Washington State Parks",
+    blm: "Bureau of Land Management",
+  };
+  return labels[site.agency] ?? site.agency;
+}
+
+/**
+ * Build a Discord embed for a batch of availability changes at one campground.
+ */
+export function buildEmbed(site: SiteInfo, changes: AvailabilityChange[]): DiscordEmbed {
+  // Group changes into a readable list.
+  const totalNewSites = changes.reduce((sum, c) => sum + c.currentAvailable, 0);
+  const dateRange =
+    changes.length === 1
+      ? formatDate(changes[0].date)
+      : `${formatDate(changes[0].date)} – ${formatDate(changes[changes.length - 1].date)}`;
+
+  // Build per-date lines (cap at 15 to stay within Discord's 1024 char field limit).
+  const dateLines = changes.slice(0, 15).map((c) => {
+    const pct = c.total > 0 ? Math.round((c.currentAvailable / c.total) * 100) : 0;
+    return `**${formatDate(c.date)}** — ${c.currentAvailable} of ${c.total} sites (${pct}% open)`;
+  });
+  if (changes.length > 15) {
+    dateLines.push(`_…and ${changes.length - 15} more dates_`);
+  }
+
+  const url = reservationUrl(site);
+
+  return {
+    title: `🏕️ ${site.name} — Sites Available!`,
+    description: `**${totalNewSites}** campsite-night${totalNewSites === 1 ? "" : "s"} just opened up across **${changes.length}** date${changes.length === 1 ? "" : "s"}.`,
+    color: GREEN,
+    url: url ?? undefined,
+    fields: [
+      {
+        name: "Park / Agency",
+        value: agencyLabel(site),
+        inline: true,
+      },
+      {
+        name: "Dates",
+        value: dateRange,
+        inline: true,
+      },
+      {
+        name: "Availability",
+        value: dateLines.join("\n"),
+        inline: false,
+      },
+      ...(url
+        ? [{ name: "Book Now", value: `[Reserve →](${url})`, inline: false }]
+        : []),
+    ],
+    footer: { text: "Robot Geographical Society • Campsite Availability Monitor" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+// --- Discord webhook dispatch ------------------------------------------------
+
+export interface DiscordWebhookPayload {
+  content?: string;
+  embeds: DiscordEmbed[];
+  username?: string;
+  avatar_url?: string;
+}
+
+/**
+ * Send a Discord webhook message. Returns true on success, false on failure
+ * (non-throwing — a notification failure should never break collection).
+ */
+export async function sendWebhook(
+  webhookUrl: string,
+  payload: DiscordWebhookPayload,
+): Promise<boolean> {
+  try {
+    const res = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    // Discord returns 204 No Content on success, or 200 with wait_until for rate limits.
+    if (res.ok || res.status === 204) return true;
+    // Rate limited — log but don't retry (the next collection will catch it).
+    if (res.status === 429) {
+      console.warn(`Discord rate limited (429), skipping notification`);
+      return false;
+    }
+    console.error(`Discord webhook failed: ${res.status} ${res.statusText}`);
+    return false;
+  } catch (err) {
+    console.error(`Discord webhook error: ${err}`);
+    return false;
+  }
+}
+
+// --- Main entry point (called from the collector) ----------------------------
+
+export type NotifyEnv = {
+  RAW: R2Bucket;
+  DISCORD_WEBHOOK_URL?: string;
+};
+
+/**
+ * After a successful collection, detect availability changes and notify Discord.
+ *
+ * Call this from the CollectorLoop after collectSite() succeeds. It:
+ *   1. Loads the previous summary snapshot from R2
+ *   2. Loads the just-written current snapshot
+ *   3. Detects dates where availability appeared (0 → >0)
+ *   4. Posts a Discord embed if any changes found
+ *
+ * Non-throwing: notification failures are logged but never propagate to the caller.
+ *
+ * @param env       Worker env (needs RAW R2 bucket + DISCORD_WEBHOOK_URL secret)
+ * @param site      The collected site's metadata
+ * @param date      Today's collection date (YYYY-MM-DD)
+ * @returns         { notified: boolean, changes: number }
+ */
+export async function notifyAvailabilityChanges(
+  env: NotifyEnv,
+  site: SiteInfo,
+  date: string,
+): Promise<{ notified: boolean; changes: number }> {
+  const webhookUrl = env.DISCORD_WEBHOOK_URL;
+  if (!webhookUrl) return { notified: false, changes: 0 };
+
+  try {
+    // 1. Load the previous snapshot for comparison.
+    const prev = await loadPreviousSummary(env.RAW, site.id, date);
+
+    // 2. Load the current (just-written) snapshot.
+    const currentObj = await env.RAW.get(`summary/${date}/${site.id}.json`);
+    if (!currentObj) return { notified: false, changes: 0 };
+    const current = await currentObj.json<SummarySnapshot>();
+    const currentBy: ByDate = current?.by_date ?? {};
+
+    // 3. Detect changes.
+    const changes = detectChanges(prev, currentBy, date);
+    if (changes.length === 0) return { notified: false, changes: 0 };
+
+    // 4. Build and send the Discord notification.
+    const embed = buildEmbed(site, changes);
+    const payload: DiscordWebhookPayload = {
+      username: "Campsite Bot",
+      avatar_url: "https://em-content.zobj.net/source/apple/391/national-park_1f3de-fe0f.png",
+      embeds: [embed],
+    };
+    const sent = await sendWebhook(webhookUrl, payload);
+    return { notified: sent, changes: changes.length };
+  } catch (err) {
+    console.error(`notifyAvailabilityChanges failed for ${site.id}: ${err}`);
+    return { notified: false, changes: 0 };
+  }
+}

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -14,6 +14,7 @@ import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:work
 import { loadInventory } from "./inventory";
 import { fetchAvailability, type Counts } from "./availability";
 import { type DueMap, type FailMap, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs, retryBackoffMs } from "./scheduler";
+import { notifyAvailabilityChanges, type SiteInfo } from "./discord";
 
 export interface WfEnv {
   RAW: R2Bucket;
@@ -29,11 +30,35 @@ export interface WfEnv {
   DEMAND_AE?: AnalyticsEngineDataset; // per-campground per-night demand → Grafana
   READINESS_AE?: AnalyticsEngineDataset; // daily prediction-readiness gauge → Grafana
   READINESS_WF: Workflow; // daily readiness Workflow (self-reference for continue-as-new)
+  DISCORD_WEBHOOK_URL?: string; // wrangler secret; when set, the loop posts "newly available" alerts
 }
 
 // `collect: false` marks map-only / disabled sites (no rec/WA provider, or a
 // deliberately-paused collector) — they appear on the map but the loop skips them.
-type Site = { id: string; kind: "rec" | "wa"; ref: string | number; name: string; agency: string; collect?: boolean };
+type Site = {
+  id: string;
+  kind: "rec" | "wa";
+  ref: string | number;
+  name: string;
+  agency: string;
+  collect?: boolean;
+  // Carried from the inventory for the Discord alert's "Book Now" link (best-effort).
+  reservation_url?: string | null;
+  lat?: number | null;
+  lng?: number | null;
+};
+
+// Project a collector Site onto the metadata the Discord notifier needs.
+const toSiteInfo = (s: Site): SiteInfo => ({
+  id: s.id,
+  name: s.name,
+  agency: s.agency,
+  kind: s.kind,
+  ref: s.ref,
+  lat: s.lat ?? null,
+  lng: s.lng ?? null,
+  reservation_url: s.reservation_url ?? null,
+});
 
 export const HEARTBEAT_KEY = "scheduler/heartbeat.json";
 export const DLQ_PREFIX = "dlq/"; // dlq/<siteId>.json — presence == site is quarantined
@@ -244,6 +269,15 @@ export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
           due[id] = plan.now + X + jitterMs(id);
           fails[id] = 0;
           collectedTotal++;
+          // Discord alert on newly-opened availability. Its own step so the webhook
+          // POST fires exactly once (memoized on replay, not re-sent on a collect
+          // retry). Guarded on the secret so no empty step is created when unset, and
+          // non-throwing internally so a webhook failure never fails the collection.
+          if (this.env.DISCORD_WEBHOOK_URL) {
+            await step.do(`notify-${i}-${id}`, () =>
+              notifyAvailabilityChanges(this.env, toSiteInfo(site), date),
+            );
+          }
         } catch (err) {
           const n = (fails[id] ?? 0) + 1;
           fails[id] = n;

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -90,6 +90,11 @@ INACTIVE_AFTER_FAILURES = "5"
 # it's an allowlisted identity, not a credential.
 BOOTSTRAP_ADMIN = "tommy.b.doerr@gmail.com"
 
+# Discord availability alerts (src/discord.ts). The webhook URL is a SECRET — set it
+# with `npx wrangler secret put DISCORD_WEBHOOK_URL`, never a [vars] entry. When unset
+# the collector simply skips notification (no-op). On each successful collect the loop
+# posts a green embed for nights that newly opened up (0 → available; gains only).
+
 # No cron. The CollectorLoop self-perpetuates via continue-as-new; a hard crash
 # is surfaced by Grafana → Discord staleness alerting (observability repo), and a
 # human restarts it with POST /collect/start?force=1.


### PR DESCRIPTION
`BACKEND` — **COLLECTOR DISPATCH**

# A campfire that pings you the moment a site opens up

> _The collector already knows the instant a sold-out night flips back to available. Now it tells you — a green Discord embed, fired straight from the durable loop, gains only._

> [!NOTE]
> **backend** · feat · risk: low · no schema change

The `CollectorLoop` banks a fresh `summary/<date>/<id>.json` every time it scrapes a campground — it has always sat on the one fact a camper actually wants: *a night that was full is bookable again.* This PR harvests the in-flight `discord.ts` change-detector, wires it into the loop, and hardens it so a webhook hiccup can never stall collection. Set one secret and the channel lights up only when sites genuinely **open**, never when they fill.

## The wiring
- After every successful `collectSite()`, diff the new R2 snapshot against the most recent prior one (lookback ≤ 7 days) and post one embed per campground with newly-open nights.
- Runs in its **own replay-safe `step.do`** — the webhook fires exactly once and a `collect` retry can't double-post.
- **Guarded on `DISCORD_WEBHOOK_URL`**: unset → no step, pure no-op. Internally non-throwing, so a 429 or network drop is logged and swallowed, never failing the collection step.

## Gains only — the core rule
- `detectChanges` fires solely on a `0 → >0` transition for **today or later**.
- A night filling up (`>0 → 0`) or merely thinning (`5 → 2`) is **silent** — no noise, just openings.

> _"A site that fills up is not news. A site that opens is."_

## Sharper than the harvest
- **Fixed the rec.gov "Book Now" link**: it used the agency slug (`usfs/middle-fork`) which 404s — now the numeric provider `ref` (e.g. `233864`), falling back to an explicit inventory `reservation_url` when present.
- Dropped the `any` casts for a typed `SummarySnapshot`.

## How it flows
```mermaid
flowchart TD
  A[CollectorLoop wake] --> B[collectSite -> PUT summary/date/id.json]
  B --> C{DISCORD_WEBHOOK_URL set?}
  C -- no --> Z[done - no-op]
  C -- yes --> D[step.do notify - replay-safe, once]
  D --> E[loadPreviousSummary: R2 lookback <= 7d]
  E --> F[detectChanges: 0 -> available, today+]
  F -- none --> Z
  F -- gains --> G[buildEmbed: green, Book Now link]
  G --> H[sendWebhook]
  H -- 2xx --> Z
  H -- 429 / error --> I[log + swallow, never fail collect]
  I --> Z
```

## Verification
- [x] `npx vitest run` — **98 passed** (24 in `discord.test.ts`).
- [x] `npx tsc --noEmit` — clean.
- [x] New cases: no-change, `0 → available`, loss `→ no alert`, thin `→ no alert`, rec.gov `ref` link, explicit `reservation_url`.
- [x] Fixed a latent bug in the harvested suite (a `not.toHaveBeenCalled()` with no `fetch` spy).

## Risk & rollout
- **Inert until configured.** No behavior change until a human runs:
  `npx wrangler secret put DISCORD_WEBHOOK_URL`. No `[vars]`, no committed value.
- No R2/KV schema change; only an additive `WfEnv` field and a per-collect notify step.
- Supersedes the generic Cowork module `discord-ops/discord-campsite-notify.ts` (no real R2 change-detection or collector hook) — safe to delete that separately.
- Files: [`backend/src/discord.ts`](https://github.com/tommyroar/robot-geographical-society/blob/1feb9921e68354f14c04ffdf2fc3b2547ab3c07c/backend/src/discord.ts) · [`workflows.ts`](https://github.com/tommyroar/robot-geographical-society/blob/1feb9921e68354f14c04ffdf2fc3b2547ab3c07c/backend/src/workflows.ts).
