### PR TITLE
feat(tailnet): serve the RGS web app on demand, not always-on

### DIFF
--- a/nomad/rgs-web-serve.hcl
+++ b/nomad/rgs-web-serve.hcl
@@ -1,10 +1,20 @@
-# Long-running service serving the RGS web app over Tailscale at its own port
-# https://tommys-mac-mini.tail59a169.ts.net:8443/ — Phase 1 of the tailnet migration
-# (parallel-run; the Cloudflare Pages surface stays up until Phase 2 tears it down).
-# serve_web.py = static web/dist + /api reverse proxy (vended Access service token).
+# ON-DEMAND serve of the RGS web app over Tailscale at
+# https://tommys-mac-mini.tail59a169.ts.net:8443/ — the only surface the app has, since
+# Phase 3 deleted the Cloudflare Pages project. serve_web.py = static web/dist + an /api
+# reverse proxy that injects the vended X-RGS-Key wall credential server-side.
 #
-#   ON  → nomad job run  nomad/rgs-web-serve.hcl
-#   OFF → nomad job stop rgs-web-serve
+# It was a long-running `service` until 2026-08-04 and that was the wrong shape. With
+# `reschedule { attempts = 0 }`, one lost allocation — a mini reboot is enough — killed it
+# permanently and silently. It died 2026-07-02 and nobody noticed for a month, because a
+# thing you look at occasionally has no one watching it.
+#
+# So: dispatch it when you want to look at the app, stop it when you are done.
+#
+#   ON   → nomad job dispatch rgs-web-serve
+#   OFF  → nomad job stop <dispatch-id>        # from `nomad job status rgs-web-serve`
+#
+# Stopping tears the :8443 tailnet route down too (see run-rgs-web-serve.sh), so the port
+# is either working or absent — never a 502 that reads as a broken deployment.
 #
 # Build/refresh the bundle (manual until the Phase-3 auto-rebuild):
 #   cd /Volumes/dev/robot-geographical-society/web && npm ci \
@@ -14,21 +24,24 @@
 # Prereqs: tailscale on PATH + the tailscale-serve NOPASSWD sudoers rule (on the mini),
 # ~/.local/bin/rgs-vend (Access service-token vendor).
 job "rgs-web-serve" {
-  type        = "service"
+  type        = "batch"
   datacenters = ["*"]
+
+  # Dispatch-only: the job exists registered but idle, and each `nomad job dispatch`
+  # creates one instance that runs until it is stopped. A batch job cannot be
+  # accidentally left "on" by a deploy the way the old service could.
+  parameterized {}
 
   group "web" {
     count = 1
 
+    # No restart, no reschedule — on purpose. This is a foreground tool you asked for:
+    # if it fails, the right feedback is a dead dispatch you can read the logs of, not a
+    # silent retry loop. The previous shape retried three times and then failed forever
+    # with no signal, which is the worst of both.
     restart {
-      attempts = 3
-      interval = "10m"
-      delay    = "15s"
+      attempts = 0
       mode     = "fail"
-    }
-    reschedule {
-      attempts  = 0
-      unlimited = false
     }
 
     task "serve" {

--- a/nomad/run-rgs-web-serve.sh
+++ b/nomad/run-rgs-web-serve.sh
@@ -1,5 +1,9 @@
 #!/bin/zsh
-# Serve the RGS web app over the tailnet — Phase 1 of the tailnet migration.
+# Serve the RGS web app over the tailnet — ON DEMAND (`nomad job dispatch rgs-web-serve`).
+#
+# Since Phase 3 deleted the Cloudflare Pages project, this is the ONLY surface the web app
+# has. It ran as an always-on Nomad service until 2026-08-04, went down on 2026-07-02, and
+# was not missed for a month — so it is now dispatched when wanted and stopped when not.
 #
 # Serves web/dist (Vite build) + /api reverse proxy via nomad/serve_web.py on loopback
 # :5197, fronted by `sudo tailscale serve --https=8443` at its own tailnet port
@@ -33,7 +37,7 @@ _cleaned=0
 cleanup() {
   [[ $_cleaned == 1 ]] && return 0
   _cleaned=1
-  echo "$(date '+%F %T') rgs-web-serve stopping — freeing :$PORT (the :$TSPORT tailnet serve persists)"
+  echo "$(date '+%F %T') rgs-web-serve stopping — freeing :$PORT and the :$TSPORT tailnet route"
   [[ -n "$SRV_PID" ]] && kill "$SRV_PID" 2>/dev/null
   for _ in 1 2 3 4 5 6; do
     local pids
@@ -42,15 +46,33 @@ cleanup() {
     echo "$pids" | xargs kill -9 2>/dev/null
     sleep 0.5
   done
+
+  # Take the tailnet route down with the server. It used to persist deliberately — that
+  # saved a sudo call on restart, but it also meant :8443 kept answering 502 with nothing
+  # behind it, which is indistinguishable from a broken deployment. For an on-demand tool
+  # the port should be working or absent, nothing in between.
+  #
+  # $TSPORT is 8443 and is written explicitly below rather than interpolated, because the
+  # failure mode of getting this wrong is unrecoverable-by-this-script: `--https=443 off`
+  # would tear down the camping/travel wikis and the whole tailnet front door. The guard
+  # makes the dangerous value impossible to reach even if TSPORT is ever changed above.
+  if [[ "$TSPORT" == "8443" ]]; then
+    sudo /opt/homebrew/bin/tailscale serve --https=8443 off 2>/dev/null \
+      && echo "$(date '+%F %T') tailnet route :8443 removed" \
+      || echo "$(date '+%F %T') warning: could not remove the :8443 route (leaving it registered)"
+  else
+    echo "$(date '+%F %T') refusing to tear down :$TSPORT — only :8443 is this job's to remove"
+  fi
 }
 trap 'cleanup; exit 0' INT TERM
 
 python3 "$REPO/nomad/serve_web.py" "$PORT" "$DIST" &
 SRV_PID=$!
 
-# Idempotent: re-asserting the same route is a no-op; the route persists in tailscaled
-# across restarts of this job. NEVER `tailscale serve --https=443 off` (nukes the wikis).
-sudo tailscale serve --bg --https="$TSPORT" "http://127.0.0.1:$PORT" \
+# Idempotent: re-asserting the same route is a no-op. cleanup() removes it again on exit,
+# so each dispatch owns the route for its lifetime. NEVER touch --https=443 (the wikis and
+# the tailnet front door live there); this job only ever asserts and removes :8443.
+sudo /opt/homebrew/bin/tailscale serve --bg --https="$TSPORT" "http://127.0.0.1:$PORT" \
   || echo "$(date '+%F %T') warning: tailscale serve registration failed (route may already exist)"
 
 echo "$(date '+%F %T') rgs-web up on :$PORT (pid $SRV_PID) — https://$TAILNET:$TSPORT/"


### PR DESCRIPTION
## Why

The serve job went down **2026-07-02 and was not missed for a month**. That is the whole argument: a surface you look at occasionally should not be a service nobody watches.

The shape guaranteed the silence. `type = "service"` with `reschedule { attempts = 0 }` means a single lost allocation — one mini reboot is enough — kills it permanently. Nomad reported:

```
Status = dead      Stop = false
```

Not stopped on purpose. Just gone, with nothing asking after it.

## What changes

A **parameterized batch job**:

```sh
nomad job dispatch rgs-web-serve      # when you want the app
nomad job stop <dispatch-id>          # when you are done
```

Registered-but-idle is the resting state, so it can't be left running by accident. No restart/reschedule policy, deliberately — a failure should surface as a dead dispatch with readable logs, not a retry loop that ends in permanent silence.

**Stopping now tears down the `:8443` tailnet route** with the server. It used to persist by design (saving a sudo call on restart), but that left `:8443` answering 502 with nothing behind it — indistinguishable from a broken deployment, and part of why a month went by.

## The dangerous bit, handled

Teardown writes `--https=8443` as a **literal**, and guards on `TSPORT` being exactly `8443`:

```zsh
if [[ "$TSPORT" == "8443" ]]; then
  sudo /opt/homebrew/bin/tailscale serve --https=8443 off
else
  echo "refusing to tear down :$TSPORT — only :8443 is this job's to remove"
fi
```

`--https=443 off` would take down the camping and travel wikis and the tailnet front door. The guard makes that unreachable even if `TSPORT` is later changed.

## Verified end to end on the mini

| step | result |
| --- | --- |
| dispatch | `:5197` → 200, `:8443` → **200 from the Air** |
| stop | `:8443` removed, `:5197` freed |
| blast radius | all ten other routes intact — `camping-wiki` 200, `travel-wiki` 200 |

The `rgs-vend` credential path works (`/api` → 200); the earlier suspicion that the vend had broken was wrong — bare `rgs-vend` exits 1 because it wants a subcommand, and the script calls `rgs-vend env`.

## Base branch, and a thing worth knowing

Based on `feat/tailnet-phase3` because **that branch has never been merged to main**. The tailnet migration which deleted the Cloudflare Pages project — making the mini the app's *only* surface — is unreviewed work currently running in production. Worth landing on its own merits, separately from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)