### PR TITLE
feat(deploy): route deploy-kv through the production environment gate

### DIFF
--- a/.github/workflows/deploy-kv.yaml
+++ b/.github/workflows/deploy-kv.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   deploy-kv:
     runs-on: ubuntu-latest
+    environment: production
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       # Account id is not sensitive (see CLAUDE.md); a scoped KV-write token is.


### PR DESCRIPTION
Adds `environment: production` to the deploy-kv job; the environment carries the rgs-deploy-gate custom protection rule, so KV deploys pause for a #dev Discord approve (pattern proven on discobots). Part of rgs#167 WS0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)