### PR TITLE
infra: dev.robogeosociety.xyz behind GitHub Access (tunnel -> mini dev-wiki)

### DIFF
--- a/infra/access/dev_wiki.tf
+++ b/infra/access/dev_wiki.tf
@@ -1,0 +1,36 @@
+# dev.robogeosociety.xyz rewire — the public dev-wiki behind GitHub Access.
+#
+# A self-hosted Access app on the dev-wiki hostname admitting anyone in the `robogeosociety`
+# GitHub org (login via the existing GitHub IdP). Origin = the mini's dev-wiki (:5193) via the
+# rgs-dev-wiki Cloudflare Tunnel (infra/tunnel) + the dev CNAME (infra/dns).
+#
+# STOMP-SAFE: the GitHub IdP is referenced by its LITERAL id (not the resource), so a targeted
+# apply of just this app never pulls the IdP into the plan — protecting its client_secret from
+# an empty-var overwrite (the known gotcha). Apply with:
+#   terraform apply -target=cloudflare_zero_trust_access_application.dev_wiki
+# after confirming the plan shows ONLY this app being created (no github/google IdP changes).
+locals {
+  # cloudflare_zero_trust_access_identity_provider.github (kept in state; referenced by value)
+  github_idp_id = "6393ada3-bc36-4e64-b4ea-20104590921a"
+}
+
+resource "cloudflare_zero_trust_access_application" "dev_wiki" {
+  account_id                = var.account_id
+  name                      = "RGS dev wiki"
+  domain                    = "dev.robogeosociety.xyz"
+  type                      = "self_hosted"
+  session_duration          = "24h"
+  allowed_idps              = [local.github_idp_id] # GitHub login only
+  auto_redirect_to_identity = true                  # skip the IdP picker (GitHub is the only one)
+
+  policies = [{
+    name     = "robogeosociety GitHub org"
+    decision = "allow"
+    include = [{
+      github_organization = {
+        name                 = "robogeosociety"
+        identity_provider_id = local.github_idp_id
+      }
+    }]
+  }]
+}

--- a/infra/dns/dev_wiki.tf
+++ b/infra/dns/dev_wiki.tf
@@ -1,0 +1,22 @@
+# dev.robogeosociety.xyz → the rgs-dev-wiki Cloudflare Tunnel (public dev-wiki behind GitHub
+# Access). Proxied CNAME to <tunnel-id>.cfargotunnel.com. The tunnel id isn't known until the
+# tunnel is created (infra/tunnel), so the record is gated on dev_tunnel_cname being supplied:
+#   terraform apply -var dev_tunnel_cname="$(terraform -chdir=../tunnel output -raw tunnel_cname)"
+# Managed with the vended rgs-frontend-dns token (zone DNS Write, this zone only), like the wall.
+variable "dev_tunnel_cname" {
+  description = "CNAME target for dev.* — the rgs-dev-wiki tunnel (<id>.cfargotunnel.com). Empty = don't create the record yet."
+  type        = string
+  default     = ""
+}
+
+resource "cloudflare_dns_record" "dev_wiki" {
+  count = var.dev_tunnel_cname == "" ? 0 : 1
+
+  zone_id = var.zone_id
+  name    = "dev.robogeosociety.xyz"
+  type    = "CNAME"
+  content = var.dev_tunnel_cname
+  proxied = true
+  ttl     = 1 # required; automatic while proxied
+  comment = "dev-wiki → rgs-dev-wiki tunnel (GitHub Access) — tailnet-migration rewire"
+}

--- a/infra/tunnel/.terraform.lock.hcl
+++ b/infra/tunnel/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/tunnel/Makefile
+++ b/infra/tunnel/Makefile
@@ -1,0 +1,38 @@
+# Manage DNS for the rgs frontend custom domains (campsites/collectors → the Pages
+# alias, proxied + gated by Access).
+#
+# Auth is the *vended* rgs-frontend-dns token, read from the cloudflare-tfvend repo's
+# Terraform output (offline — no bootstrap token needed). Override its path with
+# TFVEND=/path if the repo lives elsewhere.
+
+TFVEND ?= /Volumes/dev/cloudflare-tfvend
+export CLOUDFLARE_API_TOKEN := $(shell terraform -chdir=$(TFVEND) output -raw rgs_tunnel_token 2>/dev/null)
+# Remote-state (R2 S3 backend) credentials — the vended tfstate-r2 token.
+export AWS_ACCESS_KEY_ID := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_access_key_id 2>/dev/null)
+export AWS_SECRET_ACCESS_KEY := $(shell terraform -chdir=$(TFVEND) output -raw tfstate_r2_secret_access_key 2>/dev/null)
+
+.PHONY: help check init migrate plan apply destroy
+
+init: check
+	terraform init
+
+# One-time migration of existing local state into the R2 backend.
+migrate: check
+	terraform init -migrate-state
+
+help:
+	@echo "make plan      # terraform plan"
+	@echo "make apply     # terraform apply (auto-approve) — creates the proxied CNAMEs"
+
+check:
+	@test -n "$(CLOUDFLARE_API_TOKEN)" || { \
+		echo "No vended token. Is $(TFVEND) applied? (terraform -chdir=$(TFVEND) output rgs_tunnel_token)"; exit 1; }
+
+plan: check
+	terraform plan
+
+apply: check
+	terraform apply -auto-approve
+
+destroy: check
+	terraform destroy

--- a/infra/tunnel/backend.tf
+++ b/infra/tunnel/backend.tf
@@ -1,0 +1,15 @@
+# Remote state on R2 (S3-compatible). Creds from AWS_* (vended tfstate-r2 token), via Makefile.
+terraform {
+  backend "s3" {
+    bucket    = "tommyroar-tfstate"
+    key       = "rgs/tunnel.tfstate"
+    region    = "auto"
+    endpoints = { s3 = "https://d7adee58513c1b2f770ccaac90cf114f.r2.cloudflarestorage.com" }
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    use_path_style              = true
+    skip_s3_checksum            = true
+  }
+}

--- a/infra/tunnel/main.tf
+++ b/infra/tunnel/main.tf
@@ -1,0 +1,28 @@
+# rgs-dev-wiki Cloudflare Tunnel: dev.robogeosociety.xyz -> the mini dev-wiki (:5193).
+# Remotely-managed config (config_src=cloudflare); connector runs on the mini with the token.
+resource "random_bytes" "tunnel_secret" {
+  length = 32
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "dev_wiki" {
+  account_id    = var.account_id
+  name          = "rgs-dev-wiki"
+  tunnel_secret = random_bytes.tunnel_secret.base64
+  config_src    = "cloudflare"
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "dev_wiki" {
+  account_id = var.account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.dev_wiki.id
+  config = {
+    ingress = [
+      { hostname = "dev.robogeosociety.xyz", service = "http://localhost:5193" },
+      { service = "http_status:404" },
+    ]
+  }
+}
+
+data "cloudflare_zero_trust_tunnel_cloudflared_token" "dev_wiki" {
+  account_id = var.account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.dev_wiki.id
+}

--- a/infra/tunnel/outputs.tf
+++ b/infra/tunnel/outputs.tf
@@ -1,0 +1,12 @@
+output "tunnel_id" {
+  value = cloudflare_zero_trust_tunnel_cloudflared.dev_wiki.id
+}
+output "tunnel_cname" {
+  description = "CNAME target for dev.* (pass to infra/dns -var dev_tunnel_cname)."
+  value       = "${cloudflare_zero_trust_tunnel_cloudflared.dev_wiki.id}.cfargotunnel.com"
+}
+output "connector_token" {
+  description = "cloudflared run --token <this> on the mini."
+  value       = data.cloudflare_zero_trust_tunnel_cloudflared_token.dev_wiki.token
+  sensitive   = true
+}

--- a/infra/tunnel/providers.tf
+++ b/infra/tunnel/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    cloudflare = { source = "cloudflare/cloudflare", version = "~> 5.0" }
+    random     = { source = "hashicorp/random", version = "~> 3.5" }
+  }
+}
+provider "cloudflare" {}

--- a/infra/tunnel/variables.tf
+++ b/infra/tunnel/variables.tf
@@ -1,0 +1,5 @@
+variable "account_id" {
+  description = "Cloudflare account (tommyroar-dev)."
+  type        = string
+  default     = "d7adee58513c1b2f770ccaac90cf114f"
+}


### PR DESCRIPTION
Rewires the dev-wiki as a **public, GitHub-org-gated** door — an exception to the tailnet-migration 404 wall, reachable off-tailnet by `robogeosociety` members.

## Adds
- **infra/tunnel/** (new root) — `rgs-dev-wiki` Cloudflare Tunnel + ingress `dev.* -> http://localhost:5193` (mini dev-wiki), 404 fallback; R2 state; auth via vended `rgs_tunnel_token` (see cloudflare-tfvend PR).
- **infra/dns/dev_wiki.tf** — proxied CNAME `dev.*` -> the tunnel (gated on `dev_tunnel_cname`).
- **infra/access/dev_wiki.tf** — self-hosted Access app admitting the **robogeosociety GitHub org**. IdP referenced by **literal id** so `-target` applies never touch the IdP secrets (the known stomp gotcha) — proven: 1 add / 0 change.

## Live + verified
Tunnel applied (`a6f2f515…`), DNS + Access applied, `cloudflared` supervised on the mini (launchd). `dev.robogeosociety.xyz` resolves and returns the GitHub Access login; connector registered (sea01/sea08). Authenticated wiki-render is the one manual check left.

Domain surface now: apex/www = 404 wall · api.* = Worker (X-RGS-Key) · atlas.* = public · **dev.* = GitHub-gated dev-wiki**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)