### PR TITLE
feat: campsite alerts go personal — subscriptions + automatic hottest feed

### DIFF
--- a/backend/scripts/register-discord-commands.sh
+++ b/backend/scripts/register-discord-commands.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Register Discord slash commands for the campsite subscription bot.
+#
+# Usage:
+#   DISCORD_APP_ID=... DISCORD_BOT_TOKEN=... ./scripts/register-discord-commands.sh
+#
+# Run once after creating the Discord application, or whenever the command
+# schema changes. Uses the global commands endpoint (takes up to 1 hour to
+# propagate; for instant testing, use the guild endpoint variant below).
+
+set -euo pipefail
+
+: "${DISCORD_APP_ID:?Set DISCORD_APP_ID}"
+: "${DISCORD_BOT_TOKEN:?Set DISCORD_BOT_TOKEN}"
+
+# Guild-scoped (instant, for testing): uncomment and set GUILD_ID
+# GUILD_ID="..."
+# URL="https://discord.com/api/v10/applications/$DISCORD_APP_ID/guilds/$GUILD_ID/commands"
+URL="https://discord.com/api/v10/applications/$DISCORD_APP_ID/commands"
+
+COMMANDS='[
+  {
+    "name": "subscribe",
+    "description": "Subscribe to campsite availability alerts",
+    "options": [
+      {
+        "name": "campground",
+        "description": "Campground to watch",
+        "type": 3,
+        "required": true,
+        "autocomplete": true
+      },
+      {
+        "name": "site",
+        "description": "Specific site label (e.g. 24). Omit for any site.",
+        "type": 3,
+        "required": false
+      },
+      {
+        "name": "when",
+        "description": "When: weekends, weekdays, fri-sun, or YYYY-MM-DD",
+        "type": 3,
+        "required": false
+      },
+      {
+        "name": "note",
+        "description": "A note for this subscription (shown in alerts)",
+        "type": 3,
+        "required": false
+      }
+    ]
+  },
+  {
+    "name": "subscriptions",
+    "description": "List your active campsite subscriptions"
+  },
+  {
+    "name": "unsubscribe",
+    "description": "Remove a campsite subscription",
+    "options": [
+      {
+        "name": "id",
+        "description": "Subscription ID (from /subscriptions)",
+        "type": 3,
+        "required": true
+      }
+    ]
+  }
+]'
+
+echo "Registering commands with Discord..."
+curl -sS -X PUT "$URL" \
+  -H "Authorization: Bot $DISCORD_BOT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$COMMANDS" | python3 -m json.tool
+
+echo "Done. Global commands may take up to 1 hour to propagate."

--- a/backend/src/discord-interactions.test.ts
+++ b/backend/src/discord-interactions.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleInteraction, COMMANDS, type InteractionsEnv } from "./discord-interactions";
+
+// We can't easily mock Ed25519 verification in Vitest without a real key pair,
+// so we test the command handlers by bypassing signature verification. The
+// handleInteraction function is tested at the integration level via the Hono
+// app tests; here we focus on the exported COMMANDS schema and autocomplete.
+
+describe("COMMANDS schema", () => {
+  it("defines subscribe, subscriptions, unsubscribe", () => {
+    const names = COMMANDS.map((c) => c.name);
+    expect(names).toEqual(["subscribe", "subscriptions", "unsubscribe"]);
+  });
+
+  it("subscribe has campground (required, autocomplete), site, when, note options", () => {
+    const cmd = COMMANDS.find((c) => c.name === "subscribe")!;
+    expect(cmd.options).toHaveLength(4);
+    const campground = cmd.options!.find((o: any) => o.name === "campground")!;
+    expect(campground.required).toBe(true);
+    expect(campground.autocomplete).toBe(true);
+  });
+
+  it("unsubscribe has id (required) option", () => {
+    const cmd = COMMANDS.find((c) => c.name === "unsubscribe")!;
+    expect(cmd.options).toHaveLength(1);
+    expect(cmd.options![0].name).toBe("id");
+    expect(cmd.options![0].required).toBe(true);
+  });
+});
+
+// Test handleInteraction with signature verification disabled by passing
+// an empty public key (should return 500, which is the correct behavior).
+describe("handleInteraction", () => {
+  function mockKV(data: Record<string, any> = {}): KVNamespace {
+    return {
+      list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+        keys: Object.keys(data)
+          .filter((k) => k.startsWith(prefix))
+          .map((k) => ({ name: k })),
+      })),
+      get: vi.fn(async (key: string, opts?: any) => {
+        if (!(key in data)) return null;
+        if (opts?.type === "json") return data[key];
+        return JSON.stringify(data[key]);
+      }),
+      put: vi.fn(async () => {}),
+      delete: vi.fn(async () => {}),
+    } as any;
+  }
+
+  it("returns 500 when DISCORD_APP_PUBLIC_KEY is not set", async () => {
+    const env: InteractionsEnv = { CAMPSITES: mockKV() };
+    const req = new Request("https://example.com/discord/interactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 1 }),
+    });
+    const res = await handleInteraction(req, env);
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 401 when signature headers are missing", async () => {
+    const env: InteractionsEnv = {
+      CAMPSITES: mockKV(),
+      DISCORD_APP_PUBLIC_KEY: "abcd1234",
+    };
+    const req = new Request("https://example.com/discord/interactions", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ type: 1 }),
+    });
+    const res = await handleInteraction(req, env);
+    expect(res.status).toBe(401);
+  });
+});

--- a/backend/src/discord-interactions.ts
+++ b/backend/src/discord-interactions.ts
@@ -1,0 +1,351 @@
+/**
+ * Discord slash command interactions endpoint.
+ *
+ * Handles /subscribe, /subscriptions, /unsubscribe via Discord's HTTP
+ * interactions API (no gateway/WebSocket needed — Cloudflare Worker receives
+ * POSTs directly from Discord).
+ *
+ * Requires DISCORD_APP_PUBLIC_KEY env var for signature verification.
+ */
+
+import campsites from "./campsites-index.json";
+import {
+  listSubscriptions,
+  getSubscription,
+  putSubscription,
+  deleteSubscription,
+  type Subscription,
+} from "./subscriptions";
+
+// --- Discord interaction types -----------------------------------------------
+
+const InteractionType = {
+  PING: 1,
+  APPLICATION_COMMAND: 2,
+  AUTOCOMPLETE: 4,
+} as const;
+
+const InteractionResponseType = {
+  PONG: 1,
+  CHANNEL_MESSAGE: 4,
+  AUTOCOMPLETE_RESULT: 8,
+} as const;
+
+type InteractionOption = {
+  name: string;
+  type: number;
+  value?: string | number;
+  focused?: boolean;
+};
+
+type Interaction = {
+  type: number;
+  data?: {
+    name: string;
+    options?: InteractionOption[];
+  };
+};
+
+function jsonResponse(body: any, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+// --- Ed25519 signature verification ------------------------------------------
+
+async function verifySignature(
+  publicKeyHex: string,
+  signature: string,
+  timestamp: string,
+  body: string,
+): Promise<boolean> {
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      hexToBytes(publicKeyHex),
+      { name: "Ed25519", namedCurve: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    const message = new TextEncoder().encode(timestamp + body);
+    return crypto.subtle.verify("Ed25519", key, hexToBytes(signature), message);
+  } catch {
+    return false;
+  }
+}
+
+function hexToBytes(hex: string): Uint8Array {
+  const bytes = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < hex.length; i += 2) {
+    bytes[i / 2] = parseInt(hex.substring(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+// --- Autocomplete: campground search -----------------------------------------
+
+const collectible = (campsites as any[]).filter((c) => c.collect !== false);
+
+function autocompleteCampground(query: string): { name: string; value: string }[] {
+  const q = query.toLowerCase();
+  return collectible
+    .filter((c) => c.name.toLowerCase().includes(q) || c.id.toLowerCase().includes(q))
+    .slice(0, 25)
+    .map((c) => ({ name: `${c.name} (${c.agency.toUpperCase()})`, value: c.id }));
+}
+
+// --- Command handlers --------------------------------------------------------
+
+function getOption(opts: InteractionOption[] | undefined, name: string): string | undefined {
+  return opts?.find((o) => o.name === name)?.value as string | undefined;
+}
+
+function parseWhen(when: string | undefined): { dates?: string[]; weekdays?: number[] } {
+  if (!when) return {};
+  const w = when.toLowerCase().trim();
+  if (w === "weekends") return { weekdays: [0, 6] };
+  if (w === "weekdays") return { weekdays: [1, 2, 3, 4, 5] };
+  if (w === "fri-sun" || w === "friday-sunday") return { weekdays: [5, 6, 0] };
+  if (w === "thu-sun" || w === "thursday-sunday") return { weekdays: [4, 5, 6, 0] };
+  // Try parsing as a date (YYYY-MM-DD)
+  if (/^\d{4}-\d{2}-\d{2}$/.test(w)) return { dates: [w] };
+  // Comma-separated dates
+  const parts = w.split(/[,\s]+/).filter((p) => /^\d{4}-\d{2}-\d{2}$/.test(p));
+  if (parts.length) return { dates: parts };
+  return {};
+}
+
+const WEEKDAY_NAMES = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
+function formatSubscription(sub: Subscription): string {
+  const camp = collectible.find((c) => c.id === sub.campgroundId);
+  const name = camp?.name ?? sub.campgroundId;
+  let desc = `**${name}**`;
+  if (sub.siteLabel) desc += ` · Site ${sub.siteLabel}`;
+  if (sub.weekdays?.length) {
+    desc += ` · ${sub.weekdays.map((d) => WEEKDAY_NAMES[d]).join("/")}`;
+  }
+  if (sub.dates?.length) {
+    desc += ` · ${sub.dates.join(", ")}`;
+  }
+  if (sub.note) desc += ` · _${sub.note}_`;
+  return desc;
+}
+
+async function handleSubscribe(
+  kv: KVNamespace,
+  opts: InteractionOption[] | undefined,
+): Promise<Response> {
+  const campgroundId = getOption(opts, "campground");
+  if (!campgroundId) {
+    return jsonResponse({
+      type: InteractionResponseType.CHANNEL_MESSAGE,
+      data: { content: "Missing campground.", flags: 64 },
+    });
+  }
+
+  const known = collectible.find((c) => c.id === campgroundId);
+  if (!known) {
+    return jsonResponse({
+      type: InteractionResponseType.CHANNEL_MESSAGE,
+      data: { content: `Unknown campground: \`${campgroundId}\``, flags: 64 },
+    });
+  }
+
+  const siteLabel = getOption(opts, "site") ?? null;
+  const when = parseWhen(getOption(opts, "when"));
+  const note = getOption(opts, "note") ?? undefined;
+
+  const sub: Subscription = {
+    id: crypto.randomUUID(),
+    campgroundId,
+    siteLabel,
+    dates: when.dates,
+    weekdays: when.weekdays,
+    note,
+    createdAt: new Date().toISOString(),
+  };
+  await putSubscription(kv, sub);
+
+  return jsonResponse({
+    type: InteractionResponseType.CHANNEL_MESSAGE,
+    data: {
+      content: `Subscribed! I'll notify you when availability opens up.\n${formatSubscription(sub)}\n\n_ID: \`${sub.id}\`_`,
+      flags: 64,
+    },
+  });
+}
+
+async function handleSubscriptions(kv: KVNamespace): Promise<Response> {
+  const subs = await listSubscriptions(kv);
+  if (!subs.length) {
+    return jsonResponse({
+      type: InteractionResponseType.CHANNEL_MESSAGE,
+      data: { content: "No active subscriptions. Use `/subscribe` to add one.", flags: 64 },
+    });
+  }
+
+  const lines = subs.map((s, i) => `${i + 1}. ${formatSubscription(s)}\n   _ID: \`${s.id}\`_`);
+  return jsonResponse({
+    type: InteractionResponseType.CHANNEL_MESSAGE,
+    data: {
+      content: `**Active Subscriptions (${subs.length})**\n\n${lines.join("\n\n")}`,
+      flags: 64,
+    },
+  });
+}
+
+async function handleUnsubscribe(
+  kv: KVNamespace,
+  opts: InteractionOption[] | undefined,
+): Promise<Response> {
+  const id = getOption(opts, "id");
+  if (!id) {
+    return jsonResponse({
+      type: InteractionResponseType.CHANNEL_MESSAGE,
+      data: { content: "Missing subscription ID.", flags: 64 },
+    });
+  }
+
+  const existed = await deleteSubscription(kv, id);
+  return jsonResponse({
+    type: InteractionResponseType.CHANNEL_MESSAGE,
+    data: {
+      content: existed
+        ? `Unsubscribed \`${id}\`.`
+        : `Subscription \`${id}\` not found.`,
+      flags: 64,
+    },
+  });
+}
+
+// --- Main handler ------------------------------------------------------------
+
+export type InteractionsEnv = {
+  CAMPSITES: KVNamespace;
+  DISCORD_APP_PUBLIC_KEY?: string;
+};
+
+export async function handleInteraction(
+  request: Request,
+  env: InteractionsEnv,
+): Promise<Response> {
+  const publicKey = env.DISCORD_APP_PUBLIC_KEY;
+  if (!publicKey) {
+    return jsonResponse({ error: "DISCORD_APP_PUBLIC_KEY not configured" }, 500);
+  }
+
+  // Verify the request signature.
+  const signature = request.headers.get("X-Signature-Ed25519");
+  const timestamp = request.headers.get("X-Signature-Timestamp");
+  const body = await request.text();
+
+  if (!signature || !timestamp) {
+    return jsonResponse({ error: "Missing signature headers" }, 401);
+  }
+
+  const valid = await verifySignature(publicKey, signature, timestamp, body);
+  if (!valid) {
+    return jsonResponse({ error: "Invalid signature" }, 401);
+  }
+
+  const interaction: Interaction = JSON.parse(body);
+
+  // Discord sends a PING on initial endpoint validation.
+  if (interaction.type === InteractionType.PING) {
+    return jsonResponse({ type: InteractionResponseType.PONG });
+  }
+
+  // Autocomplete for the campground option.
+  if (interaction.type === InteractionType.AUTOCOMPLETE) {
+    const focused = interaction.data?.options?.find((o) => o.focused);
+    if (focused?.name === "campground") {
+      const choices = autocompleteCampground(String(focused.value ?? ""));
+      return jsonResponse({
+        type: InteractionResponseType.AUTOCOMPLETE_RESULT,
+        data: { choices },
+      });
+    }
+    return jsonResponse({
+      type: InteractionResponseType.AUTOCOMPLETE_RESULT,
+      data: { choices: [] },
+    });
+  }
+
+  // Slash commands.
+  if (interaction.type === InteractionType.APPLICATION_COMMAND) {
+    const name = interaction.data?.name;
+    const opts = interaction.data?.options;
+
+    switch (name) {
+      case "subscribe":
+        return handleSubscribe(env.CAMPSITES, opts);
+      case "subscriptions":
+        return handleSubscriptions(env.CAMPSITES);
+      case "unsubscribe":
+        return handleUnsubscribe(env.CAMPSITES, opts);
+      default:
+        return jsonResponse({
+          type: InteractionResponseType.CHANNEL_MESSAGE,
+          data: { content: `Unknown command: ${name}`, flags: 64 },
+        });
+    }
+  }
+
+  return jsonResponse({ error: "Unknown interaction type" }, 400);
+}
+
+// --- Command registration definition -----------------------------------------
+// Used by the register-commands script; also documents the exact command schema.
+
+export const COMMANDS = [
+  {
+    name: "subscribe",
+    description: "Subscribe to campsite availability alerts",
+    options: [
+      {
+        name: "campground",
+        description: "Campground to watch",
+        type: 3, // STRING
+        required: true,
+        autocomplete: true,
+      },
+      {
+        name: "site",
+        description: "Specific site label (e.g. 24). Omit for any site.",
+        type: 3,
+        required: false,
+      },
+      {
+        name: "when",
+        description: "When: weekends, weekdays, fri-sun, or YYYY-MM-DD",
+        type: 3,
+        required: false,
+      },
+      {
+        name: "note",
+        description: "A note for this subscription (shown in alerts)",
+        type: 3,
+        required: false,
+      },
+    ],
+  },
+  {
+    name: "subscriptions",
+    description: "List your active campsite subscriptions",
+  },
+  {
+    name: "unsubscribe",
+    description: "Remove a campsite subscription",
+    options: [
+      {
+        name: "id",
+        description: "Subscription ID (from /subscriptions)",
+        type: 3,
+        required: true,
+      },
+    ],
+  },
+];

--- a/backend/src/discord.test.ts
+++ b/backend/src/discord.test.ts
@@ -1,180 +1,125 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
-  detectChanges,
-  buildEmbed,
+  buildSubscriptionEmbed,
   sendWebhook,
-  notifyAvailabilityChanges,
-  loadPreviousSummary,
-  type AvailabilityChange,
+  notifySubscriptionMatches,
+  loadPreviousSites,
+  formatDate,
+  reservationUrl,
   type SiteInfo,
 } from "./discord";
-import type { ByDate } from "./availability";
+import type { Subscription, SiteMatch } from "./subscriptions";
 
-// --- detectChanges -----------------------------------------------------------
+// --- buildSubscriptionEmbed --------------------------------------------------
 
-describe("detectChanges", () => {
-  const today = "2026-06-27";
-
-  it("returns empty when current has no availability", () => {
-    const prev: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
-    const curr: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
-    expect(detectChanges(prev, curr, today)).toEqual([]);
-  });
-
-  it("detects 0 → >0 transition", () => {
-    const prev: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
-    const curr: ByDate = { "2026-06-28": { available: 3, reserved: 7, total: 10 } };
-    const changes = detectChanges(prev, curr, today);
-    expect(changes).toHaveLength(1);
-    expect(changes[0]).toMatchObject({
-      date: "2026-06-28",
-      previousAvailable: 0,
-      currentAvailable: 3,
-      total: 10,
-    });
-  });
-
-  it("detects newly appeared date (absent in prev)", () => {
-    const prev: ByDate = {};
-    const curr: ByDate = { "2026-07-04": { available: 5, reserved: 15, total: 20 } };
-    const changes = detectChanges(prev, curr, today);
-    expect(changes).toHaveLength(1);
-    expect(changes[0].previousAvailable).toBe(0);
-    expect(changes[0].currentAvailable).toBe(5);
-  });
-
-  it("handles null prev (first collection)", () => {
-    const curr: ByDate = { "2026-07-04": { available: 2, reserved: 8, total: 10 } };
-    const changes = detectChanges(null, curr, today);
-    expect(changes).toHaveLength(1);
-  });
-
-  it("ignores dates before today", () => {
-    const curr: ByDate = { "2026-06-20": { available: 5, reserved: 5, total: 10 } };
-    expect(detectChanges(null, curr, today)).toEqual([]);
-  });
-
-  it("ignores dates that were already available", () => {
-    const prev: ByDate = { "2026-06-28": { available: 3, reserved: 7, total: 10 } };
-    const curr: ByDate = { "2026-06-28": { available: 5, reserved: 5, total: 10 } };
-    // Was already >0, so this is NOT a new appearance.
-    expect(detectChanges(prev, curr, today)).toEqual([]);
-  });
-
-  it("does NOT alert on availability loss (>0 → 0)", () => {
-    // Sites filling up is the opposite of what we notify on — silence, not noise.
-    const prev: ByDate = { "2026-06-28": { available: 4, reserved: 6, total: 10 } };
-    const curr: ByDate = { "2026-06-28": { available: 0, reserved: 10, total: 10 } };
-    expect(detectChanges(prev, curr, today)).toEqual([]);
-  });
-
-  it("does NOT alert on a decrease that stays available (5 → 2)", () => {
-    // Still bookable, but it never went 0 → >0, so it's not a fresh opening.
-    const prev: ByDate = { "2026-06-28": { available: 5, reserved: 5, total: 10 } };
-    const curr: ByDate = { "2026-06-28": { available: 2, reserved: 8, total: 10 } };
-    expect(detectChanges(prev, curr, today)).toEqual([]);
-  });
-
-  it("returns multiple changes sorted by date", () => {
-    const prev: ByDate = {
-      "2026-07-10": { available: 0, reserved: 10, total: 10 },
-      "2026-07-05": { available: 0, reserved: 10, total: 10 },
-    };
-    const curr: ByDate = {
-      "2026-07-10": { available: 2, reserved: 8, total: 10 },
-      "2026-07-05": { available: 1, reserved: 9, total: 10 },
-    };
-    const changes = detectChanges(prev, curr, today);
-    expect(changes).toHaveLength(2);
-    expect(changes[0].date).toBe("2026-07-05");
-    expect(changes[1].date).toBe("2026-07-10");
-  });
-});
-
-// --- buildEmbed --------------------------------------------------------------
-
-describe("buildEmbed", () => {
+describe("buildSubscriptionEmbed", () => {
   const site: SiteInfo = {
     id: "usfs/middle-fork",
     name: "Middle Fork",
     agency: "usfs",
     kind: "rec",
-    lat: 47.55,
-    lng: -121.53,
+    ref: 233864,
   };
 
-  it("builds a green embed with campsite info", () => {
-    const changes: AvailabilityChange[] = [
-      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 3, total: 20 },
+  it("builds a green embed with subscription context", () => {
+    const sub: Subscription = {
+      id: "1",
+      campgroundId: "usfs/middle-fork",
+      siteLabel: "24",
+      note: "weekend trip",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const matches: SiteMatch[] = [
+      { siteId: "81835", label: "24", date: "2026-07-04", status: "available" },
     ];
-    const embed = buildEmbed(site, changes);
+    const embed = buildSubscriptionEmbed(site, sub, matches);
     expect(embed.color).toBe(0x2ecc71);
     expect(embed.title).toContain("Middle Fork");
-    expect(embed.title).toContain("Available");
-    expect(embed.fields.find((f) => f.name === "Park / Agency")?.value).toBe("US Forest Service");
+    expect(embed.title).toContain("Site 24");
+    expect(embed.description).toContain("subscription");
+    expect(embed.description).toContain("weekend trip");
   });
 
-  it("includes a book-now link for rec.gov sites", () => {
-    const changes: AvailabilityChange[] = [
-      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
+  it("includes site labels in the Sites field", () => {
+    const sub: Subscription = {
+      id: "2",
+      campgroundId: "usfs/middle-fork",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const matches: SiteMatch[] = [
+      { siteId: "81835", label: "24", date: "2026-07-04", status: "available" },
+      { siteId: "81836", label: "25", date: "2026-07-04", status: "available" },
     ];
-    const embed = buildEmbed(site, changes);
+    const embed = buildSubscriptionEmbed(site, sub, matches);
+    const sitesField = embed.fields.find((f) => f.name === "Sites");
+    expect(sitesField).toBeDefined();
+    expect(sitesField!.value).toContain("24");
+    expect(sitesField!.value).toContain("25");
+  });
+
+  it("includes a book-now link using the provider ref", () => {
+    const sub: Subscription = {
+      id: "3",
+      campgroundId: "usfs/middle-fork",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const matches: SiteMatch[] = [
+      { siteId: "81835", label: "24", date: "2026-07-04", status: "available" },
+    ];
+    const embed = buildSubscriptionEmbed(site, sub, matches);
     const bookField = embed.fields.find((f) => f.name === "Book Now");
     expect(bookField).toBeDefined();
-    expect(bookField!.value).toContain("recreation.gov");
-  });
-
-  it("uses the numeric provider ref (not the slug) in the rec.gov link", () => {
-    // rec.gov campground URLs are keyed by the numeric id; the slug would 404.
-    const refSite: SiteInfo = { ...site, ref: 233864 };
-    const changes: AvailabilityChange[] = [
-      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
-    ];
-    const embed = buildEmbed(refSite, changes);
-    const bookField = embed.fields.find((f) => f.name === "Book Now");
     expect(bookField!.value).toContain("/campgrounds/233864");
-    expect(bookField!.value).not.toContain("usfs/middle-fork");
   });
 
-  it("prefers an explicit reservation_url when provided", () => {
-    const urlSite: SiteInfo = { ...site, reservation_url: "https://example.org/book/here" };
-    const changes: AvailabilityChange[] = [
-      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
-    ];
-    const embed = buildEmbed(urlSite, changes);
-    const bookField = embed.fields.find((f) => f.name === "Book Now");
-    expect(bookField!.value).toContain("https://example.org/book/here");
-  });
-
-  it("handles WA state parks", () => {
-    const waSite: SiteInfo = { id: "wa/deception-pass", name: "Deception Pass", agency: "wa", kind: "wa" };
-    const changes: AvailabilityChange[] = [
-      { date: "2026-08-01", previousAvailable: 0, currentAvailable: 5, total: 30 },
-    ];
-    const embed = buildEmbed(waSite, changes);
-    expect(embed.fields.find((f) => f.name === "Park / Agency")?.value).toBe("Washington State Parks");
-  });
-
-  it("caps date lines at 15 with overflow indicator", () => {
-    const changes: AvailabilityChange[] = Array.from({ length: 20 }, (_, i) => ({
+  it("caps match lines at 15", () => {
+    const sub: Subscription = {
+      id: "4",
+      campgroundId: "usfs/middle-fork",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const matches: SiteMatch[] = Array.from({ length: 20 }, (_, i) => ({
+      siteId: `site-${i}`,
+      label: String(i),
       date: `2026-07-${String(i + 1).padStart(2, "0")}`,
-      previousAvailable: 0,
-      currentAvailable: 1,
-      total: 10,
+      status: "available" as const,
     }));
-    const embed = buildEmbed(site, changes);
+    const embed = buildSubscriptionEmbed(site, sub, matches);
     const availField = embed.fields.find((f) => f.name === "Availability");
-    expect(availField!.value).toContain("…and 5 more dates");
+    expect(availField!.value).toContain("…and 5 more");
   });
 
-  it("pluralizes correctly for single change", () => {
-    const changes: AvailabilityChange[] = [
-      { date: "2026-07-04", previousAvailable: 0, currentAvailable: 1, total: 10 },
+  it("pluralizes correctly for single match", () => {
+    const sub: Subscription = {
+      id: "5",
+      campgroundId: "usfs/middle-fork",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const matches: SiteMatch[] = [
+      { siteId: "81835", label: "24", date: "2026-07-04", status: "available" },
     ];
-    const embed = buildEmbed(site, changes);
-    // The number is bold-wrapped (**1**), so check for the singular noun form.
+    const embed = buildSubscriptionEmbed(site, sub, matches);
     expect(embed.description).toContain("campsite-night ");
     expect(embed.description).not.toContain("campsite-nights");
+  });
+});
+
+// --- reservationUrl ----------------------------------------------------------
+
+describe("reservationUrl", () => {
+  it("uses numeric ref for rec.gov", () => {
+    const site: SiteInfo = { id: "usfs/middle-fork", name: "Middle Fork", agency: "usfs", kind: "rec", ref: 233864 };
+    expect(reservationUrl(site)).toBe("https://www.recreation.gov/camping/campgrounds/233864");
+  });
+
+  it("prefers explicit reservation_url", () => {
+    const site: SiteInfo = { id: "usfs/middle-fork", name: "Middle Fork", agency: "usfs", kind: "rec", reservation_url: "https://example.org/book" };
+    expect(reservationUrl(site)).toBe("https://example.org/book");
+  });
+
+  it("returns goingtocamp for WA", () => {
+    const site: SiteInfo = { id: "wa/deception-pass", name: "Deception Pass", agency: "wa", kind: "wa" };
+    expect(reservationUrl(site)).toBe("https://washington.goingtocamp.com/");
   });
 });
 
@@ -185,24 +130,21 @@ describe("sendWebhook", () => {
 
   it("returns true on 204", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
-    const ok = await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] });
-    expect(ok).toBe(true);
+    expect(await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] })).toBe(true);
   });
 
-  it("returns false on 429 (rate limit)", async () => {
+  it("returns false on 429", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 429 }));
-    const ok = await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] });
-    expect(ok).toBe(false);
+    expect(await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] })).toBe(false);
   });
 
   it("returns false on network error", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network down"));
-    const ok = await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] });
-    expect(ok).toBe(false);
+    expect(await sendWebhook("https://discord.com/api/webhooks/test", { embeds: [] })).toBe(false);
   });
 });
 
-// --- loadPreviousSummary (R2 mock) -------------------------------------------
+// --- loadPreviousSites (R2 mock) ---------------------------------------------
 
 function mockR2Bucket(data: Record<string, any>): R2Bucket {
   return {
@@ -215,30 +157,46 @@ function mockR2Bucket(data: Record<string, any>): R2Bucket {
   } as any;
 }
 
-describe("loadPreviousSummary", () => {
-  it("finds the most recent prior snapshot", async () => {
+describe("loadPreviousSites", () => {
+  it("finds the most recent prior sites snapshot", async () => {
     const raw = mockR2Bucket({
-      "summary/2026-06-25/usfs/middle-fork.json": {
-        by_date: { "2026-07-04": { available: 0, reserved: 10, total: 10 } },
+      "sites/2026-06-25/usfs/middle-fork.json": {
+        sites: { "81835": { label: "24", loop: null, type: null, use: null, by_date: { "2026-07-04": "reserved" } } },
       },
     });
-    const prev = await loadPreviousSummary(raw, "usfs/middle-fork", "2026-06-27");
-    expect(prev).toEqual({ "2026-07-04": { available: 0, reserved: 10, total: 10 } });
-    // Should have tried 2026-06-26 first, then 2026-06-25.
-    expect(raw.get).toHaveBeenCalledWith("summary/2026-06-26/usfs/middle-fork.json");
-    expect(raw.get).toHaveBeenCalledWith("summary/2026-06-25/usfs/middle-fork.json");
+    const prev = await loadPreviousSites(raw, "usfs/middle-fork", "2026-06-27");
+    expect(prev).toBeDefined();
+    expect(prev!["81835"].by_date["2026-07-04"]).toBe("reserved");
+    expect(raw.get).toHaveBeenCalledWith("sites/2026-06-26/usfs/middle-fork.json");
+    expect(raw.get).toHaveBeenCalledWith("sites/2026-06-25/usfs/middle-fork.json");
   });
 
   it("returns null when no prior snapshot exists", async () => {
     const raw = mockR2Bucket({});
-    const prev = await loadPreviousSummary(raw, "usfs/middle-fork", "2026-06-27");
-    expect(prev).toBeNull();
+    expect(await loadPreviousSites(raw, "usfs/middle-fork", "2026-06-27")).toBeNull();
   });
 });
 
-// --- notifyAvailabilityChanges (integration) ---------------------------------
+// --- notifySubscriptionMatches (integration) ---------------------------------
 
-describe("notifyAvailabilityChanges", () => {
+function mockKVNamespace(data: Record<string, any>): KVNamespace {
+  return {
+    list: vi.fn(async ({ prefix }: { prefix: string }) => ({
+      keys: Object.keys(data)
+        .filter((k) => k.startsWith(prefix))
+        .map((k) => ({ name: k })),
+    })),
+    get: vi.fn(async (key: string, opts?: any) => {
+      if (!(key in data)) return null;
+      if (opts?.type === "json") return data[key];
+      return JSON.stringify(data[key]);
+    }),
+    put: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+  } as any;
+}
+
+describe("notifySubscriptionMatches", () => {
   beforeEach(() => vi.restoreAllMocks());
 
   const site: SiteInfo = {
@@ -249,45 +207,86 @@ describe("notifyAvailabilityChanges", () => {
   };
 
   it("skips when DISCORD_WEBHOOK_URL is not set", async () => {
-    const env = { RAW: mockR2Bucket({}), DISCORD_WEBHOOK_URL: undefined };
-    const result = await notifyAvailabilityChanges(env as any, site, "2026-06-27");
-    expect(result).toEqual({ notified: false, changes: 0 });
+    const env = { RAW: mockR2Bucket({}), CAMPSITES: mockKVNamespace({}), DISCORD_WEBHOOK_URL: undefined };
+    const result = await notifySubscriptionMatches(env as any, site, "2026-06-27");
+    expect(result).toEqual({ notified: 0, matches: 0 });
   });
 
-  it("notifies on availability change", async () => {
+  it("skips when no subscriptions exist", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+    const kv = mockKVNamespace({});
+    const env = { RAW: mockR2Bucket({}), CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifySubscriptionMatches(env as any, site, "2026-06-27");
+    expect(result).toEqual({ notified: 0, matches: 0 });
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("notifies when a subscription matches", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
 
+    const sub: Subscription = {
+      id: "test-sub",
+      campgroundId: "usfs/middle-fork",
+      siteLabel: "24",
+      weekdays: [0, 6],
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+
+    const kv = mockKVNamespace({ "sub:test-sub": sub });
     const raw = mockR2Bucket({
-      // Previous day: fully booked
-      "summary/2026-06-26/usfs/middle-fork.json": {
-        by_date: { "2026-07-04": { available: 0, reserved: 20, total: 20 } },
+      "sites/2026-06-27/usfs/middle-fork.json": {
+        sites: {
+          "81835": {
+            label: "24",
+            loop: "Riverbend",
+            type: "STANDARD NONELECTRIC",
+            use: "Overnight",
+            by_date: { "2026-07-04": "available", "2026-07-05": "available" },
+          },
+        },
       },
-      // Current day: 3 opened up
-      "summary/2026-06-27/usfs/middle-fork.json": {
-        by_date: { "2026-07-04": { available: 3, reserved: 17, total: 20 } },
+      "sites/2026-06-26/usfs/middle-fork.json": {
+        sites: {
+          "81835": {
+            label: "24",
+            loop: "Riverbend",
+            type: "STANDARD NONELECTRIC",
+            use: "Overnight",
+            by_date: { "2026-07-04": "reserved", "2026-07-05": "reserved" },
+          },
+        },
       },
     });
-    const env = { RAW: raw, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
-    const result = await notifyAvailabilityChanges(env as any, site, "2026-06-27");
-    expect(result).toEqual({ notified: true, changes: 1 });
+
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifySubscriptionMatches(env as any, site, "2026-06-27");
+    expect(result.notified).toBe(1);
+    expect(result.matches).toBe(2);
     expect(globalThis.fetch).toHaveBeenCalledOnce();
   });
 
-  it("skips when no changes detected", async () => {
-    // Install a spy so the not-called assertion has a real spy to inspect (and so a
-    // stray fetch can't escape to the network).
+  it("does not notify when subscription site label doesn't match", async () => {
     vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+    const sub: Subscription = {
+      id: "wrong-site",
+      campgroundId: "usfs/middle-fork",
+      siteLabel: "99",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+
+    const kv = mockKVNamespace({ "sub:wrong-site": sub });
     const raw = mockR2Bucket({
-      "summary/2026-06-26/usfs/middle-fork.json": {
-        by_date: { "2026-07-04": { available: 3, reserved: 17, total: 20 } },
-      },
-      "summary/2026-06-27/usfs/middle-fork.json": {
-        by_date: { "2026-07-04": { available: 3, reserved: 17, total: 20 } },
+      "sites/2026-06-27/usfs/middle-fork.json": {
+        sites: {
+          "81835": { label: "24", loop: null, type: null, use: null, by_date: { "2026-07-04": "available" } },
+        },
       },
     });
-    const env = { RAW: raw, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
-    const result = await notifyAvailabilityChanges(env as any, site, "2026-06-27");
-    expect(result).toEqual({ notified: false, changes: 0 });
+
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifySubscriptionMatches(env as any, site, "2026-06-27");
+    expect(result).toEqual({ notified: 0, matches: 0 });
     expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/discord.test.ts
+++ b/backend/src/discord.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   buildSubscriptionEmbed,
+  buildHotEmbed,
+  computeFillRate,
+  notifyHotCampground,
   sendWebhook,
   notifySubscriptionMatches,
   loadPreviousSites,
@@ -288,5 +291,210 @@ describe("notifySubscriptionMatches", () => {
     const result = await notifySubscriptionMatches(env as any, site, "2026-06-27");
     expect(result).toEqual({ notified: 0, matches: 0 });
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+});
+
+// --- computeFillRate ---------------------------------------------------------
+
+describe("computeFillRate", () => {
+  it("returns 1.0 when all future dates are full", () => {
+    const byDate = {
+      "2026-07-01": { available: 0, reserved: 50, total: 50 },
+      "2026-07-02": { available: 0, reserved: 50, total: 50 },
+      "2026-07-03": { available: 0, reserved: 50, total: 50 },
+    };
+    expect(computeFillRate(byDate, "2026-07-01")).toBe(1.0);
+  });
+
+  it("returns 0 when all future dates have availability", () => {
+    const byDate = {
+      "2026-07-01": { available: 10, reserved: 40, total: 50 },
+      "2026-07-02": { available: 5, reserved: 45, total: 50 },
+    };
+    expect(computeFillRate(byDate, "2026-07-01")).toBe(0);
+  });
+
+  it("excludes past dates", () => {
+    const byDate = {
+      "2026-06-25": { available: 0, reserved: 50, total: 50 }, // past
+      "2026-07-01": { available: 10, reserved: 40, total: 50 },
+    };
+    expect(computeFillRate(byDate, "2026-07-01")).toBe(0);
+  });
+
+  it("computes the correct ratio", () => {
+    const byDate = {
+      "2026-07-01": { available: 0, reserved: 50, total: 50 },
+      "2026-07-02": { available: 0, reserved: 50, total: 50 },
+      "2026-07-03": { available: 0, reserved: 50, total: 50 },
+      "2026-07-04": { available: 0, reserved: 50, total: 50 },
+      "2026-07-05": { available: 0, reserved: 50, total: 50 },
+      "2026-07-06": { available: 0, reserved: 50, total: 50 },
+      "2026-07-07": { available: 0, reserved: 50, total: 50 },
+      "2026-07-08": { available: 0, reserved: 50, total: 50 },
+      "2026-07-09": { available: 0, reserved: 50, total: 50 },
+      "2026-07-10": { available: 5, reserved: 45, total: 50 },
+    };
+    expect(computeFillRate(byDate, "2026-07-01")).toBe(0.9);
+  });
+
+  it("returns 0 for empty byDate", () => {
+    expect(computeFillRate({}, "2026-07-01")).toBe(0);
+  });
+});
+
+// --- buildHotEmbed -----------------------------------------------------------
+
+describe("buildHotEmbed", () => {
+  const site: SiteInfo = {
+    id: "247592",
+    name: "Hoh Rain Forest",
+    agency: "nps",
+    kind: "rec",
+    ref: 247592,
+  };
+
+  it("builds an orange-red embed with fill rate", () => {
+    const matches = [
+      { siteId: "s1", label: "A1", date: "2026-07-04", status: "available" as const },
+    ];
+    const embed = buildHotEmbed(site, 0.95, matches);
+    expect(embed.color).toBe(0xff4500);
+    expect(embed.title).toContain("🔥");
+    expect(embed.title).toContain("Hoh Rain Forest");
+    expect(embed.description).toContain("95%");
+    const fillField = embed.fields.find((f) => f.name === "Fill Rate");
+    expect(fillField).toBeDefined();
+    expect(fillField!.value).toBe("95%");
+  });
+});
+
+// --- notifyHotCampground (integration) ---------------------------------------
+
+describe("notifyHotCampground", () => {
+  beforeEach(() => vi.restoreAllMocks());
+
+  const site: SiteInfo = {
+    id: "247592",
+    name: "Hoh Rain Forest",
+    agency: "nps",
+    kind: "rec",
+    ref: 247592,
+  };
+
+  it("skips when fill rate is below threshold", async () => {
+    const byDate: Record<string, any> = {};
+    for (let i = 1; i <= 10; i++) {
+      byDate[`2026-07-${String(i).padStart(2, "0")}`] = { available: 5, reserved: 45, total: 50 };
+    }
+    const raw = mockR2Bucket({
+      "summary/2026-06-28/247592.json": { by_date: byDate },
+    });
+    const kv = mockKVNamespace({});
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifyHotCampground(env as any, site, "2026-06-28");
+    expect(result.hot).toBe(false);
+    expect(result.notified).toBe(false);
+  });
+
+  it("notifies when fill rate exceeds threshold and availability opens", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+    // 9 fully booked + 1 open = 90% fill rate
+    const byDate: Record<string, any> = {};
+    for (let i = 1; i <= 9; i++) {
+      byDate[`2026-07-${String(i).padStart(2, "0")}`] = { available: 0, reserved: 50, total: 50 };
+    }
+    byDate["2026-07-10"] = { available: 2, reserved: 48, total: 50 };
+
+    const raw = mockR2Bucket({
+      "summary/2026-06-28/247592.json": { by_date: byDate },
+      "sites/2026-06-28/247592.json": {
+        sites: {
+          s1: { label: "A1", loop: null, type: null, use: null, by_date: { "2026-07-10": "available" } },
+        },
+      },
+      "sites/2026-06-27/247592.json": {
+        sites: {
+          s1: { label: "A1", loop: null, type: null, use: null, by_date: { "2026-07-10": "reserved" } },
+        },
+      },
+    });
+
+    const kv = mockKVNamespace({});
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifyHotCampground(env as any, site, "2026-06-28");
+    expect(result.hot).toBe(true);
+    expect(result.notified).toBe(true);
+    expect(result.fillRate).toBe(0.9);
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+  });
+
+  it("does not notify when hot but no new availability", async () => {
+    const byDate: Record<string, any> = {};
+    for (let i = 1; i <= 10; i++) {
+      byDate[`2026-07-${String(i).padStart(2, "0")}`] = { available: 0, reserved: 50, total: 50 };
+    }
+
+    const raw = mockR2Bucket({
+      "summary/2026-06-28/247592.json": { by_date: byDate },
+      "sites/2026-06-28/247592.json": {
+        sites: {
+          s1: { label: "A1", loop: null, type: null, use: null, by_date: { "2026-07-01": "reserved" } },
+        },
+      },
+      "sites/2026-06-27/247592.json": {
+        sites: {
+          s1: { label: "A1", loop: null, type: null, use: null, by_date: { "2026-07-01": "reserved" } },
+        },
+      },
+    });
+
+    const kv = mockKVNamespace({});
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifyHotCampground(env as any, site, "2026-06-28");
+    expect(result.hot).toBe(true);
+    expect(result.notified).toBe(false);
+  });
+
+  it("alerts on first collection (no previous snapshot)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(null, { status: 204 }));
+
+    const byDate: Record<string, any> = {};
+    for (let i = 1; i <= 10; i++) {
+      byDate[`2026-07-${String(i).padStart(2, "0")}`] = { available: 0, reserved: 50, total: 50 };
+    }
+    byDate["2026-07-10"] = { available: 1, reserved: 49, total: 50 };
+
+    const raw = mockR2Bucket({
+      "summary/2026-06-28/247592.json": { by_date: byDate },
+      "sites/2026-06-28/247592.json": {
+        sites: {
+          s1: { label: "A1", loop: null, type: null, use: null, by_date: { "2026-07-10": "available" } },
+        },
+      },
+    });
+
+    const kv = mockKVNamespace({});
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test" };
+    const result = await notifyHotCampground(env as any, site, "2026-06-28");
+    expect(result.hot).toBe(true);
+    expect(result.notified).toBe(true);
+  });
+
+  it("respects custom threshold via HOT_FILL_THRESHOLD", async () => {
+    const byDate: Record<string, any> = {};
+    for (let i = 1; i <= 10; i++) {
+      byDate[`2026-07-${String(i).padStart(2, "0")}`] = { available: 0, reserved: 50, total: 50 };
+    }
+    byDate["2026-07-10"] = { available: 2, reserved: 48, total: 50 };
+    // 90% fill — below 0.95 threshold
+    const raw = mockR2Bucket({
+      "summary/2026-06-28/247592.json": { by_date: byDate },
+    });
+    const kv = mockKVNamespace({});
+    const env = { RAW: raw, CAMPSITES: kv, DISCORD_WEBHOOK_URL: "https://discord.com/api/webhooks/test", HOT_FILL_THRESHOLD: "0.95" };
+    const result = await notifyHotCampground(env as any, site, "2026-06-28");
+    expect(result.hot).toBe(false);
   });
 });

--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -1,47 +1,30 @@
 /**
  * Discord webhook notifications for campsite availability changes.
  *
- * Detects state changes (unavailable → available) by comparing the current
- * collection snapshot against the previous one in R2, then posts a rich embed
- * to a Discord channel via webhook.
+ * Subscription model: after each collection, per-site availability is compared
+ * against the previous snapshot. Changes that match an active subscription
+ * (campground + optional site label + date/weekday filters) fire a targeted
+ * Discord embed. Bulk (unfiltered) notifications are disabled.
  *
  * Integration: called from the CollectorLoop after a successful collectSite().
  * Requires the DISCORD_WEBHOOK_URL env var (a secret — add via `wrangler secret`).
- *
- * Design choices:
- *   - Change detection compares summary/<prevDate>/<id>.json vs the just-written
- *     summary/<date>/<id>.json. A date with 0 available yesterday and >0 today
- *     (or absent yesterday) is a "newly available" event.
- *   - Only fires on availability gains (not losses) to keep the channel useful.
- *   - Embeds are green (#2ecc71) for availability, with campground/park info.
- *   - Rate-limited: Discord webhooks allow 30 req/min; the collector does ≤1 site
- *     per wake (MAX_BATCH=1) so we're well within limits.
  */
 
-import type { ByDate } from "./availability";
+import type { BySite } from "./availability";
+import { listSubscriptions, matchSubscriptions, type Subscription, type SiteMatch } from "./subscriptions";
 
 // --- Types -------------------------------------------------------------------
-
-export type AvailabilityChange = {
-  date: string;           // YYYY-MM-DD
-  previousAvailable: number;
-  currentAvailable: number;
-  total: number;
-};
 
 export type SiteInfo = {
   id: string;
   name: string;
   agency: string;
   kind: "rec" | "wa";
-  ref?: string | number | null; // provider id (numeric rec.gov campground id / WA resourceLocation id)
+  ref?: string | number | null;
   lat?: number | null;
   lng?: number | null;
   reservation_url?: string | null;
 };
-
-// Shape of the R2 `summary/<date>/<id>.json` object written by collectSite().
-type SummarySnapshot = { by_date?: ByDate };
 
 export type DiscordEmbed = {
   title: string;
@@ -53,75 +36,11 @@ export type DiscordEmbed = {
   url?: string;
 };
 
-// --- Change detection --------------------------------------------------------
-
-/**
- * Compare two by_date snapshots and return dates where availability appeared
- * (was 0 or absent, now > 0). Only looks at dates from today onward.
- */
-export function detectChanges(
-  prev: ByDate | null,
-  current: ByDate,
-  today?: string,
-): AvailabilityChange[] {
-  const cutoff = today ?? new Date().toISOString().slice(0, 10);
-  const changes: AvailabilityChange[] = [];
-
-  for (const [date, counts] of Object.entries(current)) {
-    if (date < cutoff) continue; // ignore past dates
-    if (counts.available <= 0) continue; // nothing opened up
-
-    const prevCounts = prev?.[date];
-    const prevAvail = prevCounts?.available ?? 0;
-
-    // Fire when availability appeared (was 0 or missing, now > 0).
-    if (prevAvail === 0 && counts.available > 0) {
-      changes.push({
-        date,
-        previousAvailable: prevAvail,
-        currentAvailable: counts.available,
-        total: counts.total,
-      });
-    }
-  }
-
-  return changes.sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
-}
-
-/**
- * Load the previous summary snapshot from R2 for comparison. Walks the recent
- * date-partitions (newest first, excluding `currentDate`) to find the most
- * recent prior snapshot for this site.
- */
-export async function loadPreviousSummary(
-  raw: R2Bucket,
-  siteId: string,
-  currentDate: string,
-  lookbackDays = 7,
-): Promise<ByDate | null> {
-  // Generate candidate dates (yesterday back to lookbackDays ago).
-  const candidates: string[] = [];
-  const base = new Date(`${currentDate}T00:00:00Z`);
-  for (let i = 1; i <= lookbackDays; i++) {
-    const d = new Date(base.getTime() - i * 86_400_000);
-    candidates.push(d.toISOString().slice(0, 10));
-  }
-
-  for (const d of candidates) {
-    const obj = await raw.get(`summary/${d}/${siteId}.json`);
-    if (obj) {
-      const snap = await obj.json<SummarySnapshot>();
-      return snap?.by_date ?? null;
-    }
-  }
-  return null;
-}
-
-// --- Discord embed formatting ------------------------------------------------
+// --- Helpers -----------------------------------------------------------------
 
 const GREEN = 0x2ecc71;
 
-function formatDate(iso: string): string {
+export function formatDate(iso: string): string {
   const [y, m, d] = iso.split("-").map(Number);
   const dt = new Date(Date.UTC(y, m - 1, d));
   const day = dt.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" });
@@ -129,12 +48,9 @@ function formatDate(iso: string): string {
   return `${day}, ${month} ${d}`;
 }
 
-function reservationUrl(site: SiteInfo): string | null {
+export function reservationUrl(site: SiteInfo): string | null {
   if (site.reservation_url) return site.reservation_url;
   if (site.kind === "rec") {
-    // rec.gov campground URLs are keyed by the numeric provider id (the inventory
-    // `ref`, e.g. 233864) — NOT the agency slug id (e.g. "usfs/middle-fork"), which
-    // would 404. Fall back to the id only if no ref is available.
     return `https://www.recreation.gov/camping/campgrounds/${site.ref ?? site.id}`;
   }
   if (site.kind === "wa") {
@@ -153,54 +69,48 @@ function agencyLabel(site: SiteInfo): string {
   return labels[site.agency] ?? site.agency;
 }
 
-/**
- * Build a Discord embed for a batch of availability changes at one campground.
- */
-export function buildEmbed(site: SiteInfo, changes: AvailabilityChange[]): DiscordEmbed {
-  // Group changes into a readable list.
-  const totalNewSites = changes.reduce((sum, c) => sum + c.currentAvailable, 0);
-  const dateRange =
-    changes.length === 1
-      ? formatDate(changes[0].date)
-      : `${formatDate(changes[0].date)} – ${formatDate(changes[changes.length - 1].date)}`;
+// --- Subscription embed building ---------------------------------------------
 
-  // Build per-date lines (cap at 15 to stay within Discord's 1024 char field limit).
-  const dateLines = changes.slice(0, 15).map((c) => {
-    const pct = c.total > 0 ? Math.round((c.currentAvailable / c.total) * 100) : 0;
-    return `**${formatDate(c.date)}** — ${c.currentAvailable} of ${c.total} sites (${pct}% open)`;
+export function buildSubscriptionEmbed(
+  site: SiteInfo,
+  sub: Subscription,
+  matches: SiteMatch[],
+): DiscordEmbed {
+  const uniqueDates = [...new Set(matches.map((m) => m.date))];
+  const uniqueSites = [...new Set(matches.map((m) => m.label).filter(Boolean))] as string[];
+
+  const dateRange =
+    uniqueDates.length === 1
+      ? formatDate(uniqueDates[0])
+      : `${formatDate(uniqueDates[0])} – ${formatDate(uniqueDates[uniqueDates.length - 1])}`;
+
+  const lines = matches.slice(0, 15).map((m) => {
+    const siteStr = m.label ? `Site ${m.label}` : `Site ${m.siteId}`;
+    return `**${formatDate(m.date)}** — ${siteStr}`;
   });
-  if (changes.length > 15) {
-    dateLines.push(`_…and ${changes.length - 15} more dates_`);
+  if (matches.length > 15) {
+    lines.push(`_…and ${matches.length - 15} more_`);
   }
 
   const url = reservationUrl(site);
+  const titleSite = sub.siteLabel ? ` Site ${sub.siteLabel}` : "";
+  const subNote = sub.note ? ` (${sub.note})` : "";
 
   return {
-    title: `🏕️ ${site.name} — Sites Available!`,
-    description: `**${totalNewSites}** campsite-night${totalNewSites === 1 ? "" : "s"} just opened up across **${changes.length}** date${changes.length === 1 ? "" : "s"}.`,
+    title: `🏕️ ${site.name}${titleSite} — Available!`,
+    description: `**${matches.length}** campsite-night${matches.length === 1 ? "" : "s"} opened up matching your subscription${subNote}.`,
     color: GREEN,
     url: url ?? undefined,
     fields: [
-      {
-        name: "Park / Agency",
-        value: agencyLabel(site),
-        inline: true,
-      },
-      {
-        name: "Dates",
-        value: dateRange,
-        inline: true,
-      },
-      {
-        name: "Availability",
-        value: dateLines.join("\n"),
-        inline: false,
-      },
-      ...(url
-        ? [{ name: "Book Now", value: `[Reserve →](${url})`, inline: false }]
+      { name: "Park / Agency", value: agencyLabel(site), inline: true },
+      { name: "Dates", value: dateRange, inline: true },
+      ...(uniqueSites.length > 0
+        ? [{ name: "Sites", value: uniqueSites.join(", "), inline: true }]
         : []),
+      { name: "Availability", value: lines.join("\n"), inline: false },
+      ...(url ? [{ name: "Book Now", value: `[Reserve →](${url})`, inline: false }] : []),
     ],
-    footer: { text: "Robot Geographical Society • Campsite Availability Monitor" },
+    footer: { text: "Robot Geographical Society • Campsite Subscription Alert" },
     timestamp: new Date().toISOString(),
   };
 }
@@ -214,10 +124,6 @@ export interface DiscordWebhookPayload {
   avatar_url?: string;
 }
 
-/**
- * Send a Discord webhook message. Returns true on success, false on failure
- * (non-throwing — a notification failure should never break collection).
- */
 export async function sendWebhook(
   webhookUrl: string,
   payload: DiscordWebhookPayload,
@@ -228,9 +134,7 @@ export async function sendWebhook(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
-    // Discord returns 204 No Content on success, or 200 with wait_until for rate limits.
     if (res.ok || res.status === 204) return true;
-    // Rate limited — log but don't retry (the next collection will catch it).
     if (res.status === 429) {
       console.warn(`Discord rate limited (429), skipping notification`);
       return false;
@@ -243,62 +147,83 @@ export async function sendWebhook(
   }
 }
 
+// --- Previous sites snapshot loading -----------------------------------------
+
+type SitesSnapshot = { sites?: BySite };
+
+export async function loadPreviousSites(
+  raw: R2Bucket,
+  siteId: string,
+  currentDate: string,
+  lookbackDays = 7,
+): Promise<BySite | null> {
+  const base = new Date(`${currentDate}T00:00:00Z`);
+  for (let i = 1; i <= lookbackDays; i++) {
+    const d = new Date(base.getTime() - i * 86_400_000);
+    const dateStr = d.toISOString().slice(0, 10);
+    const obj = await raw.get(`sites/${dateStr}/${siteId}.json`);
+    if (obj) {
+      const snap = await obj.json<SitesSnapshot>();
+      return snap?.sites ?? null;
+    }
+  }
+  return null;
+}
+
 // --- Main entry point (called from the collector) ----------------------------
 
 export type NotifyEnv = {
   RAW: R2Bucket;
+  CAMPSITES: KVNamespace;
   DISCORD_WEBHOOK_URL?: string;
 };
 
 /**
- * After a successful collection, detect availability changes and notify Discord.
+ * After a successful collection, check per-site availability changes against
+ * active subscriptions and send targeted Discord notifications.
  *
- * Call this from the CollectorLoop after collectSite() succeeds. It:
- *   1. Loads the previous summary snapshot from R2
- *   2. Loads the just-written current snapshot
- *   3. Detects dates where availability appeared (0 → >0)
- *   4. Posts a Discord embed if any changes found
- *
- * Non-throwing: notification failures are logged but never propagate to the caller.
- *
- * @param env       Worker env (needs RAW R2 bucket + DISCORD_WEBHOOK_URL secret)
- * @param site      The collected site's metadata
- * @param date      Today's collection date (YYYY-MM-DD)
- * @returns         { notified: boolean, changes: number }
+ * Only fires when a subscription matches (campground + site label + date/weekday
+ * pattern). One embed per matched subscription.
  */
-export async function notifyAvailabilityChanges(
+export async function notifySubscriptionMatches(
   env: NotifyEnv,
   site: SiteInfo,
   date: string,
-): Promise<{ notified: boolean; changes: number }> {
+): Promise<{ notified: number; matches: number }> {
   const webhookUrl = env.DISCORD_WEBHOOK_URL;
-  if (!webhookUrl) return { notified: false, changes: 0 };
+  if (!webhookUrl) return { notified: 0, matches: 0 };
 
   try {
-    // 1. Load the previous snapshot for comparison.
-    const prev = await loadPreviousSummary(env.RAW, site.id, date);
+    const allSubs = await listSubscriptions(env.CAMPSITES);
+    const relevant = allSubs.filter((s) => s.campgroundId === site.id);
+    if (!relevant.length) return { notified: 0, matches: 0 };
 
-    // 2. Load the current (just-written) snapshot.
-    const currentObj = await env.RAW.get(`summary/${date}/${site.id}.json`);
-    if (!currentObj) return { notified: false, changes: 0 };
-    const current = await currentObj.json<SummarySnapshot>();
-    const currentBy: ByDate = current?.by_date ?? {};
+    const currentObj = await env.RAW.get(`sites/${date}/${site.id}.json`);
+    if (!currentObj) return { notified: 0, matches: 0 };
+    const currentSnap = await currentObj.json<SitesSnapshot>();
+    const currentSites = currentSnap?.sites ?? {};
 
-    // 3. Detect changes.
-    const changes = detectChanges(prev, currentBy, date);
-    if (changes.length === 0) return { notified: false, changes: 0 };
+    const previousSites = await loadPreviousSites(env.RAW, site.id, date);
 
-    // 4. Build and send the Discord notification.
-    const embed = buildEmbed(site, changes);
-    const payload: DiscordWebhookPayload = {
-      username: "Campsite Bot",
-      avatar_url: "https://em-content.zobj.net/source/apple/391/national-park_1f3de-fe0f.png",
-      embeds: [embed],
-    };
-    const sent = await sendWebhook(webhookUrl, payload);
-    return { notified: sent, changes: changes.length };
+    const matched = matchSubscriptions(site.id, currentSites, previousSites, relevant, date);
+    if (matched.size === 0) return { notified: 0, matches: 0 };
+
+    let notified = 0;
+    let totalMatches = 0;
+    for (const [sub, matches] of matched) {
+      totalMatches += matches.length;
+      const embed = buildSubscriptionEmbed(site, sub, matches);
+      const payload: DiscordWebhookPayload = {
+        username: "Campsite Bot",
+        avatar_url: "https://em-content.zobj.net/source/apple/391/national-park_1f3de-fe0f.png",
+        embeds: [embed],
+      };
+      if (await sendWebhook(webhookUrl, payload)) notified++;
+    }
+
+    return { notified, matches: totalMatches };
   } catch (err) {
-    console.error(`notifyAvailabilityChanges failed for ${site.id}: ${err}`);
-    return { notified: false, changes: 0 };
+    console.error(`notifySubscriptionMatches failed for ${site.id}: ${err}`);
+    return { notified: 0, matches: 0 };
   }
 }

--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -151,7 +151,7 @@ export async function notifyHotCampground(
 
     if (matches.length === 0) return { notified: false, hot: true, fillRate };
 
-    matches.sort((a, b) => a.date.localeCompare(b.date) || a.label.localeCompare(b.label));
+    matches.sort((a, b) => a.date.localeCompare(b.date) || (a.label ?? "").localeCompare(b.label ?? ""));
 
     const embed = buildHotEmbed(site, fillRate, matches);
     const payload: DiscordWebhookPayload = {

--- a/backend/src/discord.ts
+++ b/backend/src/discord.ts
@@ -1,16 +1,17 @@
 /**
  * Discord webhook notifications for campsite availability changes.
  *
- * Subscription model: after each collection, per-site availability is compared
- * against the previous snapshot. Changes that match an active subscription
- * (campground + optional site label + date/weekday filters) fire a targeted
- * Discord embed. Bulk (unfiltered) notifications are disabled.
+ * Two notification paths:
+ *  1. Subscriptions — per-site changes matching an active subscription
+ *     (campground + optional site label + date/weekday filters).
+ *  2. "Hottest" feed — any availability opening at a high-demand campground
+ *     (fill rate ≥ threshold). Enabled by default, no subscription needed.
  *
  * Integration: called from the CollectorLoop after a successful collectSite().
  * Requires the DISCORD_WEBHOOK_URL env var (a secret — add via `wrangler secret`).
  */
 
-import type { BySite } from "./availability";
+import type { ByDate, BySite } from "./availability";
 import { listSubscriptions, matchSubscriptions, type Subscription, type SiteMatch } from "./subscriptions";
 
 // --- Types -------------------------------------------------------------------
@@ -67,6 +68,103 @@ function agencyLabel(site: SiteInfo): string {
     blm: "Bureau of Land Management",
   };
   return labels[site.agency] ?? site.agency;
+}
+
+// --- Fill-rate / "hottest" feed -----------------------------------------------
+
+const HOT_FILL_DEFAULT = 0.9;
+const FIRE = 0xff4500; // orange-red
+
+export function computeFillRate(byDate: ByDate, today: string): number {
+  const entries = Object.entries(byDate).filter(([d]) => d >= today);
+  if (entries.length === 0) return 0;
+  const full = entries.filter(([, c]) => c.available === 0).length;
+  return full / entries.length;
+}
+
+export function buildHotEmbed(
+  site: SiteInfo,
+  fillRate: number,
+  matches: SiteMatch[],
+): DiscordEmbed {
+  const pct = Math.round(fillRate * 100);
+  const lines = matches.slice(0, 15).map((m) => {
+    const siteStr = m.label ? `Site ${m.label}` : `Site ${m.siteId}`;
+    return `**${formatDate(m.date)}** — ${siteStr}`;
+  });
+  if (matches.length > 15) {
+    lines.push(`_…and ${matches.length - 15} more_`);
+  }
+  const url = reservationUrl(site);
+  return {
+    title: `🔥 ${site.name} — Rare Opening!`,
+    description: `This campground is **${pct}% full** across all future dates. **${matches.length}** site-night${matches.length === 1 ? "" : "s"} just opened up — book fast.`,
+    color: FIRE,
+    url: url ?? undefined,
+    fields: [
+      { name: "Park / Agency", value: agencyLabel(site), inline: true },
+      { name: "Fill Rate", value: `${pct}%`, inline: true },
+      { name: "Availability", value: lines.join("\n"), inline: false },
+      ...(url ? [{ name: "Book Now", value: `[Reserve →](${url})`, inline: false }] : []),
+    ],
+    footer: { text: "Robot Geographical Society • Hot Campground Alert" },
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export async function notifyHotCampground(
+  env: NotifyEnv & { HOT_FILL_THRESHOLD?: string },
+  site: SiteInfo,
+  date: string,
+): Promise<{ notified: boolean; hot: boolean; fillRate: number }> {
+  const webhookUrl = env.DISCORD_WEBHOOK_URL;
+  if (!webhookUrl) return { notified: false, hot: false, fillRate: 0 };
+
+  try {
+    const summaryObj = await env.RAW.get(`summary/${date}/${site.id}.json`);
+    if (!summaryObj) return { notified: false, hot: false, fillRate: 0 };
+    const summary = await summaryObj.json<{ by_date?: ByDate }>();
+    const byDate = summary?.by_date ?? {};
+
+    const fillRate = computeFillRate(byDate, date);
+    const threshold = parseFloat(env.HOT_FILL_THRESHOLD ?? "") || HOT_FILL_DEFAULT;
+    if (fillRate < threshold) return { notified: false, hot: false, fillRate };
+
+    // Hot campground — check for reserved→available transitions
+    const currentObj = await env.RAW.get(`sites/${date}/${site.id}.json`);
+    if (!currentObj) return { notified: false, hot: true, fillRate };
+    const currentSnap = await currentObj.json<{ sites?: BySite }>();
+    const currentSites = currentSnap?.sites ?? {};
+
+    const previousSites = await loadPreviousSites(env.RAW, site.id, date);
+
+    const matches: SiteMatch[] = [];
+    for (const [siteId, info] of Object.entries(currentSites)) {
+      for (const [d, status] of Object.entries(info.by_date)) {
+        if (d < date) continue;
+        if (status !== "available") continue;
+        const prev = previousSites?.[siteId]?.by_date?.[d];
+        if (prev && prev === "available") continue; // already was available
+        matches.push({ siteId, label: info.label, date: d, status });
+      }
+    }
+
+    if (matches.length === 0) return { notified: false, hot: true, fillRate };
+
+    matches.sort((a, b) => a.date.localeCompare(b.date) || a.label.localeCompare(b.label));
+
+    const embed = buildHotEmbed(site, fillRate, matches);
+    const payload: DiscordWebhookPayload = {
+      username: "Campsite Bot",
+      avatar_url: "https://em-content.zobj.net/source/apple/391/national-park_1f3de-fe0f.png",
+      embeds: [embed],
+    };
+    const sent = await sendWebhook(webhookUrl, payload);
+    return { notified: sent, hot: true, fillRate };
+  } catch (err) {
+    console.error(`notifyHotCampground failed for ${site.id}: ${err}`);
+    return { notified: false, hot: false, fillRate: 0 };
+  }
 }
 
 // --- Subscription embed building ---------------------------------------------

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,8 @@ import campsites from './campsites-index.json';
 import { collectSite, HEARTBEAT_KEY, DLQ_PREFIX, listDlqIds, type WfEnv, type DlqEntry } from './workflows';
 import { readApi, edgeCache } from './read-api';
 import { whoami, adminOnly, ROLE_PREFIX } from './auth';
+import { listSubscriptions, getSubscription, putSubscription, deleteSubscription, type Subscription } from './subscriptions';
+import { handleInteraction } from './discord-interactions';
 
 // Cloudflare Workflows must be exported from the entry module by class name.
 export { CollectorLoop, HotDateWatchWorkflow } from './workflows';
@@ -13,6 +15,7 @@ type Bindings = WfEnv & {
   CAMPSITES: KVNamespace;
   WATCH_WF: Workflow;
   BOOTSTRAP_ADMIN?: string; // email that is always admin (RBAC bootstrap)
+  DISCORD_APP_PUBLIC_KEY?: string; // for verifying Discord interaction signatures
 };
 
 // If no heartbeat younger than this, the loop is considered dead → (re)start it.
@@ -26,6 +29,13 @@ async function loopAlive(env: Bindings): Promise<{ alive: boolean; hb?: any }> {
 }
 
 export const app = new Hono<{ Bindings: Bindings }>();
+
+// Discord interactions endpoint — signature-verified, no Access identity needed.
+// Must be registered before CORS/auth middleware.
+app.post('/discord/interactions', async (c) => {
+  return handleInteraction(c.req.raw, c.env);
+});
+
 app.use('/*', cors());
 
 app.get('/', (c) => c.text('Robot Geographical Society Backend API'));
@@ -174,6 +184,51 @@ app.post('/watch', adminOnly(), async (c) => {
   if (!site || !date) return c.json({ error: 'need ?id=<campsite id>&date=YYYY-MM-DD [&every=]' }, 400);
   const i = await c.env.WATCH_WF.create({ params: { ...site, targetDate: date, every } });
   return c.json({ workflow: 'campsite-hot-date-watch', instanceId: i.id, watching: site.name, targetDate: date, every });
+});
+
+// --- Subscriptions -----------------------------------------------------------
+
+app.get('/subscriptions', adminOnly(), async (c) => {
+  const subs = await listSubscriptions(c.env.CAMPSITES);
+  return c.json({ count: subs.length, subscriptions: subs });
+});
+
+app.get('/subscriptions/:id', adminOnly(), async (c) => {
+  const sub = await getSubscription(c.env.CAMPSITES, c.req.param('id'));
+  if (!sub) return c.json({ error: 'Subscription not found' }, 404);
+  return c.json(sub);
+});
+
+app.post('/subscriptions', adminOnly(), async (c) => {
+  const body = await c.req.json<Partial<Subscription>>();
+  if (!body.campgroundId) return c.json({ error: 'campgroundId is required' }, 400);
+
+  const known = (campsites as any[]).find((s) => s.id === body.campgroundId);
+  if (!known) return c.json({ error: `Unknown campground: ${body.campgroundId}` }, 400);
+
+  if (body.weekdays?.length) {
+    if (body.weekdays.some((d) => d < 0 || d > 6)) {
+      return c.json({ error: 'weekdays must be 0 (Sun) – 6 (Sat)' }, 400);
+    }
+  }
+
+  const sub: Subscription = {
+    id: body.id ?? crypto.randomUUID(),
+    campgroundId: body.campgroundId,
+    siteLabel: body.siteLabel ?? null,
+    dates: body.dates ?? undefined,
+    weekdays: body.weekdays ?? undefined,
+    note: body.note ?? undefined,
+    createdAt: new Date().toISOString(),
+  };
+  await putSubscription(c.env.CAMPSITES, sub);
+  return c.json(sub, 201);
+});
+
+app.delete('/subscriptions/:id', adminOnly(), async (c) => {
+  const id = c.req.param('id');
+  const existed = await deleteSubscription(c.env.CAMPSITES, id);
+  return c.json({ status: existed ? 'deleted' : 'not-found', id });
 });
 
 // No scheduled() handler / cron. The CollectorLoop self-perpetuates via

--- a/backend/src/subscriptions.test.ts
+++ b/backend/src/subscriptions.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+import { dateMatches, siteMatches, matchSubscriptions, type Subscription } from "./subscriptions";
+import type { BySite } from "./availability";
+
+// --- dateMatches -------------------------------------------------------------
+
+describe("dateMatches", () => {
+  const baseSub: Subscription = {
+    id: "1",
+    campgroundId: "usfs/middle-fork",
+    createdAt: "2026-06-27T00:00:00Z",
+  };
+
+  it("matches any date when no filters set", () => {
+    expect(dateMatches(baseSub, "2026-07-04")).toBe(true);
+    expect(dateMatches(baseSub, "2026-12-25")).toBe(true);
+  });
+
+  it("matches specific dates", () => {
+    const sub = { ...baseSub, dates: ["2026-07-04", "2026-07-05"] };
+    expect(dateMatches(sub, "2026-07-04")).toBe(true);
+    expect(dateMatches(sub, "2026-07-06")).toBe(false);
+  });
+
+  it("matches weekdays (0=Sun, 6=Sat)", () => {
+    const sub = { ...baseSub, weekdays: [0, 6] }; // weekends
+    // 2026-07-04 is a Saturday (6)
+    expect(dateMatches(sub, "2026-07-04")).toBe(true);
+    // 2026-07-05 is a Sunday (0)
+    expect(dateMatches(sub, "2026-07-05")).toBe(true);
+    // 2026-07-06 is a Monday (1)
+    expect(dateMatches(sub, "2026-07-06")).toBe(false);
+  });
+
+  it("OR logic: matches if either dates or weekdays match", () => {
+    const sub = { ...baseSub, dates: ["2026-07-04"], weekdays: [1] }; // July 4 OR Mondays
+    expect(dateMatches(sub, "2026-07-04")).toBe(true); // specific date
+    expect(dateMatches(sub, "2026-07-06")).toBe(true); // Monday
+    expect(dateMatches(sub, "2026-07-08")).toBe(false); // Wednesday, not in dates
+  });
+});
+
+// --- siteMatches -------------------------------------------------------------
+
+describe("siteMatches", () => {
+  const baseSub: Subscription = {
+    id: "1",
+    campgroundId: "usfs/middle-fork",
+    createdAt: "2026-06-27T00:00:00Z",
+  };
+
+  it("matches any site when no siteLabel filter", () => {
+    expect(siteMatches(baseSub, "24")).toBe(true);
+    expect(siteMatches(baseSub, null)).toBe(true);
+  });
+
+  it("matches specific site label (case-insensitive)", () => {
+    const sub = { ...baseSub, siteLabel: "24" };
+    expect(siteMatches(sub, "24")).toBe(true);
+    expect(siteMatches(sub, "25")).toBe(false);
+    expect(siteMatches(sub, null)).toBe(false);
+  });
+
+  it("matches case-insensitively (WA labels like A012)", () => {
+    const sub = { ...baseSub, siteLabel: "a012" };
+    expect(siteMatches(sub, "A012")).toBe(true);
+  });
+});
+
+// --- matchSubscriptions ------------------------------------------------------
+
+describe("matchSubscriptions", () => {
+  const today = "2026-06-27";
+
+  const currentSites: BySite = {
+    "81835": {
+      label: "24",
+      loop: "Riverbend",
+      type: "STANDARD NONELECTRIC",
+      use: "Overnight",
+      by_date: {
+        "2026-07-04": "available",
+        "2026-07-05": "available",
+        "2026-07-06": "reserved",
+      },
+    },
+    "81836": {
+      label: "25",
+      loop: "Riverbend",
+      type: "STANDARD NONELECTRIC",
+      use: "Overnight",
+      by_date: {
+        "2026-07-04": "available",
+        "2026-07-05": "reserved",
+      },
+    },
+  };
+
+  const previousSites: BySite = {
+    "81835": {
+      label: "24",
+      loop: "Riverbend",
+      type: "STANDARD NONELECTRIC",
+      use: "Overnight",
+      by_date: {
+        "2026-07-04": "reserved",
+        "2026-07-05": "reserved",
+        "2026-07-06": "reserved",
+      },
+    },
+    "81836": {
+      label: "25",
+      loop: "Riverbend",
+      type: "STANDARD NONELECTRIC",
+      use: "Overnight",
+      by_date: {
+        "2026-07-04": "reserved",
+        "2026-07-05": "reserved",
+      },
+    },
+  };
+
+  it("matches subscription for specific site on weekends", () => {
+    const sub: Subscription = {
+      id: "1",
+      campgroundId: "usfs/middle-fork",
+      siteLabel: "24",
+      weekdays: [0, 6], // weekends
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const result = matchSubscriptions("usfs/middle-fork", currentSites, previousSites, [sub], today);
+    expect(result.size).toBe(1);
+    const matches = result.get(sub)!;
+    // Site 24 became available on July 4 (Sat) and July 5 (Sun) — both weekends.
+    expect(matches).toHaveLength(2);
+    expect(matches[0]).toMatchObject({ siteId: "81835", label: "24", date: "2026-07-04" });
+    expect(matches[1]).toMatchObject({ siteId: "81835", label: "24", date: "2026-07-05" });
+  });
+
+  it("matches subscription for any site on a specific date", () => {
+    const sub: Subscription = {
+      id: "2",
+      campgroundId: "usfs/middle-fork",
+      dates: ["2026-07-04"],
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const result = matchSubscriptions("usfs/middle-fork", currentSites, previousSites, [sub], today);
+    const matches = result.get(sub)!;
+    // Both site 24 and 25 became available on July 4.
+    expect(matches).toHaveLength(2);
+  });
+
+  it("ignores campgrounds that don't match", () => {
+    const sub: Subscription = {
+      id: "3",
+      campgroundId: "wa/deception-pass",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const result = matchSubscriptions("usfs/middle-fork", currentSites, previousSites, [sub], today);
+    expect(result.size).toBe(0);
+  });
+
+  it("ignores sites that were already available", () => {
+    const prevWithAvail: BySite = {
+      "81835": {
+        ...currentSites["81835"],
+        by_date: { "2026-07-04": "available", "2026-07-05": "reserved", "2026-07-06": "reserved" },
+      },
+      "81836": previousSites["81836"],
+    };
+    const sub: Subscription = {
+      id: "4",
+      campgroundId: "usfs/middle-fork",
+      siteLabel: "24",
+      dates: ["2026-07-04"],
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const result = matchSubscriptions("usfs/middle-fork", currentSites, prevWithAvail, [sub], today);
+    // Site 24 on July 4 was already available — no change.
+    expect(result.size).toBe(0);
+  });
+
+  it("ignores past dates", () => {
+    const sub: Subscription = {
+      id: "5",
+      campgroundId: "usfs/middle-fork",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const pastSites: BySite = {
+      "81835": {
+        label: "24",
+        loop: null,
+        type: null,
+        use: null,
+        by_date: { "2026-06-20": "available" },
+      },
+    };
+    const result = matchSubscriptions("usfs/middle-fork", pastSites, null, [sub], today);
+    expect(result.size).toBe(0);
+  });
+
+  it("handles null previous (first collection)", () => {
+    const sub: Subscription = {
+      id: "6",
+      campgroundId: "usfs/middle-fork",
+      siteLabel: "24",
+      createdAt: "2026-06-27T00:00:00Z",
+    };
+    const result = matchSubscriptions("usfs/middle-fork", currentSites, null, [sub], today);
+    const matches = result.get(sub)!;
+    expect(matches).toHaveLength(2); // July 4 and 5
+  });
+});

--- a/backend/src/subscriptions.ts
+++ b/backend/src/subscriptions.ts
@@ -1,0 +1,133 @@
+/**
+ * Subscription-based campsite notifications.
+ *
+ * Users subscribe to specific campground + optional site label + date pattern.
+ * After each collection, matched subscriptions fire a targeted Discord alert.
+ * Subscriptions are stored in KV under the `sub:` prefix.
+ */
+
+import type { BySite, SiteStatus } from "./availability";
+
+// --- Types -------------------------------------------------------------------
+
+export type Subscription = {
+  id: string;
+  campgroundId: string;       // e.g. "usfs/middle-fork"
+  siteLabel?: string | null;  // e.g. "24" — null/omitted = any site
+  dates?: string[];           // specific dates ["2026-07-04"] — omit for pattern-only
+  weekdays?: number[];        // 0=Sun … 6=Sat — e.g. [0, 6] for weekends
+  note?: string;              // human-readable label
+  createdAt: string;
+};
+
+export type SiteMatch = {
+  siteId: string;
+  label: string | null;
+  date: string;
+  status: SiteStatus;
+};
+
+const SUB_PREFIX = "sub:";
+
+// --- KV CRUD -----------------------------------------------------------------
+
+export async function listSubscriptions(kv: KVNamespace): Promise<Subscription[]> {
+  const keys = await kv.list({ prefix: SUB_PREFIX });
+  const subs: Subscription[] = [];
+  for (const k of keys.keys) {
+    const raw = await kv.get(k.name, { type: "json" });
+    if (raw) subs.push(raw as Subscription);
+  }
+  return subs;
+}
+
+export async function getSubscription(kv: KVNamespace, id: string): Promise<Subscription | null> {
+  return kv.get(`${SUB_PREFIX}${id}`, { type: "json" });
+}
+
+export async function putSubscription(kv: KVNamespace, sub: Subscription): Promise<void> {
+  await kv.put(`${SUB_PREFIX}${sub.id}`, JSON.stringify(sub));
+}
+
+export async function deleteSubscription(kv: KVNamespace, id: string): Promise<boolean> {
+  const exists = (await kv.get(`${SUB_PREFIX}${id}`)) !== null;
+  await kv.delete(`${SUB_PREFIX}${id}`);
+  return exists;
+}
+
+// --- Matching ----------------------------------------------------------------
+
+function dayOfWeek(iso: string): number {
+  const [y, m, d] = iso.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d)).getUTCDay();
+}
+
+/** Does this date match the subscription's date/weekday filters? */
+export function dateMatches(sub: Subscription, date: string): boolean {
+  if (sub.dates?.length) {
+    if (sub.dates.includes(date)) return true;
+    // If specific dates are set but don't match, fall through to weekday check
+    // only if weekdays are also set (OR logic between the two).
+    if (!sub.weekdays?.length) return false;
+  }
+  if (sub.weekdays?.length) {
+    return sub.weekdays.includes(dayOfWeek(date));
+  }
+  // No date/weekday filter → matches all dates.
+  return true;
+}
+
+/** Does this campsite label match the subscription? */
+export function siteMatches(sub: Subscription, label: string | null): boolean {
+  if (!sub.siteLabel) return true; // no filter → all sites
+  if (!label) return false;       // filter set, but site has no label
+  return label.toLowerCase() === sub.siteLabel.toLowerCase();
+}
+
+/**
+ * Given the per-site availability for a campground (current and previous),
+ * find individual site+date pairs that became available and match at least
+ * one subscription.
+ */
+export function matchSubscriptions(
+  campgroundId: string,
+  currentSites: BySite,
+  previousSites: BySite | null,
+  subs: Subscription[],
+  today: string,
+): Map<Subscription, SiteMatch[]> {
+  const relevant = subs.filter((s) => s.campgroundId === campgroundId);
+  if (!relevant.length) return new Map();
+
+  const result = new Map<Subscription, SiteMatch[]>();
+
+  for (const [siteId, current] of Object.entries(currentSites)) {
+    const prevSite = previousSites?.[siteId];
+
+    for (const [date, status] of Object.entries(current.by_date)) {
+      if (date < today) continue;
+      if (status !== "available") continue;
+
+      // Was it previously unavailable (reserved/other/absent)?
+      const prevStatus = prevSite?.by_date?.[date];
+      if (prevStatus === "available") continue; // already available, not new
+
+      // This site+date is newly available. Check against subscriptions.
+      for (const sub of relevant) {
+        if (!siteMatches(sub, current.label)) continue;
+        if (!dateMatches(sub, date)) continue;
+
+        const matches = result.get(sub) ?? [];
+        matches.push({ siteId, label: current.label, date, status });
+        result.set(sub, matches);
+      }
+    }
+  }
+
+  // Sort each subscription's matches by date then label.
+  for (const matches of result.values()) {
+    matches.sort((a, b) => a.date.localeCompare(b.date) || (a.label ?? "").localeCompare(b.label ?? ""));
+  }
+
+  return result;
+}

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -14,7 +14,7 @@ import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:work
 import { loadInventory } from "./inventory";
 import { fetchAvailability, type Counts } from "./availability";
 import { type DueMap, type FailMap, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs, retryBackoffMs } from "./scheduler";
-import { notifyAvailabilityChanges, type SiteInfo } from "./discord";
+import { notifySubscriptionMatches, type SiteInfo } from "./discord";
 
 export interface WfEnv {
   RAW: R2Bucket;
@@ -269,13 +269,16 @@ export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
           due[id] = plan.now + X + jitterMs(id);
           fails[id] = 0;
           collectedTotal++;
-          // Discord alert on newly-opened availability. Its own step so the webhook
-          // POST fires exactly once (memoized on replay, not re-sent on a collect
-          // retry). Guarded on the secret so no empty step is created when unset, and
-          // non-throwing internally so a webhook failure never fails the collection.
-          if (this.env.DISCORD_WEBHOOK_URL) {
+          // Subscription-based Discord alerts: check per-site availability changes
+          // against active subscriptions in KV. Its own step so the webhook POST
+          // fires exactly once (memoized on replay). Non-throwing internally.
+          if (this.env.DISCORD_WEBHOOK_URL && this.env.CAMPSITES) {
             await step.do(`notify-${i}-${id}`, () =>
-              notifyAvailabilityChanges(this.env, toSiteInfo(site), date),
+              notifySubscriptionMatches(
+                { RAW: this.env.RAW, CAMPSITES: this.env.CAMPSITES!, DISCORD_WEBHOOK_URL: this.env.DISCORD_WEBHOOK_URL },
+                toSiteInfo(site),
+                date,
+              ),
             );
           }
         } catch (err) {

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -14,7 +14,7 @@ import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:work
 import { loadInventory } from "./inventory";
 import { fetchAvailability, type Counts } from "./availability";
 import { type DueMap, type FailMap, seedDue, mergeDue, selectDue, nextSleepMs, jitterMs, retryBackoffMs } from "./scheduler";
-import { notifySubscriptionMatches, type SiteInfo } from "./discord";
+import { notifySubscriptionMatches, notifyHotCampground, type SiteInfo } from "./discord";
 
 export interface WfEnv {
   RAW: R2Bucket;
@@ -31,6 +31,7 @@ export interface WfEnv {
   READINESS_AE?: AnalyticsEngineDataset; // daily prediction-readiness gauge → Grafana
   READINESS_WF: Workflow; // daily readiness Workflow (self-reference for continue-as-new)
   DISCORD_WEBHOOK_URL?: string; // wrangler secret; when set, the loop posts "newly available" alerts
+  HOT_FILL_THRESHOLD?: string; // 0-1 fill rate threshold for the "hottest" feed (default 0.9)
 }
 
 // `collect: false` marks map-only / disabled sites (no rec/WA provider, or a
@@ -276,6 +277,17 @@ export class CollectorLoop extends WorkflowEntrypoint<WfEnv, LoopPayload> {
             await step.do(`notify-${i}-${id}`, () =>
               notifySubscriptionMatches(
                 { RAW: this.env.RAW, CAMPSITES: this.env.CAMPSITES!, DISCORD_WEBHOOK_URL: this.env.DISCORD_WEBHOOK_URL },
+                toSiteInfo(site),
+                date,
+              ),
+            );
+          }
+          // "Hottest" feed: auto-alert on any availability at high-demand campgrounds
+          // (≥90% fill rate). No subscription needed — enabled by default.
+          if (this.env.DISCORD_WEBHOOK_URL) {
+            await step.do(`hot-${i}-${id}`, () =>
+              notifyHotCampground(
+                { RAW: this.env.RAW, CAMPSITES: this.env.CAMPSITES!, DISCORD_WEBHOOK_URL: this.env.DISCORD_WEBHOOK_URL, HOT_FILL_THRESHOLD: this.env.HOT_FILL_THRESHOLD },
                 toSiteInfo(site),
                 date,
               ),

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -77,6 +77,11 @@ dataset = "campsite_readiness"
 # The one knob: every campsite is refreshed within this many days. No fixed schedule.
 MAX_STALENESS_DAYS = "2"
 
+# Fill-rate threshold for the "hottest" feed (0–1). Campgrounds with this fraction
+# of future dates fully booked trigger automatic Discord alerts on any availability
+# opening — no subscription needed. Default 0.9 (90% full). Set to "1.0" to disable.
+HOT_FILL_THRESHOLD = "0.90"
+
 # Consecutive failures before a site is quarantined: removed from the schedule,
 # written to the DLQ (dlq/<id>.json in R2), and emitted as an "inactive" state
 # change in the campsite_collector AE dataset. Failed sites back off exponentially

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -90,10 +90,16 @@ INACTIVE_AFTER_FAILURES = "5"
 # it's an allowlisted identity, not a credential.
 BOOTSTRAP_ADMIN = "tommy.b.doerr@gmail.com"
 
-# Discord availability alerts (src/discord.ts). The webhook URL is a SECRET — set it
-# with `npx wrangler secret put DISCORD_WEBHOOK_URL`, never a [vars] entry. When unset
-# the collector simply skips notification (no-op). On each successful collect the loop
-# posts a green embed for nights that newly opened up (0 → available; gains only).
+# Discord subscription alerts (src/discord.ts) + slash commands (src/discord-interactions.ts).
+# Both are SECRETS — set via `npx wrangler secret put`:
+#   DISCORD_WEBHOOK_URL       — webhook URL for posting alerts to the channel
+#   DISCORD_APP_PUBLIC_KEY    — Ed25519 public key for verifying slash command signatures
+# When unset, the collector skips notification and the interactions endpoint returns 500.
+# Slash commands: /subscribe, /subscriptions, /unsubscribe — registered via
+# scripts/register-discord-commands.sh (needs DISCORD_APP_ID + DISCORD_BOT_TOKEN).
+# Interactions endpoint: POST /discord/interactions (set as the app's Interactions URL
+# in the Discord Developer Portal). The Cloudflare Access policy must bypass this path
+# (add a Service Auth → Bypass rule for path=/discord/interactions in infra/access).
 
 # No cron. The CollectorLoop self-perpetuates via continue-as-new; a hard crash
 # is surfaced by Grafana → Discord staleness alerting (observability repo), and a


### PR DESCRIPTION
`BACKEND` — **FEATURE**

# Campsite alerts go personal — plus an automatic "hottest" feed for rare openings

> _The bulk Discord firehose is replaced by two smarter paths: targeted subscriptions for sites you're tracking, and an automatic "hottest" feed that catches rare openings at high-demand campgrounds like Hoh Rain Forest and Kalaloch._

> [!NOTE]
> backend · feature · low risk · no migration

The original Discord integration (PR #113) posted a notification every time *any* campground gained availability — noisy in practice. Every alert for a campground you don't care about trains you to ignore the channel.

## Targeted alerts beat broadcast

Subscriptions live in KV (`sub:` prefix) with four filters: **campground** (required), **site label** (optional, e.g. `24`), **weekdays** (e.g. `[0, 6]` for weekends), and **dates** (specific ISO dates). After each collection, the loop diffs per-site `sites/` snapshots and checks `reserved → available` transitions against matching subscriptions — one embed per match.

## The "hottest" feed — enabled by default

Some campgrounds are so hard to get that *any* opening is actionable. The collector now computes a **fill rate** from each campground's summary data: the fraction of future dates with zero availability. When the fill rate exceeds the threshold (default **90%**, configurable via `HOT_FILL_THRESHOLD`), any `reserved → available` transition fires a 🔥 hot-campground alert automatically — no subscription needed.

## Discord slash commands

Three commands via HTTP interactions (Ed25519-verified, no gateway needed):

- `/subscribe campground:<autocomplete> [site:] [when:weekends] [note:]`
- `/subscriptions` — list active subscriptions
- `/unsubscribe id:<uuid>`

```mermaid
flowchart TD
    F[CollectorLoop] --> G[collectSite + diff sites/]
    G --> I{Match subscriptions?}
    I -->|yes| J[🏕️ Targeted embed]
    I -->|no| K[Silent]
    G --> H{Fill rate ≥ 90%?}
    H -->|yes + new avail| L[🔥 Hot campground embed]
    H -->|no| K
```

## Verification

- [x] 120 tests pass (13 subscription, 28 discord incl. 11 hottest-feed, 5 interactions)
- [x] `wrangler deploy --dry-run` builds clean
- [x] Fill rate computation verified: 90% threshold, past-date exclusion, first-collection, already-available skipped

## Risk

**Low.** Secrets unset = silent no-op. `HOT_FILL_THRESHOLD = "1.0"` disables the hot feed. Collection/R2/observability untouched. One infra change: Access bypass for `/discord/interactions`.
