### PR TITLE
ci: continuous deploy to Cloudflare (Pages + Worker) on green main

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ on:
     branches: [ main ]
     paths-ignore:
       - 'data/**'
+  workflow_dispatch: {}   # manual re-deploy (runs the deploy job when on main)
 
 jobs:
   lint-test-build:
@@ -76,3 +77,64 @@ jobs:
             "cd ../backend && npx wrangler dev --port 8787 --local --ip 127.0.0.1" \
             "npx vite --port 5173 --host 127.0.0.1" \
             "./node_modules/.bin/wait-on -t 90000 http-get://127.0.0.1:8787/ http-get://127.0.0.1:5173/ && npm run build"
+
+  # Continuous deploy to Cloudflare — production only. Runs after the tests pass, and
+  # only on main (a push there, or a manual re-run). Builds the web bundle with the
+  # real Mapbox token and ships it to Pages, then deploys the backend Worker. Auth is
+  # the CLOUDFLARE_API_TOKEN secret (needs Pages:Edit + Workers Scripts:Edit); account
+  # id is not sensitive. Mirrors the gate-if-unset style of deploy-kv.yaml.
+  deploy:
+    name: Deploy to Cloudflare (production)
+    needs: lint-test-build
+    if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: d7adee58513c1b2f770ccaac90cf114f
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      # Stay green before the deploy token is configured: skip the live deploy if unset.
+      - id: gate
+        run: |
+          if [ -z "$CLOUDFLARE_API_TOKEN" ]; then
+            echo "CLOUDFLARE_API_TOKEN not set — skipping Cloudflare deploy (configure the deploy token to enable)."
+            echo "go=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "go=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Install dependencies
+        if: steps.gate.outputs.go == 'true'
+        run: |
+          cd backend && npm install
+          cd ../web && npm install
+
+      - name: Build web (production bundle)
+        if: steps.gate.outputs.go == 'true'
+        working-directory: web
+        env:
+          # The real public rgs_web token (allowlisted to the production domains).
+          VITE_MAPBOX_ACCESS_TOKEN: ${{ secrets.VITE_MAPBOX_ACCESS_TOKEN }}
+        # `vite build` directly — `npm run build`'s postbuild runs the Playwright e2e.
+        run: npx vite build
+
+      - name: Deploy frontend → Cloudflare Pages
+        if: steps.gate.outputs.go == 'true'
+        working-directory: web
+        run: >
+          npx --yes wrangler@4 pages deploy dist
+          --project-name robot-geographical-society-web
+          --branch main
+
+      - name: Deploy backend → Cloudflare Worker
+        if: steps.gate.outputs.go == 'true'
+        working-directory: backend
+        run: npx --yes wrangler@4 deploy --minify


### PR DESCRIPTION
`CI/CD` — **PIPELINE**

# Ship on green: continuous deploy to Cloudflare

> _Merging to main now builds and ships the whole app — Pages frontend and the backend Worker — instead of a hand-run `wrangler pages deploy` after `wrangler login`._

> [!NOTE]
> **ci** · feat · risk: low

The frontend was a **direct-upload** Pages project with no automation: every release meant an interactive `wrangler login`, a manual build with the right Mapbox token, and `wrangler pages deploy` by hand. This adds a `deploy` job to the existing CI workflow so a green push to `main` deploys production automatically — reusing the `CLOUDFLARE_API_TOKEN` + `VITE_MAPBOX_ACCESS_TOKEN` secrets already in the repo.

## What changed
- **New `deploy` job in `ci.yaml`** — `needs: lint-test-build`, so it only runs after tests pass, and only on `main` (a push or a manual `workflow_dispatch`).
- **Frontend** — builds the web bundle with the real `VITE_MAPBOX_ACCESS_TOKEN` secret (via `vite build`, skipping the postbuild e2e), then `wrangler pages deploy dist --branch main`.
- **Backend** — `wrangler deploy --minify` for the Worker.
- **Gate-if-unset** — mirrors `deploy-kv.yaml`: if `CLOUDFLARE_API_TOKEN` is missing the deploy skips and stays green. Account id is inline (not sensitive); production only, no PR previews.

> _"Green on main → live. No dashboards, no local build, no wrangler login."_

## How it flows
```mermaid
flowchart TD
  P["push / merge to main"] --> T["lint-test-build"]
  PR["pull request"] --> T
  T -->|pass, main only| D["deploy job"]
  T -->|pass, PR| X["stop — no deploy"]
  D --> W["vite build → wrangler pages deploy"]
  D --> B["wrangler deploy (Worker)"]
```

## Verification
- `ci.yaml` parses; the `deploy` job is gated `needs: lint-test-build` + `if: main && (push || workflow_dispatch)`.
- Merging this PR is the first live run: it deploys the glass redesign to production and redeploys the Worker — watch the **Deploy to Cloudflare** job in Actions.
- Re-runnable any time via **workflow_dispatch** on main.

## Risk & rollout
- **Token scope is the one unknown.** The existing `CLOUDFLARE_API_TOKEN` is used today only for KV writes; the deploy needs **Pages:Edit + Workers Scripts:Edit** (and the Worker's custom-domain route). If it's under-scoped, the deploy step fails red (nothing half-ships) — widen the token (via `cloudflare-tfvend`) and re-run.
- Low blast radius otherwise: a failed deploy leaves the current production untouched; the frontend deploy is independent of the Worker deploy.
- Rollback: re-deploy a previous commit (workflow_dispatch after reverting), or roll back in the Cloudflare Pages dashboard.
