### PR TITLE
VaultMarkdownLoop: per-campsite markdown → campsite-vault R2 + sync endpoints

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,6 +10,7 @@ import { handleInteraction } from './discord-interactions';
 // Cloudflare Workflows must be exported from the entry module by class name.
 export { CollectorLoop, HotDateWatchWorkflow } from './workflows';
 export { ReadinessWorkflow } from './readiness-workflow';
+export { VaultMarkdownLoop } from './vault-markdown';
 
 type Bindings = WfEnv & {
   CAMPSITES: KVNamespace;
@@ -115,6 +116,51 @@ app.post('/collect/start', adminOnly(), async (c) => {
 app.post('/readiness/start', adminOnly(), async (c) => {
   const i = await c.env.READINESS_WF.create({ params: {} });
   return c.json({ status: 'started', instanceId: i.id });
+});
+
+// Start (or re-kick) the VaultMarkdownLoop — renders per-campsite Obsidian markdown +
+// loop canvases into the campsite-vault R2 bucket, daily, self-perpetuating. One-time
+// start after deploy (or to force a regen).
+app.post('/vault/start', adminOnly(), async (c) => {
+  const i = await c.env.VAULT_WF.create({ params: {} });
+  return c.json({ status: 'started', instanceId: i.id });
+});
+
+// Read endpoints for the local Obsidian sync (obsidian-automations vault_sync). Open to any
+// Access-authenticated caller (like the other read routes). The geo manifest drives the
+// area-of-interest filter; /vault/bundle returns one campground's rendered files in a single
+// response so the sync pulls per-campground, not per-file.
+app.get('/vault/manifest', async (c) => {
+  const o = await c.env.VAULT.get('manifest.json');
+  if (!o) return c.json({ error: 'manifest not generated yet' }, 404);
+  return new Response(o.body, { headers: { 'content-type': 'application/json' } });
+});
+
+app.get('/vault/bundle', async (c) => {
+  const cg = c.req.query('cg');
+  if (!cg) return c.json({ error: 'cg query param required' }, 400);
+  const prefix = `Campsites/${cg}/`;
+  // List all keys first, then fetch in parallel batches — a big campground is hundreds of
+  // objects, and sequential gets blow the client timeout. Batched to stay well under the
+  // Workers subrequest limit while keeping wall time low.
+  const keys: string[] = [];
+  let cursor: string | undefined;
+  do {
+    const r = await c.env.VAULT.list({ prefix, cursor });
+    for (const obj of r.objects) keys.push(obj.key);
+    cursor = r.truncated ? r.cursor : undefined;
+  } while (cursor);
+  const files: Record<string, string> = {};
+  const BATCH = 50;
+  for (let i = 0; i < keys.length; i += BATCH) {
+    await Promise.all(
+      keys.slice(i, i + BATCH).map(async (key) => {
+        const f = await c.env.VAULT.get(key);
+        if (f) files[key] = await f.text();
+      }),
+    );
+  }
+  return c.json({ cg, count: Object.keys(files).length, files });
 });
 
 // Freshness/observability snapshot (the loop's heartbeat).

--- a/backend/src/vault-markdown.ts
+++ b/backend/src/vault-markdown.ts
@@ -1,0 +1,160 @@
+/**
+ * VaultMarkdownLoop — a separate collector loop that renders the per-campsite Obsidian
+ * markdown (one note per individual campsite) + a per-campground loop canvas, and banks
+ * them to the `campsite-vault` R2 bucket. It does NOT touch recreation.gov: it reads the
+ * per-site structure the availability CollectorLoop already wrote to RAW R2
+ * (`sites/<date>/<id>.json`) and transforms it into vault files.
+ *
+ * Layout in the VAULT bucket (mirrors the Obsidian camping vault tree):
+ *   Campsites/<Campground>/Sites/<label>.md          tag: campsite-site
+ *   Campsites/<Campground>/<Campground> loops.canvas
+ *   manifest.json   — [{name, agency, lat, lng, sites, files[]}] for geo-filtered sync
+ *
+ * Loop geometry is synthesized (rec.gov has no per-site coordinates): a tidy grid per loop.
+ * The local Obsidian vault mirrors only an *area of interest* from this bucket (the
+ * obsidian-automations `vault_sync` job filters by distance), so all campgrounds live here
+ * while only nearby ones sync down. Self-perpetuates daily via continue-as-new.
+ *
+ * Start once: POST /vault/start.
+ */
+import { WorkflowEntrypoint, WorkflowStep, WorkflowEvent } from "cloudflare:workers";
+import { loadInventory } from "./inventory";
+import type { WfEnv } from "./workflows";
+
+type Site = {
+  id: string;
+  kind: "rec" | "wa";
+  ref: string | number;
+  name: string;
+  agency: string;
+  collect?: boolean;
+  lat?: number | null;
+  lng?: number | null;
+};
+
+type PerSite = { label: string | null; loop: string | null; type: string | null; use: string | null };
+type SitesSnap = { collected_date?: string; sites?: Record<string, PerSite> };
+
+const OBS_COLORS = ["1", "2", "3", "4", "5", "6"];
+const LOOKBACK_DAYS = 35;
+
+const safe = (label: string) => (String(label).replace(/[^A-Za-z0-9._-]/g, "_").replace(/^_+|_+$/g, "") || "site");
+
+/** Read the most recent per-site snapshot for a campground from RAW (newest→oldest). */
+async function latestSites(env: WfEnv, id: string): Promise<SitesSnap | null> {
+  const now = Date.now();
+  for (let d = 0; d < LOOKBACK_DAYS; d++) {
+    const date = new Date(now - d * 86_400_000).toISOString().slice(0, 10);
+    const o = await env.RAW.get(`sites/${date}/${id}.json`);
+    if (o) return (await o.json()) as SitesSnap;
+  }
+  return null;
+}
+
+function siteNote(cg: string, siteId: string, ps: PerSite): string {
+  const label = ps.label || siteId;
+  const loop = ps.loop || "—";
+  const typ = ps.type || "";
+  const use = ps.use || "";
+  const url = siteId ? `https://www.recreation.gov/camping/campsites/${siteId}` : "";
+  const fm = [
+    "---", "tags:", "  - campsite-site",
+    `site: "${label}"`, `campground: "[[${cg}]]"`, `loop: "${loop}"`,
+    `type: "${typ}"`, `use: "${use}"`, "reservable: true",
+    `provider_site_id: "${siteId}"`, "source: robot-geographical-society",
+  ];
+  if (url) fm.push(`official_url: "${url}"`);
+  fm.push("---");
+  const body = [
+    "", `# ${cg} — ${label}`, "",
+    `- **Campground:** [[${cg}]]`, `- **Loop:** ${loop}`,
+    `- **Type:** ${typ}${use ? " · " + use : ""}`,
+  ];
+  if (url) body.push(`- **Reserve:** [recreation.gov](${url})`);
+  body.push("", `> Site ${label} in ${loop} at [[${cg}]]. Canonical data from recreation.gov via the Robot Geographical Society collector.`, "");
+  return [...fm, ...body].join("\n");
+}
+
+type Entry = { siteId: string; ps: PerSite; fname: string };
+
+function assignFnames(entries: Entry[]): void {
+  const seen = new Set<string>();
+  for (const e of entries) {
+    let stem = safe(e.ps.label || e.siteId || "site");
+    if (seen.has(stem)) stem = `${stem}_${safe(e.siteId)}`;
+    seen.add(stem);
+    e.fname = stem;
+  }
+}
+
+function buildCanvas(cg: string, entries: Entry[]): unknown {
+  const byLoop = new Map<string, Entry[]>();
+  for (const e of entries) {
+    const k = e.ps.loop || "—";
+    (byLoop.get(k) ?? byLoop.set(k, []).get(k)!).push(e);
+  }
+  const nodes: unknown[] = [{ id: "cg", type: "file", file: `Campsites/${cg}.md`, x: 0, y: -300, width: 360, height: 120 }];
+  const edges: unknown[] = [];
+  const COLW = 200, ROWH = 110, PERROW = 5;
+  const loopGap = COLW * PERROW + 160;
+  const loops = [...byLoop.keys()].sort();
+  loops.forEach((loop, li) => {
+    const color = OBS_COLORS[li % OBS_COLORS.length];
+    const lx = li * loopGap;
+    const hub = `loop${li}`;
+    const group = byLoop.get(loop)!.slice().sort((a, b) => (a.ps.label || "").localeCompare(b.ps.label || ""));
+    nodes.push({ id: hub, type: "text", text: `### ${loop}\n${group.length} sites`, x: lx, y: 0, width: 280, height: 90, color });
+    edges.push({ id: `e_cg_${hub}`, fromNode: "cg", toNode: hub });
+    group.forEach((e, si) => {
+      const row = Math.floor(si / PERROW), col = si % PERROW;
+      const nid = `s_${li}_${si}`;
+      nodes.push({ id: nid, type: "file", file: `Campsites/${cg}/Sites/${e.fname}.md`, x: lx + col * COLW, y: 150 + row * ROWH, width: COLW - 20, height: ROWH - 20, color });
+      edges.push({ id: `e_${hub}_${nid}`, fromNode: hub, toNode: nid });
+    });
+  });
+  return { nodes, edges };
+}
+
+type ManifestEntry = { name: string; agency: string; lat: number | null; lng: number | null; sites: number; files: string[] };
+
+/** Render one campground's vault files into the VAULT bucket; return its manifest entry. */
+async function genCampground(env: WfEnv, s: Site): Promise<ManifestEntry | null> {
+  const snap = await latestSites(env, s.id);
+  const sites = snap?.sites ?? {};
+  const entries: Entry[] = Object.entries(sites).map(([siteId, ps]) => ({ siteId, ps, fname: "" }));
+  if (entries.length === 0) return null;
+  assignFnames(entries);
+  const files: string[] = [];
+  for (const e of entries) {
+    const key = `Campsites/${s.name}/Sites/${e.fname}.md`;
+    await env.VAULT.put(key, siteNote(s.name, e.siteId, e.ps));
+    files.push(key);
+  }
+  const canvasKey = `Campsites/${s.name}/${s.name} loops.canvas`;
+  await env.VAULT.put(canvasKey, JSON.stringify(buildCanvas(s.name, entries), null, 1));
+  files.push(canvasKey);
+  return { name: s.name, agency: s.agency, lat: s.lat ?? null, lng: s.lng ?? null, sites: entries.length, files };
+}
+
+export class VaultMarkdownLoop extends WorkflowEntrypoint<WfEnv, Record<string, never>> {
+  async run(_event: WorkflowEvent<Record<string, never>>, step: WorkflowStep) {
+    const sites = await step.do("load-inventory", async () =>
+      ((await loadInventory(this.env.CAMPSITES)) as unknown as Site[]).filter((s) => s.collect !== false),
+    );
+    const manifest: ManifestEntry[] = [];
+    for (const s of sites) {
+      const entry = await step.do(`gen-${s.id}`, { retries: { limit: 2, delay: "10 seconds", backoff: "exponential" }, timeout: "2 minutes" }, () => genCampground(this.env, s));
+      if (entry) manifest.push(entry);
+    }
+    await step.do("manifest", async () => {
+      await this.env.VAULT.put("manifest.json", JSON.stringify({ updated_at: new Date().toISOString(), campgrounds: manifest }, null, 1));
+      return { campgrounds: manifest.length, notes: manifest.reduce((n, m) => n + m.sites, 0) };
+    });
+    await step.sleep("daily", "24 hours");
+    await step.do("continue-as-new", async () => {
+      await this.env.VAULT_WF.create({ params: {} });
+      return { handedOff: true };
+    });
+    return { campgrounds: manifest.length };
+  }
+}

--- a/backend/src/workflows.ts
+++ b/backend/src/workflows.ts
@@ -30,6 +30,8 @@ export interface WfEnv {
   DEMAND_AE?: AnalyticsEngineDataset; // per-campground per-night demand → Grafana
   READINESS_AE?: AnalyticsEngineDataset; // daily prediction-readiness gauge → Grafana
   READINESS_WF: Workflow; // daily readiness Workflow (self-reference for continue-as-new)
+  VAULT: R2Bucket; // markdown mirror bucket (campsite-vault) for the Obsidian sync
+  VAULT_WF: Workflow; // self-reference for the VaultMarkdownLoop continue-as-new
   DISCORD_WEBHOOK_URL?: string; // wrangler secret; when set, the loop posts "newly available" alerts
   HOT_FILL_THRESHOLD?: string; // 0-1 fill rate threshold for the "hottest" feed (default 0.9)
 }

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -25,6 +25,14 @@ preview_id = "aad9f04d90e945ffb8d278d7b8e70976"
 binding = "RAW"
 bucket_name = "campsite-raw"
 
+# Rendered Obsidian markdown mirror (per-campsite notes + loop canvases + manifest.json),
+# written by the VaultMarkdownLoop. The local camping vault syncs only an area-of-interest
+# subset from here (obsidian-automations vault_sync). A scoped read token is vended from
+# cloudflare-tfvend for that sync.
+[[r2_buckets]]
+binding = "VAULT"
+bucket_name = "campsite-vault"
+
 # Per-run/per-site collector coverage → queried by the observability "Collector
 # history" Grafana dashboard via the AE SQL API. Schema:
 #   index=site.id  blob1=date blob2=agency blob3=kind blob4=name
@@ -121,6 +129,13 @@ class_name = "CollectorLoop"
 name = "campsite-hot-date-watch"
 binding = "WATCH_WF"
 class_name = "HotDateWatchWorkflow"
+
+# Renders per-campsite Obsidian markdown + loop canvases into the campsite-vault bucket,
+# daily, self-perpetuating. Start once with POST /vault/start.
+[[workflows]]
+name = "campsite-vault"
+binding = "VAULT_WF"
+class_name = "VaultMarkdownLoop"
 
 # Daily prediction-readiness scan (self-schedules via step.sleep 24h, continues-as-new).
 # Start once with POST /readiness/start.


### PR DESCRIPTION
## What

A **separate collector loop** that renders the per-campsite Obsidian markdown in Cloudflare and keeps it in R2, so the local vault can mirror just an area of interest.

- **`VaultMarkdownLoop`** (`src/vault-markdown.ts`) — self-perpetuating daily workflow. Reads the availability collector's existing `sites/<date>/<id>.json` (no extra rec.gov calls) and writes, per monitored campground:
  - `Campsites/<cg>/Sites/<label>.md` — one note per campsite (tag `campsite-site`; loop, type, use, rec.gov URL)
  - `Campsites/<cg>/<cg> loops.canvas` — synthesized loop layout, nodes → site notes
  - `manifest.json` — `{name, agency, lat, lng, sites, files[]}` per campground
  to a new **`campsite-vault`** R2 bucket.
- **Read endpoints** (Access-gated, open to authed callers): `GET /vault/manifest`, `GET /vault/bundle?cg=<name>` (parallel-fetched).
- **`POST /vault/start`** (admin) to kick it.

## Why

Per-campsite notes for all ~137 monitored campgrounds is ~9k files — too much to keep fully local. Generation moves to CF; the local camping vault syncs only nearby campgrounds via the companion `obsidian-automations` `vault_sync` job.

## Status

Deployed and verified (version `df3b6f84`); loop populated the bucket; `vault_sync` pulled 41 AOI campgrounds (3,020 files) cleanly. This PR captures the already-deployed code (it was live but uncommitted — committing to prevent deploy drift).

## Follow-ups

- The loop is sequential (~25-30 min/run); could parallelize per-campground steps.
- Step names use `gen-${id}`; switch to a per-index name to be collision-proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)